### PR TITLE
(SERVER-687) Classify agent nodes

### DIFF
--- a/jenkins-integration/beaker/install/foss/50_install_modules.rb
+++ b/jenkins-integration/beaker/install/foss/50_install_modules.rb
@@ -39,6 +39,6 @@ def install_environment_modules(host, modules)
 end
 
 scenario_id = ENV['PUPPET_GATLING_SCENARIO']
-modules = scenario_modules(scenario_id)
+modules = modules_per_environment(node_configs(scenario_id))
 install_librarian_puppet(master)
 install_environment_modules(master, modules)

--- a/jenkins-integration/beaker/install/foss/60_classify_nodes.rb
+++ b/jenkins-integration/beaker/install/foss/60_classify_nodes.rb
@@ -1,0 +1,29 @@
+require 'puppet/gatling/config'
+
+test_name "Classify Puppet agents on master"
+
+def generate_sitepp(node_configs)
+  node_configs.map do |config|
+    config['classes'].
+      map { |klass| "include #{klass}" }.
+      insert(0, "node '#{config['certname']}' {").
+      push('}').
+      join("\n")
+  end.join("\n").strip
+end
+
+def classify_foss_nodes(host, nodes)
+  environments = on(host, puppet('config print environmentpath')).stdout.chomp
+  nodes = group_by_environment(nodes)
+  nodes.each_pair do |env, node_configs|
+    sitepp = generate_sitepp(node_configs)
+    manifestdir = "#{environments}/#{env}/manifests"
+    on(host, "mkdir -p #{manifestdir}")
+    create_remote_file(host, "#{manifestdir}/site.pp", sitepp)
+    on(host, "chmod 644 #{manifestdir}/site.pp")
+  end
+end
+
+scenario_id = ENV['PUPPET_GATLING_SCENARIO']
+nodes = node_configs(scenario_id)
+classify_foss_nodes(master, nodes)

--- a/jenkins-integration/config/nodes/example-node1.json
+++ b/jenkins-integration/config/nodes/example-node1.json
@@ -1,7 +1,11 @@
 {
     "certname": "example-node1",
+    "environment": "exampleenv1",
     "simulation_class": "com.puppetlabs.gatling.node_simulations.FOSSPuppetserver210CatalogZero",
     "modules": [
+        {
+            "name": "puppetlabs-firewall"
+        },
         {
             "name": "catalog_zero1",
             "path": "/root/test-catalogs/catalog_zero/modules/catalog_zero1"
@@ -16,6 +20,5 @@
             "ref": "1.9.3"
         }
     ],
-    "classes": [],
-    "environment": "exampleenv1"
+    "classes": ["catalog_zero1", "simmons", "python"]
 }

--- a/jenkins-integration/config/nodes/example-node2.json
+++ b/jenkins-integration/config/nodes/example-node2.json
@@ -1,16 +1,16 @@
 {
     "certname": "example-node2",
+    "environment": "exampleenv1",
     "simulation_class": "com.puppetlabs.gatling.node_simulations.FOSSPuppetserver210CatalogZero",
     "modules": [
         {
             "name": "puppetlabs-firewall"
         },
         {
-            "name": "puppetlabs-reboot",
-            "git": "git://github.com/puppetlabs/puppetlabs-reboot.git",
-            "ref": "1.0.x"
+            "name": "puppetlabs-tomcat",
+            "git": "git://github.com/puppetlabs/puppetlabs-tomcat.git",
+            "ref": "1.3.x"
         }
     ],
-    "classes": [],
-    "environment": "exampleenv1"
+    "classes": ["firewall", "tomcat"]
 }

--- a/jenkins-integration/config/nodes/example-node3.json
+++ b/jenkins-integration/config/nodes/example-node3.json
@@ -1,12 +1,12 @@
 {
     "certname": "example-node3",
+    "environment": "",
     "simulation_class": "com.puppetlabs.gatling.node_simulations.FOSSPuppetserver210CatalogZero",
     "modules": [
         {
-            "name": "puppetlabs-tagmail",
-            "git": "git://github.com/puppetlabs/puppetlabs-tagmail.git"
+            "name": "puppetlabs-postgresql",
+            "git": "git://github.com/puppetlabs/puppetlabs-postgresql.git"
         }
     ],
-    "classes": [],
-    "environment": ""
+    "classes": ["postgresql::server"]
 }


### PR DESCRIPTION
This commit adds support for classifying agent nodes with classes
specified in the node config JSON. Each node config will be a Puppet
node definition in the appropriate environment-specific site.pp file.

---

Note this is FOSS only, as the Node Classifier will be used for the PE implementation. This is work that still needs to be done, and will probably be a subsequent PR under the same JIRA ticket number.