### PR TITLE
(SERVER-1469) finish scala conversion script

### DIFF
--- a/proxy-recorder/process_gatling_recording.rb
+++ b/proxy-recorder/process_gatling_recording.rb
@@ -24,9 +24,21 @@ def comment_line(line)
   "// #{line}"
 end
 
-def step1_look_for_inferred_html_resources()
+def step1_look_for_inferred_html_resources(text)
   puts "STEP 1: Look for inferred HTML resources"
-  puts "\t(Not yet implemented)"
+
+  if text.match(/\.inferHtmlResources\(\)/) or
+      text.match(/\.resource\(http/)
+    puts
+    puts "ERROR: Found references to 'inferHtmlResources' and/or 'resources'.\n" +
+             "This most likely means that you had the 'Infer Html resources?' checkbox\n" +
+             "in the gatling proxy recorder GUI checked.  This causes the simulation to\n" +
+             "try to behave like a browser and request multiple 'resources' in parallel;\n" +
+             "this behavior is not suitable for simulating puppet agents.  Please re-record\n" +
+             "your scenario with the 'Infer Html resources?' checkbox *unchecked*."
+    exit 1
+  end
+
 end
 
 # Step 2
@@ -162,7 +174,7 @@ def main(infile, outfile)
 
   output = input.dup
 
-  step1_look_for_inferred_html_resources()
+  step1_look_for_inferred_html_resources(output)
   step2_rename_package(output)
   output = step3_add_new_imports(output)
   step4_remove_unneeded_import(output)

--- a/proxy-recorder/process_gatling_recording.rb
+++ b/proxy-recorder/process_gatling_recording.rb
@@ -24,13 +24,20 @@ def comment_line(line)
   "// #{line}"
 end
 
+def step1_look_for_inferred_html_resources()
+  puts "STEP 1: Look for inferred HTML resources"
+  puts "\t(Not yet implemented)"
+end
+
 # Step 2
-def rename_package(text)
+def step2_rename_package(text)
+  puts "STEP 2: Renaming package to `com.puppetlabs.gatling.node_simulations`"
   text.gsub!(/^\s*package (.*)/, "package com.puppetlabs.gatling.node_simulations")
 end
 
 # Step 3
-def add_new_imports(text)
+def step3_add_new_imports(text)
+  puts "STEP 3: Adding additional import statements (for SimulationWithScnario and date/time classes)"
   out_text = text.lines.map do |line|
     if line.match(/package com.puppetlabs.gatling.node_simulations$/)
       [line,
@@ -48,17 +55,20 @@ def add_new_imports(text)
 end
 
 # Step 4
-def remove_unneeded_import(text)
+def step4_remove_unneeded_import(text)
+  puts "STEP 4: Removing unused JDBC import"
   text.gsub!(/^\s*(import io\.gatling\.jdbc\.Predef\._)/, '// \1')
 end
 
 # Step 5
-def update_extends(text)
+def step5_update_extends(text)
+  puts "STEP 5: Set class to extend `SimulationWithScenario`"
   text.gsub!(/^class (.*) extends Simulation/, 'class \1 extends SimulationWithScenario')
 end
 
 # Step 6
-def comment_out_http_protocol(text)
+def step6_comment_out_http_protocol(text)
+  puts "STEP 6: Comment out `httpProtocol` variable"
   begin_comment = false
   end_comment = false
 
@@ -79,31 +89,39 @@ end
 
 # Step 7
 # TODO define this method
-def add_connection_close(text)
+def step7_add_connection_close(text)
+  puts "STEP 7: Add 'Connection: close' after report request"
+  puts "\t(Not yet implemented)"
 end
 
 # Step 8
-def comment_out_uri1(text)
+def step8_comment_out_uri1(text)
+  puts "STEP 8: Comment out `uri1` variable"
   text.gsub!(/^\s*(val uri1 = ".*")/, '// \1')
 end
 
 # Step 9
-def update_expiration(text)
-  text.gsub!(/(expiration%22%3A%22)(\d{4})/, '\12025')
+def step9_update_expiration(text)
+  puts "STEP 9: Update facts expiration date"
+  text.gsub!(/(expiration%22%3A%22)(\d{4})/, '\12125')
 end
 
 # Step 10
 # TODO define this method
-def add_dynamic_timestamp(text)
+def step10_add_dynamic_timestamp(text)
+  puts "STEP 10: Use dynamic timestamp and transaction UUID"
+  puts "\t(Not yet implemented)"
 end
 
 # Step 11
-def comment_out_setup(text)
+def step11_comment_out_setup(text)
+  puts "STEP 11: Comment out SCN setUp call since driver will handle it"
   text.gsub!(/^\s*(setUp\(.*\))/, '// \1')
 end
 
 # Step 12
-def rename_request_bodies(text)
+def step12_rename_request_bodies(text)
+  puts "STEP 12: Add names for HTTP requests"
   current_replacement = ""
   out_text = ""
   # Here we replace request types according to step 12 in
@@ -130,25 +148,35 @@ def rename_request_bodies(text)
   out_text
 end
 
+def step13_setup_node_feeder()
+  puts "STEP 13: Set up ${node} var for feeder"
+  puts "\t(Not yet implemented)"
+end
+
 def main(infile, outfile)
   # The main event.
   # the input file tends to not end in a newline, which gets messy later
   input = File.read(infile) + "\n"
 
+  puts "Reading input from file '#{infile}'"
+
   output = input.dup
 
-  rename_package(output)
-  output = add_new_imports(output)
-  remove_unneeded_import(output)
-  update_extends(output)
-  output = comment_out_http_protocol(output)
-  add_connection_close(output)
-  comment_out_uri1(output)
-  update_expiration(output)
-  add_dynamic_timestamp(output)
-  comment_out_setup(output)
-  output = rename_request_bodies(output)
+  step1_look_for_inferred_html_resources()
+  step2_rename_package(output)
+  output = step3_add_new_imports(output)
+  step4_remove_unneeded_import(output)
+  step5_update_extends(output)
+  output = step6_comment_out_http_protocol(output)
+  step7_add_connection_close(output)
+  step8_comment_out_uri1(output)
+  step9_update_expiration(output)
+  step10_add_dynamic_timestamp(output)
+  step11_comment_out_setup(output)
+  output = step12_rename_request_bodies(output)
+  step13_setup_node_feeder()
 
+  puts "All steps completed, writing output to file '#{outfile}'"
   # Dump the reformatted file to disk
   File.open(outfile, 'w').write(output.split("\n").reverse.join("\n"))
 end

--- a/proxy-recorder/process_gatling_recording.rb
+++ b/proxy-recorder/process_gatling_recording.rb
@@ -186,7 +186,7 @@ end
 
 # Step 3
 def step3_add_new_imports(text)
-  puts "STEP 3: Adding additional import statements (for SimulationWithScnario and date/time classes)"
+  puts "STEP 3: Adding additional import statements (for SimulationWithScenario and date/time classes)"
   out_text = text.lines.map do |line|
     if line.match(/package com.puppetlabs.gatling.node_simulations$/)
       [line,

--- a/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
+++ b/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
@@ -5,16 +5,22 @@ simulation, i.e., the scala simulation and associated files commonly generated
 via the proxy-recorder tool, in order to make the simulation compatible with the
 puppet-gatling-jenkins-plugin project.
 
-## NOTE re ruby script to automate some of these steps
+## Use the ruby script to automate these steps
 
-There is a ruby script in the proxy-recorder directory that will apply most of
-these changes.  (*NOTE: requires ruby 2.0 or greater.*)
+There is a ruby script in the proxy-recorder directory that will make all of these
+changes.  (*NOTE: requires ruby 2.0 or greater.*)
 
 Just run `ruby ../proxy-recorder/process_gatling_recording.rb
 $path_to_scala_file` and it will output the modified scala to a file named
 after the input file with .new added. So an updated `MySimulation.scala` would
-be called `MySimulation.scala.new`. The script does not apply Step 13, but does
-do the rest of the changes below.
+be called `MySimulation.scala.new`.  It will also find the txt file for the report
+body, and create a modified copy of that file with the extension `.new` appended.
+
+The rest of this file just provides some gory details in case you're really interested
+in double-checking the output of the script, but it is strongly advised that
+you use the script.
+
+## The Future
 
 In the future we'd like to be able to fully automate the agent recording process
 so that we can set up jenkins jobs to take new recordings when a new version

--- a/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
+++ b/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
@@ -13,8 +13,8 @@ these changes.  (*NOTE: requires ruby 2.0 or greater.*)
 Just run `ruby ../proxy-recorder/process_gatling_recording.rb
 $path_to_scala_file` and it will output the modified scala to a file named
 after the input file with .new added. So an updated `MySimulation.scala` would
-be called `MySimulation.scala.new`. The script does not apply Step 1, Step 7,
-Step 10, or Step 13, but does do the rest of the changes below.
+be called `MySimulation.scala.new`. The script does not apply Step 13, but does
+do the rest of the changes below.
 
 In the future we'd like to be able to fully automate the agent recording process
 so that we can set up jenkins jobs to take new recordings when a new version
@@ -164,7 +164,39 @@ a simulation is fully automated.
   For an example of this change, see this commit:
   https://github.com/puppetlabs/gatling-puppet-load-test/commit/2b54e20f724ca25184f7f7b9e9a4b41b63439485.
 
-10. Add a dynamic timestamp to the report payload.
+10. Presuming you want to control the simulation parameters through a scenario
+    json file rather than hardcoding them in the Scala file directly, comment
+    out the generated call to setup():
+
+  ~~~~scala
+  // setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
+  ~~~~
+
+  For an example of this change, see this commit:
+  https://github.com/puppetlabs/gatling-puppet-load-test/commit/2b54e20f724ca25184f7f7b9e9a4b41b63439485.
+
+11. In order for Gatling to generate useful reports per request endpoint, the
+    names of the endpoints should be renamed.
+
+  | Name                 | Legacy Endpoint                                            | Modern v3 Endpoint                                              |
+  | -------------------- | ------------                                               | ------------                                                    |
+  | catalog              | /production/catalog/agent.localdomain                      | /puppet/v3/catalog/agent.localdomain                            |
+  | filemeta pluginfacts | /production/file_metadatas/pluginfacts                     | /puppet/v3/file_metadatas/pluginfacts                           |
+  | filemeta plugins     | /production/file_metadatas/plugins                         | /puppet/v3/file_metadatas/plugins                               |
+  | filemeta             | /production/file_metadatas/modules/xyz                     | /puppet/v3/file_metadata/modules/xyz                            |
+  | filemeta mco plugins | /production/file_metadatas/modules/pe_mcollective/plugins  | /puppet/v3/file_metadata/modules/puppet_enterprise/mcollective  |
+  | node                 | /production/node/agent.localdomain                         | /puppet/v3/node/agent.localdomain                               |
+  | report               | /production/report/agent.localdomain                       | /puppet/v3/report/agent.localdomain                             |
+
+  To change this for the "node" request, for example, the argument to the
+  http() method would need to be changed from "request_0" to "node":
+
+  ~~~~scala
+  val chain_0 = exec(http("node")
+    .get("/production/node/myhost.localdomain?transaction_uuid=2eabf4c0-acf8-466f-a0e4-d75519be6afc&fail_on_404=true"))
+  ~~~~
+
+12. Add a dynamic timestamp to the report payload.
 
   This change is needed whenever the report processor registered with the Puppet
   master would somehow reject the report content based on the same timestamp
@@ -249,38 +281,6 @@ a simulation is fully automated.
 
   For an example of the above changes, see this commit:
   https://github.com/puppetlabs/gatling-puppet-load-test/commit/9450847e52bd436192278a5fe9ea50308e4ddb26
-
-11. Presuming you want to control the simulation parameters through a scenario
-    json file rather than hardcoding them in the Scala file directly, comment
-    out the generated call to setup():
-
-  ~~~~scala
-  // setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
-  ~~~~
-
-  For an example of this change, see this commit:
-  https://github.com/puppetlabs/gatling-puppet-load-test/commit/2b54e20f724ca25184f7f7b9e9a4b41b63439485.
-
-12. In order for Gatling to generate useful reports per request endpoint, the
-    names of the endpoints should be renamed.
-
-  | Name                 | Legacy Endpoint                                            | Modern v3 Endpoint                                              |
-  | -------------------- | ------------                                               | ------------                                                    |
-  | catalog              | /production/catalog/agent.localdomain                      | /puppet/v3/catalog/agent.localdomain                            |
-  | filemeta pluginfacts | /production/file_metadatas/pluginfacts                     | /puppet/v3/file_metadatas/pluginfacts                           |
-  | filemeta plugins     | /production/file_metadatas/plugins                         | /puppet/v3/file_metadatas/plugins                               |
-  | filemeta             | /production/file_metadatas/modules/xyz                     | /puppet/v3/file_metadata/modules/xyz                            |
-  | filemeta mco plugins | /production/file_metadatas/modules/pe_mcollective/plugins  | /puppet/v3/file_metadata/modules/puppet_enterprise/mcollective  |
-  | node                 | /production/node/agent.localdomain                         | /puppet/v3/node/agent.localdomain                               |
-  | report               | /production/report/agent.localdomain                       | /puppet/v3/report/agent.localdomain                             |
-
-  To change this for the "node" request, for example, the argument to the
-  http() method would need to be changed from "request_0" to "node":
-
-  ~~~~scala
-  val chain_0 = exec(http("node")
-    .get("/production/node/myhost.localdomain?transaction_uuid=2eabf4c0-acf8-466f-a0e4-d75519be6afc&fail_on_404=true"))
-  ~~~~
 
 13. In order to make the simulation more realistic, the driver program will automatically
     replace occurrences of the variable `${node}` in Strings with a dynamically

--- a/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
+++ b/simulation-runner/README-GENERATING-AGENT-SIMULATIONS.md
@@ -34,51 +34,10 @@ a simulation is fully automated.
 
   If you find any of these, it means that you probably left the
   "Infer Html resources?" box checked in the Gatling proxy recorder GUI when you
-  generated the simulation file.  To correct this problem, it might be easier
-  to just re-run the proxy recorder with the box not checked to get a new
-  simulation file.
-
-  If you want to instead manually correct the simulation file, you would need to
-  remove any calls like this from the file:
-
-  ~~~~scala
-  .resources(http(request_1")
-  ~~~~
-
-  You would also need to promote any nested requests under one `.exec()` up to
-  separate `.exec()` calls.  For example, the following source would need to
-  be changed from...
-
-  ~~~~scala
-  val scn = ...
-    .exec(http("request_0")
-      .get("/production/node/myhost.localdomain?transaction_uuid=aa073181-5aec-4c07-896a-458b20b4c2f4&fail_on_404=true")
-      .resources(http("request_1")
-      .get(uri1 + "/file_metadatas/pluginfacts?links=manage&recurse=true&ignore=.svn&ignore=CVS&ignore=.git&checksum_type=md5"),
-  ...
-  ~~~~
-
-  to...
-
-  ~~~~scala
-  val scn = ...
-    .exec(http("request_0")
-      .get("/production/node/myhost.localdomain?transaction_uuid=aa073181-5aec-4c07-896a-458b20b4c2f4&fail_on_404=true"))
-    .exec(http("request_1")
-      .get("/production/file_metadatas/pluginfacts?links=manage&recurse=true&ignore=.svn&ignore=CVS&ignore=.git&checksum_type=md5"))
-  ...
-  ~~~~
-
-  For an example of this change, see this commit:
-  https://github.com/puppetlabs/gatling-puppet-load-test/commit/b134e63fd99693d94cc2d4da05910ce8f5773043.
-
-  Another disadvantage to manually removing resource references is that any
-  natural pauses between requests that the simulation would otherwise have
-  captured would be gone - because replays of resource requests are done
-  concurrently.  Again, it would be much better to just start with a simulation
-  which is captured with "Infer Html Resources?" not checked as the resulting
-  data should more accurately reflect the real agent communication with the
-  master.
+  generated the simulation file.  This causes the simulation to try to behave
+  like a browser and request multiple 'resources' in parallel; this behavior is
+  not suitable for simulating puppet agents.  Please re-record your scenario with
+  the 'Infer Html resources?' checkbox *unchecked*.
 
 2. Change the package name to:
 


### PR DESCRIPTION
This PR extends the script for post-processing gatling recordings to do the following:

* Complete *all* of the processing steps listed in the docs, rather than just a subset.  Theoretically this should mean that after taking a raw recording all you need to do is run this script and then you're done.
* Finds and modifies the request body text file in addition to the scala file
* Looks for a 'node config' JSON file and generates one if one doesn't exist.