### PR TITLE
Feature/master/non csv feeder

### DIFF
--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/config/NodeFeeder.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/config/NodeFeeder.scala
@@ -1,0 +1,7 @@
+package com.puppetlabs.gatling.config
+
+object NodeFeeder {
+  def apply(certnamePrefix: String,
+            numInstances: Int) =
+    Range(1,numInstances).map(i => {Map("node" -> (certnamePrefix + i.toString))})
+}

--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PEBurnsideCatalogZeroStaticCatalogWithFeeder.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PEBurnsideCatalogZeroStaticCatalogWithFeeder.scala
@@ -1,4 +1,6 @@
 package com.puppetlabs.gatling.node_simulations
+
+import com.puppetlabs.gatling.config.NodeFeeder
 import com.puppetlabs.gatling.runner.SimulationWithScenario
 import org.joda.time.LocalDateTime
 import org.joda.time.format.ISODateTimeFormat
@@ -16,7 +18,7 @@ class PEBurnsideCatalogZeroStaticCatalogWithFeeder extends SimulationWithScenari
 // 		.baseURL("https://${node}:8140")
 
 	val reportBody = ELFileBody("PEBurnsideCatalogZeroStaticCatalogWithFeeder_0010_request.txt")
-        val nodeNames = csv("nodes.1000.csv").circular
+	val nodeNames = NodeFeeder("node", 1000).circular
 
 	val headers_0 = Map("X-Puppet-Version" -> "4.4.0")
 

--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PEBurnsideCatalogZeroStaticCatalogWithFeeder.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PEBurnsideCatalogZeroStaticCatalogWithFeeder.scala
@@ -18,7 +18,6 @@ class PEBurnsideCatalogZeroStaticCatalogWithFeeder extends SimulationWithScenari
 // 		.baseURL("https://${node}:8140")
 
 	val reportBody = ELFileBody("PEBurnsideCatalogZeroStaticCatalogWithFeeder_0010_request.txt")
-	val nodeNames = NodeFeeder("node", 1000).circular
 
 	val headers_0 = Map("X-Puppet-Version" -> "4.4.0")
 
@@ -34,7 +33,6 @@ class PEBurnsideCatalogZeroStaticCatalogWithFeeder extends SimulationWithScenari
 // val uri1 = "https://${node}:8140/puppet/v3"
 
 	val scn = scenario("PEBurnsideCatalogZeroStaticCatalogWithFeeder")
-                .feed(nodeNames)
 		.exec(http("node")
 			.get("/puppet/v3/node/${node}?environment=production&transaction_uuid=9221e708-f25f-4255-ad62-c03a21a270a5&fail_on_404=true")
 			.headers(headers_0))

--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/runner/ConfigDrivenSimulation.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/runner/ConfigDrivenSimulation.scala
@@ -3,7 +3,7 @@ package com.puppetlabs.gatling.runner
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
-import com.puppetlabs.gatling.config.PuppetGatlingConfig
+import com.puppetlabs.gatling.config.{NodeFeeder, PuppetGatlingConfig}
 import io.gatling.core.structure.{ChainBuilder}
 
 import scala.concurrent.duration._
@@ -101,7 +101,10 @@ class ConfigDrivenSimulation extends Simulation {
     val chainWithSleeps:ChainBuilder =
       addSleeps(chainWithFailFast, sleepDuration, numRepetitions)
 
+    val feeder = NodeFeeder("node", numInstances).circular
+
     scenario(simulationClass.getSimpleName)
+        .feed(feeder)
       .repeat(numRepetitions) {
         group((session) => simulationClass.getSimpleName) {
           chainWithSleeps


### PR DESCRIPTION
This commit introduces a feeder class in scala code, so that we don't need CSV files for all of the various numbers of feeders that we might want to use.

I think that it might break any existing sims that are explicitly using feeders via csv, but not 100% sure whether that is true, or whether I care :)