### PR TITLE
(SERVER-1466) Configure custom JAVA_ARGS for pipeline jobs

### DIFF
--- a/jenkins-integration/beaker/install/shared/60_classify_nodes_via_site_pp.rb
+++ b/jenkins-integration/beaker/install/shared/60_classify_nodes_via_site_pp.rb
@@ -26,7 +26,7 @@ def classify_foss_nodes(host, nodes)
     # need to restart the server to make this change take effect.
     # TODO: should move the restart into a helper method or something, this
     # is duplicated in 99_restart_server.rb.
-    service_name = ENV['PUPPET_SERVER_SERVICE_NAME']
+    service_name = get_puppet_server_service_name_from_env()
 
     on(host, "systemctl restart #{service_name}")
 

--- a/jenkins-integration/beaker/install/shared/80_configure_java_args.rb
+++ b/jenkins-integration/beaker/install/shared/80_configure_java_args.rb
@@ -1,0 +1,38 @@
+require 'puppet/gatling/config'
+require 'inifile'
+
+test_name 'Configure java args'
+
+def service_config_name(service_name)
+  "/etc/sysconfig/#{service_name}"
+end
+
+def get_service_config(host, service_name)
+  local_service_config_dir = Dir.mktmpdir
+  scp_from(host, service_config_name(service_name), local_service_config_dir)
+  File.join(local_service_config_dir, service_name)
+end
+
+def update_java_args_in_local_config(java_args, local_service_config_path)
+  # Replace the existing JAVA_ARGS in the config
+  ini_file = IniFile.load(local_service_config_path)
+  ini_file['global']['JAVA_ARGS'] = java_args
+  ini_file.save
+
+  ini_file_lines = File.readlines(local_service_config_path)
+  # Clip the '[global]' section header off of the first line
+  File.open(local_service_config_path, 'w') do |f|
+    f.puts(ini_file_lines[1..-1])
+  end
+end
+
+def update_service_config(host, source_path, service_name)
+  scp_to(host, source_path, service_config_name(service_name))
+  on(host, "chmod 644 #{service_config_name(service_name)}")
+end
+
+service_name = get_puppet_server_service_name_from_env()
+local_service_config_path = get_service_config(master, service_name)
+java_args = get_puppet_server_java_args_from_env()
+update_java_args_in_local_config(java_args, local_service_config_path)
+update_service_config(master, local_service_config_path, service_name)

--- a/jenkins-integration/beaker/install/shared/99_restart_server.rb
+++ b/jenkins-integration/beaker/install/shared/99_restart_server.rb
@@ -1,6 +1,8 @@
+require 'puppet/gatling/config'
+
 test_name 'Restart PE Puppet Server to pick up configuration changes'
 
-service_name = ENV['PUPPET_SERVER_SERVICE_NAME']
+service_name = get_puppet_server_service_name_from_env()
 
 on(master, "systemctl restart #{service_name}")
 

--- a/jenkins-integration/jenkins-jobs/common/scripts/job-steps/080_configure_java_args.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/job-steps/080_configure_java_args.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+pushd jenkins-integration
+source jenkins-jobs/common/scripts/job-steps/initialize_ruby_env.sh
+
+# This file configures java args for the puppetserver process
+
+set -x
+set -e
+
+# Setup SSH agent for SSH access to SUT
+eval $(ssh-agent -t 24h -s)
+ssh-add ${HOME}/.ssh/id_rsa
+
+bundle exec beaker \
+        --config hosts.yaml \
+        --load-path lib \
+        --log-level debug \
+        --no-color \
+        --tests \
+beaker/install/shared/80_configure_java_args.rb,\
+beaker/install/shared/99_restart_server.rb
+
+# without this set +x, rvm will log 10 gigs of garbage
+set +x
+popd

--- a/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
@@ -47,5 +47,6 @@ pipeline.multipass_pipeline([
                  basedir: "/etc/puppetlabs/code-staging/environments",
                  environments: ["production"],
                  hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
-         ]]
+         ],
+         server_java_args: "-Xms12g -Xmx12g"]
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
@@ -14,7 +14,8 @@ pipeline.multipass_pipeline([
                  control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
                  basedir: "/etc/puppetlabs/code-staging/environments",
                  environments: ["production"],
-                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"]],
+                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"],
+         server_java_args: "-Xms12g -Xmx12g"],
         [job_name: 'secondtest',
          gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
          server_version: [
@@ -26,4 +27,5 @@ pipeline.multipass_pipeline([
                  control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
                  basedir: "/etc/puppetlabs/code-staging/environments",
                  environments: ["production"],
-                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"]]])
+                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"],
+         server_java_args: "-Xms12g -Xmx12g"]])

--- a/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
@@ -16,5 +16,6 @@ pipeline.single_pipeline([
                 basedir: "/etc/puppetlabs/code-staging/environments",
                 environments: ["production"],
                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
-        ]
+        ],
+        server_java_args: "-Xms12g -Xmx12g"
 ])

--- a/jenkins-integration/lib/puppet/gatling/config.rb
+++ b/jenkins-integration/lib/puppet/gatling/config.rb
@@ -60,6 +60,14 @@ def parse_scenario_file(scenario_file)
   JSON.parse(File.read(File.join(scenario_file)))
 end
 
+def get_puppet_server_service_name_from_env()
+  ENV['PUPPET_SERVER_SERVICE_NAME']
+end
+
+def get_puppet_server_java_args_from_env()
+  ENV['PUPPET_SERVER_JAVA_ARGS']
+end
+
 ################################################################################
 ### Nodes
 


### PR DESCRIPTION
This commit adds the ability for a pipeline job to supply a new
argument, `server_java_args`, which can be used to setup custom
JAVA_ARGS which, when set, replace the ones from the Puppet Server
sysconfig file.