### PR TITLE
(SERVER-713) Add directory environment support

### DIFF
--- a/jenkins-integration/lib/puppet/gatling/config.rb
+++ b/jenkins-integration/lib/puppet/gatling/config.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'set'
 
 ## Assumptions:
 ## 1. CWD is "jenkins-integration"
@@ -18,7 +17,12 @@ def get_node_configs(scenario)
 end
 
 def get_modules(node_configs)
-  node_configs.reduce(Set.new) do |modules, node_config|
-    modules.merge(node_config['modules'])
-  end.to_a
+  result = Hash.new { |h, k| h[k] = Array.new }
+  node_configs.each do |node_config|
+    env = node_config['environment']
+    env = 'production' if (env.nil? || env.empty?)
+    result[env] += node_config['modules']
+  end
+  result.values.each &:uniq!
+  result
 end


### PR DESCRIPTION
This commit adds an additional property to the node config JSON called
'environment' which specifies which directory environment the associated
modules will be installed to.

The default 'production' environment is used if the property is empty or
missing.