### PR TITLE
(PE-12968) Add UUID import to SG recording

### DIFF
--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PE201523CatalogZero.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PE201523CatalogZero.scala
@@ -8,6 +8,7 @@ import io.gatling.http.Predef._
 import com.puppetlabs.gatling.runner.SimulationWithScenario
 import org.joda.time.LocalDateTime
 import org.joda.time.format.ISODateTimeFormat
+import java.util.UUID
 
 class PE201523CatalogZero extends SimulationWithScenario {
 


### PR DESCRIPTION
The java.util.UUID import was not included in the initial SG recording,
which made it unusable for gatling runs. This commit adds the needed
import.