### PR TITLE
(MAINT) Change NC classification rule to use clientcert fact

### DIFF
--- a/jenkins-integration/beaker/install/pe/60_classify_nodes_via_NC.rb
+++ b/jenkins-integration/beaker/install/pe/60_classify_nodes_via_NC.rb
@@ -13,7 +13,7 @@ def classify_pe_nodes(classifier, nodes)
         'parent' => production_id,
         'environment' => env,
         'environment_trumps' => true,
-        'rule' => ['~', 'clientcert', "#{config['certname_prefix']}.*"],
+        'rule' => ['~', ['fact', 'clientcert'], "#{config['certname_prefix']}.*"],
         'classes' => Hash[config['classes'].map { |klass| [klass, {}] }])
     end
   end


### PR DESCRIPTION
This commit changes the NC classification rule done for
`classify_pe_nodes` to wrap the `clientcert` in a `fact` value.
Previously, the value was not wrapped, which was erroneous and caused
nodes to not match the intended classification.