### PR TITLE
(SERVER-1471) Move scenario config out of job params

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -85,13 +85,12 @@ def step020_install_pe(SKIP_PE_INSTALL, script_dir, server_era) {
     }
 }
 
-def step025_collect_facter_data(job_name, script_dir) {
-    withEnv(["PUPPET_GATLING_SIMULATION_CONFIG=${PUPPET_GATLING_SIMULATION_CONFIG}",
+def step025_collect_facter_data(job_name, gatling_simulation_config, script_dir) {
+    withEnv(["PUPPET_GATLING_SIMULATION_CONFIG=${gatling_simulation_config}",
              "PUPPET_GATLING_SIMULATION_ID=${job_name}"]) {
         sh "${script_dir}/025_collect_facter_data.sh"
     }
 }
-
 
 def step030_customize_settings() {
     echo "Hi! TODO: I should be customizing PE settings on the SUT, but I'm not."
@@ -204,7 +203,9 @@ def single_pipeline(job) {
         step020_install_pe(SKIP_PE_INSTALL, SCRIPT_DIR, server_era)
 
         stage '025-collect-facter-data'
-        step025_collect_facter_data(job['job_name'], SCRIPT_DIR)
+        step025_collect_facter_data(job['job_name'],
+                job['gatling_simulation_config'],
+                SCRIPT_DIR)
 
         stage '030-customize-settings'
         step030_customize_settings()
@@ -263,7 +264,9 @@ def multipass_pipeline(jobs) {
             step010_setup_beaker(SCRIPT_DIR, job["server_version"])
             server_era = get_server_era(job["server_version"]["pe_version"])
             step020_install_pe(SKIP_PE_INSTALL, SCRIPT_DIR, server_era)
-            step025_collect_facter_data(job_name, SCRIPT_DIR)
+            step025_collect_facter_data(job_name,
+                    job['gatling_simulation_config'],
+                    SCRIPT_DIR)
             step030_customize_settings()
             step040_install_puppet_code(SCRIPT_DIR, job["code_deploy"], server_era)
             step045_install_hiera_config(SCRIPT_DIR, job["code_deploy"], server_era)

--- a/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
+++ b/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
@@ -35,9 +35,6 @@ scenarios_dir.eachFileRecurse (FileType.FILES) { file ->
                 stringParam('SUT_HOST',
                         'puppetserver-perf-sut54.delivery.puppetlabs.net',
                         'The host/IP address of the system to use as the SUT')
-                stringParam('PUPPET_GATLING_SIMULATION_CONFIG',
-                        '../simulation-runner/config/scenarios/ops-scenario.json',
-                        'The path to the gplt gatling scenario config file.')
                 booleanParam('SKIP_PE_INSTALL', false, 'If checked, will skip over the PE Install step.  Useful if you are doing development and already have a PE SUT.')
                 booleanParam('SKIP_PROVISIONING', true, 'If checked, will skip over the Razor provisioning step.  Useful if you already have an SUT provisioned, e.g. via the VM Pooler.')
             }

--- a/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
@@ -5,6 +5,7 @@ node {
 
 //pipeline.single_pipeline(
 //        [job_name: 'pe33-medium',
+//         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
 //         server_version: [
 //                 type: "pe",
 //                 pe_version: "3.3.2"
@@ -21,6 +22,7 @@ node {
 
 pipeline.multipass_pipeline([
         [job_name: 'pe33-medium',
+         gatling_simulation_config: '../simulation-runner/config/scenarios/pe33-medium-10.json',
          server_version: [
                  type: "pe",
                  pe_version: "3.3.2"
@@ -34,6 +36,7 @@ pipeline.multipass_pipeline([
                  hiera_config_datadir: "/etc/puppetlabs/puppet/environments/%{environment}/hieradata"
          ]],
         [job_name: 'pe-couch-medium',
+         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
          server_version: [
                  type: "pe",
                  pe_version: "2016.2.0"

--- a/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 //pipeline.single_pipeline(
 //        [job_name: 'pe33-medium',
-//         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
+//         gatling_simulation_config: '../simulation-runner/config/scenarios/pe33-medium-10.json',
 //         server_version: [
 //                 type: "pe",
 //                 pe_version: "3.3.2"

--- a/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
@@ -4,6 +4,7 @@ node {
 }
 pipeline.multipass_pipeline([
         [job_name: 'firsttest',
+         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
          server_version: [
                  type: "pe",
                  pe_version: "2016.2.0"
@@ -15,6 +16,7 @@ pipeline.multipass_pipeline([
                  environments: ["production"],
                  hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"]],
         [job_name: 'secondtest',
+         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
          server_version: [
                  type: "pe",
                  pe_version: "2016.2.0"

--- a/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
@@ -5,6 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'singletest',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
         server_version: [
                 type: "pe",
                 pe_version: "2016.2.0"


### PR DESCRIPTION
This commit moves the logic for specifying the
PUPPET_GATLING_SIMULATION_CONFIG setting from a Jenkins workflow job
parameter down into a job parameter at the level where the pipeline is
being constructed.  This was done since a multipass pipeline needs to
allow for the simulation config to be unique per "job" it runs.