### PR TITLE
(MAINT) Use stahnma-epel module

### DIFF
--- a/dev/beaker/20_install_required_module_and_binaries.rb
+++ b/dev/beaker/20_install_required_module_and_binaries.rb
@@ -3,7 +3,8 @@ test_name "Install required binaries and puppet modules"
 modules = [
   "puppetlabs-firewall",
   "rtyler-jenkins",
-  "puppetlabs-inifile"
+  "puppetlabs-inifile",
+  "stahnma-epel"
 ]
 
 step "Install git"

--- a/dev/manifests/setup_jjb.pp
+++ b/dev/manifests/setup_jjb.pp
@@ -1,46 +1,38 @@
-$jjb_config_dir = '/etc/jenkins_jobs'
-$jjb_config_file = "${jjb_config_dir}/jenkins_jobs.ini"
-
 #####################
 # Jenkins job builder
 #####################
 
 # Need this for pip
-package { 'epel-release-6-8.noarch':
-  ensure => installed,
-  source => "http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm",
-  provider => "rpm",
-}
-
-# Centos 6 doesn't come with pip, needed for the pip provider
+class { 'epel': }
+->
 package { 'python-pip':
   ensure => installed,
-  require => Package['epel-release-6-8.noarch']
 }
-
+->
 package { 'jenkins-job-builder':
-  ensure => installed,
+  ensure   => installed,
   provider => 'pip',
-  require => Package['python-pip']
 }
-
 
 #################
 # JJB Config File
 #################
+
+$jjb_config_dir = '/etc/jenkins_jobs'
+$jjb_config_file = "${jjb_config_dir}/jenkins_jobs.ini"
+
 file { $jjb_config_dir:
   ensure => directory,
 }
-
+->
 file { $jjb_config_file:
   ensure => file,
 }
-
+->
 ini_setting { 'jenkins url':
   ensure  => present,
   path    => $jjb_config_file,
   section => 'jenkins',
   setting => 'url',
   value   => 'http://localhost:8080',
-  require => File[$jjb_config_file]
 }


### PR DESCRIPTION
This commit removes the manual EPEL setup and instead just relies on the
stahnma-epel module. The result is less code, and more supported platforms.