### PR TITLE
for review only: 17 Environment classroom simulation (SERVER-651)

### DIFF
--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/17Env.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/17Env.scala
@@ -1,0 +1,66 @@
+package com.puppetlabs.gatling.simulation
+
+import scala.concurrent.duration._
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+// import io.gatling.jdbc.Predef._
+import com.puppetlabs.gatling.runner.SimulationWithScenario
+import org.joda.time.LocalDateTime
+import org.joda.time.format.ISODateTimeFormat
+
+class 17Env extends SimulationWithScenario {
+
+  val headers_3 = Map("Accept" -> "pson, b64_zlib_yaml, yaml, dot, raw")
+
+  val headers_106 = Map(
+    "Accept" -> "pson, yaml",
+    "Content-Type" -> "text/pson", // add Connection Close...
+    "Connection" -> "close")
+
+//    val uri1 = "https://perf-bl15.delivery.puppetlabs.net:8140/production"
+
+// val reportBody = ELFileBody("PE372_CatalogZero_request.txt")
+
+  val chain_0 = exec(http("node")
+        .get("/v2.0/environments")
+        .pause(2)
+        .get("/hankfan/resource_types/*")
+        .pause(3)
+        .get("/clifflu/resource_types/*")
+        .pause(2)
+        .get("/ericlin/resource_types/*")
+        .pause(2)
+        .get("/alex/resource_types/*")
+        .pause(2)
+        .get("/roman/resource_types/*")
+        .pause(2)
+        .get("/yenchen/resource_types/*")
+        .pause(2)
+        .get("/tinaho/resource_types/*")
+        .pause(3)
+        .get("/geoff/resource_types/*")
+        .pause(2)
+        .get("/rayyen/resource_types/*")
+        .pause(2)
+        .get("/production/resource_types/*")
+        .pause(2)
+        .get("/ericliao/resource_types/*")
+        .pause(2)
+        .get("/carol/resource_types/*")
+        .pause(2)
+        .get("/ryan/resource_types/*")
+        .pause(3)
+        .get("/otislin/resource_types/*")
+        .pause(2)
+        .get("/chenhsili/resource_types/*")
+        .pause(2)
+        .get("/cywu/resource_types/*")
+        .pause(2)
+        .get("/student/resource_types/*")
+         
+  val scn = scenario("17Env").exec(
+    chain_0)
+
+//  setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
+}


### PR DESCRIPTION
This scala file was produced by observing the timings on a few runs of the node classifier against puppet server in PE3.8 (via the access log), and replacing chain_0 with the appropriate urls and timings.

Left TODO:
1.  Decide if we really want to (A) use gatling/scala for this, or (B) if using curl is good enough, or if (C) we want some more deeply automated solution where we generate some arbitrary number of environments with some kind of default content, and generate either the scala or the curl for simulating the Node Classifier traffic against the generated environment.

2.  Build an appropriate config json file(s).  (If we want to run this with catalog zero, we'd perhaps want a catalog zero json with a smaller sleep, 10 minutes instead of 1/2 hour?.  Otherwise, we end up in a situation where we need to merge these scala files into one, or attempt to run them under separate process ids.)
3.  Build a little bash script that:
  - installs the classroom sample test catalogs from https://github.com/puppetlabs/test-catalogs/pull/12
  - installs catalog zero
  - calls this gatling test every 10 minutes if simulating normal idle Node Classifier behavior, or every 5 minutes if we want to generate more stress.
  - runs the catalog zero group every 30 minutes as typical.
4. Run it
