### PR TITLE
(SERVER-780) Validate node classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ proxy-recorder/user-files
 .bundle
 vendor
 Gemfile.lock
+Gemfile.local
 
 # Beaker
 log

--- a/jenkins-integration/Gemfile
+++ b/jenkins-integration/Gemfile
@@ -2,3 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gem 'beaker', '2.15.1'
 gem 'scooter', :git => 'git@github.com:puppetlabs/scooter.git', :tag => '2.2'
+
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end

--- a/jenkins-integration/beaker/install/shared/validate_classification.rb
+++ b/jenkins-integration/beaker/install/shared/validate_classification.rb
@@ -1,0 +1,39 @@
+require 'puppet/gatling/config'
+require 'json'
+
+test_name "Validate node classification"
+
+## ASSUMPTIONS:
+## - agent certs/keys are already on the master in the $ssldir (SERVER-787)
+
+def check_for_classes(catalog_response, config)
+  expected = config['classes']
+  actual = catalog_response['classes']
+  all_found = expected.all? { |klass| actual.include?(klass) }
+  if not all_found
+    abort "Node '#{config['certname']}' missing classes.\nExpected: #{expected}\nActual: #{actual}"
+  end
+end
+
+def build_catalog_query(host, node_config, server, cacert)
+  certname = node_config['certname']
+  cert = on(host, puppet("config print hostcert --certname #{certname}")).stdout.chomp
+  key = on(host, puppet("config print hostprivkey --certname #{certname}")).stdout.chomp
+  environment = node_environment(node_config)
+  url = "https://#{server}:8140/puppet/v3/catalog/#{certname}\?environment=#{environment}"
+  "curl --cert #{cert} --key #{key} --cacert #{cacert} #{url}"
+end
+
+def validate_classification(host, nodes)
+  server = on(host, puppet('config print certname')).stdout.chomp
+  cacert = on(host, puppet('config print localcacert')).stdout.chomp
+  nodes.each do |config|
+    catalog_query = build_catalog_query(host, config, server, cacert)
+    response = on(host, catalog_query).stdout.chomp
+    check_for_classes(JSON.parse(response), config)
+  end
+end
+
+scenario_id = ENV['PUPPET_GATLING_SCENARIO']
+nodes = node_configs(scenario_id)
+validate_classification(master, nodes)

--- a/jenkins-integration/config/nodes/example-node1.json
+++ b/jenkins-integration/config/nodes/example-node1.json
@@ -11,14 +11,14 @@
             "path": "/root/test-catalogs/catalog_zero/modules/catalog_zero1"
         },
         {
-            "name": "nwolfe-simmons",
-            "version": "0.3.1"
+            "name": "puppetlabs-mysql",
+            "version": "3.4.0"
         },
         {
-            "name": "stankevich-python",
-            "git": "git://github.com/stankevich/puppet-python.git",
-            "ref": "1.9.3"
+            "name": "maestrodev-wget",
+            "git": "git://github.com/maestrodev/puppet-wget.git",
+            "ref": "v1.6.0"
         }
     ],
-    "classes": ["catalog_zero1", "simmons", "python"]
+    "classes": ["catalog_zero1", "mysql::server", "wget"]
 }

--- a/jenkins-integration/lib/puppet/gatling/config.rb
+++ b/jenkins-integration/lib/puppet/gatling/config.rb
@@ -21,12 +21,18 @@ def node_configs(scenario_id)
   parse_node_config_files(parse_scenario_file(scenario_id))
 end
 
+# Returns the environment from the node config hash, or 'production'
+# if it is nil or empty.
+def node_environment(node_config)
+  env = node_config['environment']
+  (env.nil? || env.empty?) ? 'production' : env
+end
+
 # Group the list of node configs into a hash keyed by their environments.
 # A nil or empty environment will be interpreted as 'production'.
 def group_by_environment(node_configs)
   node_configs.group_by do |config|
-    env = config['environment']
-    (env.nil? || env.empty?) ? 'production' : env
+    node_environment(config)
   end
 end
 

--- a/jenkins-integration/scripts/foss_install.sh
+++ b/jenkins-integration/scripts/foss_install.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -x
 
-export BEAKER_TESTSUITE="
+export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-\
 beaker/install/foss/10_install_dev_repos.rb,\
 beaker/install/foss/20_install_puppet.rb,\
 beaker/install/foss/30_install_puppetserver.rb,\
 beaker/install/shared/40_clone_test_catalogs.rb,\
 beaker/install/shared/50_install_modules.rb,\
 beaker/install/foss/60_classify_nodes.rb
-"
+}"
 export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
 export BEAKER_HELPER="beaker/helper.rb"
 

--- a/jenkins-integration/scripts/pe_install.sh
+++ b/jenkins-integration/scripts/pe_install.sh
@@ -6,12 +6,12 @@ set -x
 #     pe_dist_dir="http://neptune.puppetlabs.lan/4.0/ci-ready"
 #     (optional) pe_ver="4.0.0-rc5-161-g85ecc84"
 
-export BEAKER_TESTSUITE="
+export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-\
 beaker/install/pe/10_install_pe.rb,\
 beaker/install/shared/40_clone_test_catalogs.rb,\
 beaker/install/shared/50_install_modules.rb,\
 beaker/install/pe/60_classify_nodes.rb
-"
+}"
 export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
 export BEAKER_HELPER="beaker/helper.rb"
 


### PR DESCRIPTION
This commit adds a beaker script that will query the master's HTTP API
and validate that each node will receive the correct classes during the
catalog request.

This beaker script requires that each node already has an SSL
certificate and private key on the master. Unfortunately there is no
automation for putting the certificate and key on the master yet,
see SERVER-787.

This validation script will likely be executed as the very last thing
prior to launching Gatling.