### PR TITLE
(SERVER-1463) fix auth so gatling can connect to server

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/job-steps/020_install_pe.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/job-steps/020_install_pe.sh
@@ -23,7 +23,9 @@ bundle exec beaker \
         --tests \
 beaker/install/shared/hack_hostname_into_etc_hosts.rb,\
 beaker/install/shared/disable_firewall.rb,\
-beaker/install/pe/10_install_pe.rb
+beaker/install/pe/10_install_pe.rb,\
+beaker/install/shared/configure_permissive_server_auth.rb,\
+beaker/install/pe/99_restart_server.rb
 
 # without this set +x, rvm will log 10 gigs of garbage
 set +x


### PR DESCRIPTION
This commit adds back in some calls to some code that will set up permissive auth.conf on the server and then restart it, so that Gatling can connect without getting 403 errors.