### PR TITLE
(SERVER-714) Add Hiera support

### DIFF
--- a/jenkins-integration/beaker/install/shared/70_install_hiera.rb
+++ b/jenkins-integration/beaker/install/shared/70_install_hiera.rb
@@ -1,0 +1,24 @@
+require 'puppet/gatling/config'
+
+test_name 'Install Hiera data'
+
+def install_hieraconfig(host, hiera)
+  configfile = hiera_configpath(hiera)
+  configpath = on(host, puppet('config print hiera_config')).stdout.chomp
+  scp_to(host, configfile, configpath)
+end
+
+def install_hieradata(host, hiera)
+  datadirs = hiera_datadirs(hiera)
+  datadirs.each do |localpath, hostpath|
+    targetpath = File.dirname(hostpath)
+    scp_to(host, localpath, targetpath)
+  end
+end
+
+scenario_id = ENV['PUPPET_GATLING_SCENARIO']
+hiera = parse_scenario_file(scenario_id)['hiera']
+if not hiera.nil?
+  install_hieraconfig(master, hiera)
+  install_hieradata(master, hiera)
+end

--- a/jenkins-integration/config/hieras/basic-example/hiera.yaml
+++ b/jenkins-integration/config/hieras/basic-example/hiera.yaml
@@ -1,0 +1,10 @@
+---
+:backends:
+  - yaml
+  - json
+:hierarchy:
+  - common
+:yaml:
+  :datadir: /etc/puppetlabs/code/hieradata
+:json:
+  :datadir: /etc/puppetlabs/code/hieradata

--- a/jenkins-integration/config/hieras/basic-example/hieradata/common.json
+++ b/jenkins-integration/config/hieras/basic-example/hieradata/common.json
@@ -1,0 +1,3 @@
+{
+    "simmons::exercises": ["simmons::content_file", "simmons::binary_file"]
+}

--- a/jenkins-integration/config/hieras/basic-example/hieradata/common.yaml
+++ b/jenkins-integration/config/hieras/basic-example/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+simmons::studio: /tmp/simmons-studio-%{::clientcert}

--- a/jenkins-integration/config/nodes/example-node3.json
+++ b/jenkins-integration/config/nodes/example-node3.json
@@ -6,7 +6,10 @@
         {
             "name": "puppetlabs-postgresql",
             "git": "git://github.com/puppetlabs/puppetlabs-postgresql.git"
+        },
+        {
+            "name": "nwolfe-simmons"
         }
     ],
-    "classes": ["postgresql::server"]
+    "classes": ["postgresql::server", "simmons"]
 }

--- a/jenkins-integration/config/scenarios/example-scenario.json
+++ b/jenkins-integration/config/scenarios/example-scenario.json
@@ -1,5 +1,6 @@
 {
     "run_description": "example scenario",
+    "hiera": "basic-example",
     "nodes": [
         {
             "node_config": "example-node1",

--- a/jenkins-integration/scripts/foss_install.sh
+++ b/jenkins-integration/scripts/foss_install.sh
@@ -7,7 +7,8 @@ beaker/install/foss/20_install_puppet.rb,\
 beaker/install/foss/30_install_puppetserver.rb,\
 beaker/install/shared/40_clone_test_catalogs.rb,\
 beaker/install/shared/50_install_modules.rb,\
-beaker/install/foss/60_classify_nodes.rb
+beaker/install/foss/60_classify_nodes.rb,\
+beaker/install/shared/70_install_hiera.rb
 }"
 export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
 export BEAKER_HELPER="beaker/helper.rb"

--- a/jenkins-integration/scripts/pe_install.sh
+++ b/jenkins-integration/scripts/pe_install.sh
@@ -10,7 +10,8 @@ export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-\
 beaker/install/pe/10_install_pe.rb,\
 beaker/install/shared/40_clone_test_catalogs.rb,\
 beaker/install/shared/50_install_modules.rb,\
-beaker/install/pe/60_classify_nodes.rb
+beaker/install/pe/60_classify_nodes.rb,\
+beaker/install/shared/70_install_hiera.rb
 }"
 export BEAKER_KEYFILE="~/.ssh/id_rsa-acceptance"
 export BEAKER_HELPER="beaker/helper.rb"


### PR DESCRIPTION
This commit adds support for optionally specifying a Hiera "tree" as
part of the scenario. Each hiera tree is made up a hiera.yaml
configuration file and multiple data directories.

Installation will copy the hiera.yaml file to the master, and copy the
data directories into place as specified by :datadir: properties in
hiera.yaml.