### PR TITLE
(MAINT) Add server_version sections to single/multi pass Jenkinsfiles

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
@@ -4,12 +4,20 @@ node {
 }
 pipeline.multipass_pipeline([
         [job_name: 'firsttest',
+         server_version: [
+                 type: "pe",
+                 pe_version: "2016.2.0"
+         ],
          code_deploy: [
                  type: "r10k",
                  control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
                  basedir: "/etc/puppetlabs/code-staging/environments",
                  environments: ["production"]]],
         [job_name: 'secondtest',
+         server_version: [
+                 type: "pe",
+                 pe_version: "2016.2.0"
+         ],
          code_deploy: [
                  type: "r10k",
                  control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",

--- a/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
@@ -5,6 +5,10 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'singletest',
+        server_version: [
+                type: "pe",
+                pe_version: "2016.2.0"
+        ],
         code_deploy: [
                 type: "r10k",
                 control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",


### PR DESCRIPTION
This commit adds a `server_version` section in the calls to the
pipeline() functions from the single-pass and multi-pass scenario
Jenkinsfiles.  This section is now required in that the beaker setup
step would otherwise fail if these sections are not included.