### PR TITLE
(SERVER-852) Partial r10k support

### DIFF
--- a/jenkins-integration/beaker/install/shared/70_install_hiera.rb
+++ b/jenkins-integration/beaker/install/shared/70_install_hiera.rb
@@ -18,7 +18,7 @@ end
 
 scenario_id = ENV['PUPPET_GATLING_SCENARIO']
 hiera = parse_scenario_file(scenario_id)['hiera']
-if not hiera.nil?
+if hiera
   install_hieraconfig(master, hiera)
   install_hieradata(master, hiera)
 end

--- a/jenkins-integration/beaker/install/shared/r10k_deploy.rb
+++ b/jenkins-integration/beaker/install/shared/r10k_deploy.rb
@@ -1,0 +1,36 @@
+require 'puppet/gatling/config'
+
+test_name "Deploy r10k control repository"
+
+## TODO This probably needs more work to finish hooking up everything that
+##      comes in the control repository, like a hiera.yaml config file.
+##
+##      Also, r10k will manage the entire environment directory, which means
+##      previous gatling installation steps (e.g. 50_install_modules.rb) may
+##      be overridden. For example, any modules defined in the JSON node files
+##      that aren't defined in the r10k control repo will be removed.
+
+def install_r10k(host)
+  gem = '/opt/puppetlabs/puppet/bin/gem'
+  on(host, "#{gem} install r10k --no-document")
+end
+
+def create_r10k_config(host, r10k)
+  configfile = r10k_configpath(r10k)
+  configdir = '/etc/puppetlabs/r10k'
+  on(host, "mkdir -p #{configdir}")
+  scp_to(host, configfile, "#{configdir}/r10k.yaml")
+end
+
+def run_r10k_deploy(host)
+  r10k = '/opt/puppetlabs/puppet/bin/r10k'
+  on(host, "#{r10k} deploy environment --puppetfile --verbose")
+end
+
+scenario_id = ENV['PUPPET_GATLING_SCENARIO']
+r10k_config = parse_scenario_file(scenario_id)['r10k']
+if r10k_config
+  install_r10k(master)
+  create_r10k_config(master, r10k_config)
+  run_r10k_deploy(master)
+end

--- a/jenkins-integration/config/nodes/example-r10k-node.json
+++ b/jenkins-integration/config/nodes/example-r10k-node.json
@@ -1,0 +1,6 @@
+{
+    "certname": "example-r10k-node",
+    "simulation_class": "com.puppetlabs.gatling.node_simulations.FOSSPuppetserver210CatalogZero",
+    "modules": [],
+    "classes": []
+}

--- a/jenkins-integration/config/r10ks/basic.yaml
+++ b/jenkins-integration/config/r10ks/basic.yaml
@@ -1,0 +1,6 @@
+:cachedir: '/opt/puppetlabs/r10k/cache'
+
+:sources:
+  :basic:
+    remote: 'https://github.com/nwolfe/r10k-control-repo.git'
+    basedir: '/etc/puppetlabs/code/environments'

--- a/jenkins-integration/config/scenarios/example-r10k-scenario.json
+++ b/jenkins-integration/config/scenarios/example-r10k-scenario.json
@@ -1,0 +1,13 @@
+{
+    "run_description": "example scenario with r10k configuration instead of JSON",
+    "r10k": "basic",
+    "nodes": [
+        {
+            "node_config": "example-r10k-node",
+            "num_instances": 1,
+            "ramp_up_duration_seconds": 1,
+            "num_repetitions": 1,
+            "sleep_duration_seconds": 1
+        },
+    ]
+}

--- a/jenkins-integration/lib/puppet/gatling/config.rb
+++ b/jenkins-integration/lib/puppet/gatling/config.rb
@@ -7,6 +7,7 @@ require 'yaml'
 ## 3. Node config JSON files in "./config/nodes/*.json"
 ## 4. Hiera config YAML files in "./config/hieras/<hiera>/hiera.yaml"
 ## 5. Hiera data trees in "./config/hieras/<hiera>/<datadir(s)>/"
+## 6. r10k config YAML files in "./config/r10ks/<r10k>.yaml"
 
 def parse_scenario_file(scenario_id)
   JSON.parse(File.read(File.join('config', 'scenarios', scenario_id + '.json')))
@@ -64,4 +65,9 @@ def hiera_datadirs(hiera)
     localpath = File.join('config', 'hieras', hiera, File.basename(datadir))
     [localpath, datadir]
   end
+end
+
+# Returns the path to the local r10k YAML configuration file
+def r10k_configpath(r10k)
+  File.join('config', 'r10ks', r10k + '.yaml')
 end

--- a/jenkins-integration/scripts/foss_install.sh
+++ b/jenkins-integration/scripts/foss_install.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
 set -x
 
+## Requires:
+## 1. Version of puppet-agent package to install
+##    Can be specified with either:
+##    - ENV['PUPPET_BUILD_VERSION']=1.3.0
+##    - hosts.yaml#CONFIG#puppet_version: 1.3.0
+##
+## 2. Version of puppet-server package to install
+##    Can be specified with either:
+##    - ENV['PUPPETSERVER_BUILD_VERSION']=2.2.1
+##    - hosts.yaml#CONFIG#puppetserver_version=1.3.0
+
+if [ -z $BEAKER_CONFIG ]; then
+    echo "BEAKER_CONFIG hosts configuration required"
+    exit 1
+fi
+
+## TODO Add the r10k_deploy.rb step to the TESTSUITE
+##      below once we know how it should interoperate
+##      with some of the other steps, like install_hiera
+##      and install_modules. SERVER-852
 export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-\
 beaker/install/foss/10_install_dev_repos.rb,\
 beaker/install/foss/20_install_puppet.rb,\

--- a/jenkins-integration/scripts/pe_install.sh
+++ b/jenkins-integration/scripts/pe_install.sh
@@ -6,6 +6,10 @@ set -x
 #     pe_dist_dir="http://neptune.puppetlabs.lan/4.0/ci-ready"
 #     (optional) pe_ver="4.0.0-rc5-161-g85ecc84"
 
+## TODO Add the r10k_deploy.rb step to the TESTSUITE
+##      below once we know how it should interoperate
+##      with some of the other steps, like install_hiera
+##      and install_modules. SERVER-852
 export BEAKER_TESTSUITE="${BEAKER_TESTSUITE:-\
 beaker/install/pe/10_install_pe.rb,\
 beaker/install/shared/40_clone_test_catalogs.rb,\


### PR DESCRIPTION
This commit adds the beginnings of configuring the master via an r10k
control repository. It goes so far as to run "r10k deploy" to map the
repository branches to Puppet environment directories, but does not do
anything after that like wire up any hiera.yaml configuration.