### PR TITLE
(SERVER-712) Initial support for basic module installation

### DIFF
--- a/jenkins-integration/beaker/install/foss/40_install_modules.rb
+++ b/jenkins-integration/beaker/install/foss/40_install_modules.rb
@@ -1,0 +1,35 @@
+require 'puppet/gatling/config'
+
+test_name "Install Puppet modules"
+
+def install_librarian_puppet(host)
+  gem = '/opt/puppetlabs/puppet/bin/gem'
+  on(host, "#{gem} install librarian-puppet -v 2.2.0 --no-document")
+  on(host, puppet_resource("package git ensure=installed"))
+end
+
+def generate_puppetfile(modules)
+  modules
+    .map { |mod| "mod '#{mod}'" }
+    .insert(0, "forge 'https://forgeapi.puppetlabs.com'")
+    .join("\n")
+end
+
+def run_librarian_puppet(host, environment, puppetfile)
+  create_remote_file(host, "#{environment}/Puppetfile", puppetfile)
+  librarian_puppet = '/opt/puppetlabs/puppet/bin/librarian-puppet'
+  on(host, "cd #{environment} && #{librarian_puppet} install --clean --verbose")
+end
+
+def install_modules(host, modules)
+  puppetfile_content = generate_puppetfile(modules)
+  environments = on(host, puppet('config print environmentpath')).stdout.chomp
+
+  environment = 'production'
+  run_librarian_puppet(host, "#{environments}/#{environment}", puppetfile_content)
+end
+
+scenario_id = ENV['PUPPET_GATLING_SCENARIO']
+modules = get_modules(get_node_configs(get_scenario(scenario_id)))
+install_librarian_puppet(master)
+install_modules(master, modules)

--- a/jenkins-integration/lib/puppet/gatling/config.rb
+++ b/jenkins-integration/lib/puppet/gatling/config.rb
@@ -1,0 +1,24 @@
+require 'json'
+require 'set'
+
+## Assumptions:
+## 1. CWD is "jenkins-integration"
+## 2. Scenario config JSON files in "./config/scenarios/*.json"
+## 3. Node config JSON files in "./config/nodes/*.json"
+
+def get_scenario(scenario_id)
+  JSON.parse(File.read(File.join('config', 'scenarios', scenario_id + '.json')))
+end
+
+def get_node_configs(scenario)
+  scenario['nodes'].map do |node|
+    config_path = File.join('config', 'nodes', node['node_config'] + '.json')
+    JSON.parse(File.read(config_path))
+  end
+end
+
+def get_modules(node_configs)
+  node_configs.reduce(Set.new) do |modules, node_config|
+    modules.merge(node_config['modules'])
+  end.to_a
+end

--- a/jenkins-integration/scripts/foss_install.sh
+++ b/jenkins-integration/scripts/foss_install.sh
@@ -11,7 +11,8 @@ bundle exec beaker \
   --config $BEAKER_CONFIG \
   --type aio \
   --helper $BEAKER_HELPER \
+  --load-path lib \
   --tests $BEAKER_TESTSUITE \
   --keyfile $BEAKER_KEYFILE \
   --preserve-hosts onfail \
-  --debug 
+  --debug


### PR DESCRIPTION
This commit adds simple module installation support using
librarian-puppet. Modules are specified in
jenkins-integration/config/nodes/*.json node config files, and installed
into the default production environment.