### PR TITLE
(MAINT) Fix foss 2.1.0 sim, improve cert script

### DIFF
--- a/simulation-runner/config/scenarios/foss-puppetserver210-catalogzero-1.json
+++ b/simulation-runner/config/scenarios/foss-puppetserver210-catalogzero-1.json
@@ -1,5 +1,5 @@
 {
-    "run_description": "puppeserver 2.1.0 Catalog Zero - 1000 agents, 30 minute ramp, 2 times",
+    "run_description": "puppeserver 2.1.0 Catalog Zero - 1 agent, 30 minute ramp, 2 times",
     "nodes": [
         {
             "node_config": "foss-puppetserver210-catalogzero.json",

--- a/simulation-runner/config/scenarios/foss-puppetserver210-catalogzero-1.json
+++ b/simulation-runner/config/scenarios/foss-puppetserver210-catalogzero-1.json
@@ -1,0 +1,13 @@
+{
+    "run_description": "puppeserver 2.1.0 Catalog Zero - 1000 agents, 30 minute ramp, 2 times",
+    "nodes": [
+        {
+            "node_config": "foss-puppetserver210-catalogzero.json",
+            "num_instances": 1,
+            "ramp_up_duration_seconds": 0,
+            "num_repetitions": 2,
+            "sleep_duration_seconds": 0
+        }
+    ]
+}
+

--- a/simulation-runner/retrieve-agent-ssl-certs.sh
+++ b/simulation-runner/retrieve-agent-ssl-certs.sh
@@ -37,12 +37,14 @@ read -e PE_AGENT
 
 echo "Copying files from $PE_AGENT"
 
+PUPPET_SCRIPT="/opt/puppetlabs/bin/puppet"
+
 rm -rf ./target/ssl
 mkdir -p ./target/ssl
-HOST_CERTNAME=`ssh root@${PE_AGENT} "puppet agent --configprint certname"`
-HOST_CERT=`ssh root@${PE_AGENT} "puppet agent --configprint hostcert"`
-HOST_KEY=`ssh root@${PE_AGENT} "puppet agent --configprint hostprivkey"`
-CA_CERT=`ssh root@${PE_AGENT} "puppet agent --configprint localcacert"`
+HOST_CERTNAME=`ssh root@${PE_AGENT} "${PUPPET_SCRIPT} agent --configprint certname"`
+HOST_CERT=`ssh root@${PE_AGENT} "${PUPPET_SCRIPT} agent --configprint hostcert"`
+HOST_KEY=`ssh root@${PE_AGENT} "${PUPPET_SCRIPT} agent --configprint hostprivkey"`
+CA_CERT=`ssh root@${PE_AGENT} "${PUPPET_SCRIPT} agent --configprint localcacert"`
 
 scp root@${PE_AGENT}:${HOST_CERT} ./target/ssl/hostcert.pem
 scp root@${PE_AGENT}:${HOST_KEY} ./target/ssl/hostkey.pem

--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/FOSSPuppetserver210CatalogZero.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/FOSSPuppetserver210CatalogZero.scala
@@ -33,15 +33,15 @@ class FOSSPuppetserver210CatalogZero extends SimulationWithScenario {
 		"Connection" -> "close")
 
     // val uri1 = "https://perf-bl14.delivery.puppetlabs.net:8140/puppet/v3"
-	val reportBody = ELFileBody("FOSSPuppetserver210CatalogZero_0105_response.txt")
+	val reportBody = ELFileBody("FOSSPuppetserver210CatalogZero_0105_request.txt")
 
 	val chain_0 = exec(http("node")
 			.get("/puppet/v3/node/stfui0skrwbvd7n.delivery.puppetlabs.net?environment=production&transaction_uuid=e1c0a4a6-b57f-4dd9-b3bc-5d127fc134b3&fail_on_404=true")
 			.headers(headers_0))
-		.exec(http("filemeta")
+		.exec(http("filemeta pluginfacts")
 			.get("/puppet/v3/file_metadatas/pluginfacts?environment=production&links=follow&recurse=true&source_permissions=use&ignore=.svn&ignore=CVS&ignore=.git&checksum_type=md5")
 			.headers(headers_0))
-		.exec(http("filemeta")
+		.exec(http("filemeta plugins")
 			.get("/puppet/v3/file_metadatas/plugins?environment=production&links=follow&recurse=true&source_permissions=ignore&ignore=.svn&ignore=CVS&ignore=.git&checksum_type=md5")
 			.headers(headers_0))
 		.pause(613 milliseconds)


### PR DESCRIPTION
This commit does the following:

* Adds an explicit path to the puppet executable for the
  `retrieve-agent-ssl-certs.sh` script, so that it will work with
  puppet 4.0+ out of the box.  (Backward incompatible with Puppet 3,
  but we should be testing that more and more rarely in the future.)
* Fixes a few bugs/typos in the "Foss PuppetServer 2.1.0" sim