### PR TITLE
(PE-12968) Update agent simulations readme for v3 api endpoints

### DIFF
--- a/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
+++ b/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
@@ -282,15 +282,15 @@ puppet-gatling-jenkins-plugin project.
 12. In order for Gatling to generate useful reports per request endpoint, the
     names of the endpoints should be renamed.
 
-  | Name                 | Legacy Endpoint     | Modern v3 Endpoint |
-  | -------------------- | ------------ | ------------ |
-  | catalog              | /production/catalog/agent.localdomain | /puppet/v3/catalog/agent.localdomain |
-  | filemeta pluginfacts | /production/file_metadatas/pluginfacts | /puppet/v3/file_metadatas/pluginfacts |
-  | filemeta plugins     | /production/file_metadatas/plugins | /puppet/v3/file_metadatas/plugins |
-  | filemeta             | /production/file_metadatas/modules/xyz | /puppet/v3/file_metadata/modules/xyz |
-  | filemeta mco plugins | /production/file_metadatas/modules/pe_mcollective/plugins | /puppet/v3/file_metadata/modules/puppet_enterprise/mcollective |
-  | node                 | /production/node/agent.localdomain | /puppet/v3/node/agent.localdomain |
-  | report               | /production/report/agent.localdomain | /puppet/v3/report/agent.localdomain |
+  | Name                 | Legacy Endpoint                                            | Modern v3 Endpoint                                              |
+  | -------------------- | ------------                                               | ------------                                                    |
+  | catalog              | /production/catalog/agent.localdomain                      | /puppet/v3/catalog/agent.localdomain                            |
+  | filemeta pluginfacts | /production/file_metadatas/pluginfacts                     | /puppet/v3/file_metadatas/pluginfacts                           |
+  | filemeta plugins     | /production/file_metadatas/plugins                         | /puppet/v3/file_metadatas/plugins                               |
+  | filemeta             | /production/file_metadatas/modules/xyz                     | /puppet/v3/file_metadata/modules/xyz                            |
+  | filemeta mco plugins | /production/file_metadatas/modules/pe_mcollective/plugins  | /puppet/v3/file_metadata/modules/puppet_enterprise/mcollective  |
+  | node                 | /production/node/agent.localdomain                         | /puppet/v3/node/agent.localdomain                               |
+  | report               | /production/report/agent.localdomain                       | /puppet/v3/report/agent.localdomain                             |
 
   To change this for the "node" request, for example, the argument to the
   http() method would need to be changed from "request_0" to "node":

--- a/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
+++ b/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
@@ -282,15 +282,15 @@ puppet-gatling-jenkins-plugin project.
 12. In order for Gatling to generate useful reports per request endpoint, the
     names of the endpoints should be renamed.
 
-  | Name                 | Endpoint     |
-  | -------------------- | ------------ |
-  | catalog              | /production/catalog/agent.localdomain
-  | filemeta pluginfacts | /production/file_metadatas/pluginfacts
-  | filemeta plugins     | /production/file_metadatas/plugins
-  | filemeta             | /production/file_metadatas/modules/xyz
-  | filemeta mco plugins | /production/file_metadatas/modules/pe_mcollective/plugins
-  | node                 | /production/node/agent.localdomain
-  | report               | /production/report/agent.localdomain
+  | Name                 | Legacy Endpoint     | Modern v3 Endpoint |
+  | -------------------- | ------------ | ------------ |
+  | catalog              | /production/catalog/agent.localdomain | /puppet/v3/catalog/agent.localdomain |
+  | filemeta pluginfacts | /production/file_metadatas/pluginfacts | /puppet/v3/file_metadatas/pluginfacts |
+  | filemeta plugins     | /production/file_metadatas/plugins | /puppet/v3/file_metadatas/plugins |
+  | filemeta             | /production/file_metadatas/modules/xyz | /puppet/v3/file_metadata/modules/xyz |
+  | filemeta mco plugins | /production/file_metadatas/modules/pe_mcollective/plugins | /puppet/v3/file_metadata/modules/puppet_enterprise/mcollective |
+  | node                 | /production/node/agent.localdomain | /puppet/v3/node/agent.localdomain |
+  | report               | /production/report/agent.localdomain | /puppet/v3/report/agent.localdomain |
 
   To change this for the "node" request, for example, the argument to the
   http() method would need to be changed from "request_0" to "node":


### PR DESCRIPTION
Previously the README for the agent simulations only referenced the
legacy endpoints. This commit adds the new v3 api endpoints for Puppet
4/Server 2 gatling runs.