### PR TITLE
(MAINT) Switch to puppet-gatling-jenkins-plugin

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -179,7 +179,9 @@ def step100_collect_sut_artifacts() {
 }
 
 def step900_collect_driver_artifacts() {
-    gatlingArchive()
+    // NOTE: this DSL step requires the puppet-gatling-jenkins plugin.  It also
+    // depends on some data that gets created via 025_collect_facter_data.sh
+    puppetGatlingArchive()
 }
 
 SCRIPT_DIR = "./jenkins-integration/jenkins-jobs/common/scripts/job-steps"


### PR DESCRIPTION
This commit switches us from calling the `gatlingArchive()` step
in the gatling jenkins plugin to calling the `puppetGatlingArchive()`
step in the puppet-gatling-jenkins-plugin.