### PR TITLE
Server 566 and 580 apply manifests clone repo

### DIFF
--- a/dev/beaker/01_install_required_module_and_binaries.rb
+++ b/dev/beaker/01_install_required_module_and_binaries.rb
@@ -1,0 +1,16 @@
+test_name "Install required binaries and puppet modules"
+
+modules = [
+  "rtyler-jenkins",
+  "puppetlabs-inifile"
+]
+
+hosts.each do |host|
+  step "Install git"
+  on(host, "puppet resource package git ensure=installed")
+
+  modules.each do |module_name|
+    step "Install puppet module: #{module_name}"
+    on(host, "puppet module install #{module_name}")
+  end
+end

--- a/dev/beaker/01_install_required_module_and_binaries.rb
+++ b/dev/beaker/01_install_required_module_and_binaries.rb
@@ -5,12 +5,10 @@ modules = [
   "puppetlabs-inifile"
 ]
 
-hosts.each do |host|
-  step "Install git"
-  on(host, "puppet resource package git ensure=installed")
+step "Install git"
+on(dev_machine, "puppet resource package git ensure=installed")
 
-  modules.each do |module_name|
-    step "Install puppet module: #{module_name}"
-    on(host, "puppet module install #{module_name}")
-  end
+modules.each do |module_name|
+  step "Install puppet module: #{module_name}"
+  on(dev_machine, "puppet module install #{module_name}")
 end

--- a/dev/beaker/apply_manifests.rb
+++ b/dev/beaker/apply_manifests.rb
@@ -2,15 +2,18 @@ test_name "Apply manifests for jenkins/git, sbt, and jjb"
 
 manifests = Dir.glob("./dev/manifests/*.pp")
 
-hosts.each do |host|
-  manifests.each do |local_path|
-    manifest_name = File.basename(local_path)
-    remote_path = File.join("/tmp/", manifest_name)
+step "Make a temp dir for manifests"
+remote_temp_dir = create_tmpdir_on(dev_machine)
 
-    step "Send #{manifest_name} to host"
-    scp_to(host, local_path, remote_path)
+manifests.each do |local_path|
+  manifest_name = File.basename(local_path)
+  remote_path = File.join(remote_temp_dir, manifest_name)
 
-    step "Apply #{manifest_name} manifest"
-    on(host, "puppet apply #{remote_path}")
-  end
+  step "Send #{manifest_name} to #{dev_machine}"
+  scp_to(dev_machine, local_path, remote_path)
+
+  step "Apply #{manifest_name} manifest"
+  on(dev_machine, "puppet apply #{remote_path}")
+  
 end
+

--- a/dev/beaker/apply_manifests.rb
+++ b/dev/beaker/apply_manifests.rb
@@ -1,6 +1,6 @@
 test_name "Apply manifests for jenkins/git, sbt, and jjb"
 
-manifests = [Dir.glob("../manifests/*.pp")]
+manifests = Dir.glob("./dev/manifests/*.pp")
 
 hosts.each do |host|
   manifests.each do |local_path|

--- a/dev/beaker/apply_manifests.rb
+++ b/dev/beaker/apply_manifests.rb
@@ -1,0 +1,16 @@
+test_name "Apply manifests for jenkins/git, sbt, and jjb"
+
+manifests = [Dir.glob("../manifests/*.pp")]
+
+hosts.each do |host|
+  manifests.each do |local_path|
+    manifest_name = File.basename(local_path)
+    remote_path = File.join("/tmp/", manifest_name)
+
+    step "Send #{manifest_name} to host"
+    scp_to(host, local_path, remote_path)
+
+    step "Apply #{manifest_name} manifest"
+    on(host, "puppet apply #{remote_path}")
+  end
+end

--- a/dev/beaker/clone_gatling-puppet-load-test.rb
+++ b/dev/beaker/clone_gatling-puppet-load-test.rb
@@ -1,0 +1,9 @@
+test_name "Clone the gatling-puppet-load-test repo on the target machine"
+
+repo = "gatling-puppet-load-test"
+repo_url = "https://github.com/puppetlabs/#{repo}.git"
+
+hosts.each do |host|
+  step "Clone #{repo_url}"
+  on(host, "git clone #{repo_url} ~/#{repo}")
+end

--- a/dev/beaker/clone_gatling-puppet-load-test.rb
+++ b/dev/beaker/clone_gatling-puppet-load-test.rb
@@ -3,7 +3,5 @@ test_name "Clone the gatling-puppet-load-test repo on the target machine"
 repo = "gatling-puppet-load-test"
 repo_url = "https://github.com/puppetlabs/#{repo}.git"
 
-hosts.each do |host|
-  step "Clone #{repo_url}"
-  on(host, "git clone #{repo_url} ~/#{repo}")
-end
+step "Clone #{repo_url}"
+on(dev_machine, "git clone #{repo_url} ~/#{repo}")

--- a/dev/beaker/target_machine.yml
+++ b/dev/beaker/target_machine.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  target_hostname:
+    roles:
+      - master
+      - agent
+    platform: el-6-x86_64
+
+CONFIG:
+  nfs_server: none
+  consoleport: 443

--- a/dev/beaker/target_machine.yml
+++ b/dev/beaker/target_machine.yml
@@ -3,6 +3,7 @@ HOSTS:
     roles:
       - master
       - agent
+      - dev_machine
     platform: el-6-x86_64
 
 CONFIG:


### PR DESCRIPTION
I through both tickets into one PR because they're so small, and related.

If you have a centos-6 box with puppet installed, you can test it with

```bash
beaker --log-level debug --hosts dev/beaker/target_machine.yml --tests dev/beaker/
```
You'll have to put the hostname for your centos box into `target_machine.yml` first
