### PR TITLE
(SERVER-1492) Do an agent run on FOSS SUT before Gatling run

### DIFF
--- a/jenkins-integration/beaker/install/foss/80_run_agent_on_master.rb
+++ b/jenkins-integration/beaker/install/foss/80_run_agent_on_master.rb
@@ -1,0 +1,9 @@
+test_name 'Run puppet agent on the master to prime directories' do
+  # Before kicking off a Gatling run, we run the agent on the master against
+  # itself one time.  This ensures that the master will create any directories
+  # in which it will need to store artifacts for future agent runs.  Doing this
+  # ahead of the Gatling run avoids collisions in the priming that can happen
+  # when multiple agent runs happen at the same time.  See PUP-6651 for more
+  # information.
+  on(master, 'puppet agent -t --server `hostname`')
+end

--- a/jenkins-integration/beaker/install/shared/60_classify_nodes_via_site_pp.rb
+++ b/jenkins-integration/beaker/install/shared/60_classify_nodes_via_site_pp.rb
@@ -8,6 +8,7 @@ def generate_sitepp(node_configs)
       map { |klass| "include #{klass}" }.
       insert(0, "node /#{config['certname_prefix']}.*/ {").
       push('}').
+      push("node 'default' {}").
       join("\n")
   end.join("\n").strip
 end

--- a/jenkins-integration/beaker/install/shared/99_restart_server.rb
+++ b/jenkins-integration/beaker/install/shared/99_restart_server.rb
@@ -1,6 +1,6 @@
 require 'puppet/gatling/config'
 
-test_name 'Restart PE Puppet Server to pick up configuration changes'
+test_name 'Restart puppet master to pick up configuration changes'
 
 service_name = get_puppet_server_service_name_from_env()
 

--- a/jenkins-integration/jenkins-jobs/common/scripts/job-steps/020_install_oss.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/job-steps/020_install_oss.sh
@@ -27,7 +27,8 @@ beaker/install/shared/disable_firewall.rb,\
 beaker/install/foss/30_install_dev_repos.rb,\
 beaker/install/foss/70_install_puppet.rb,\
 beaker/install/shared/configure_permissive_server_auth.rb,\
-beaker/install/shared/99_restart_server.rb
+beaker/install/shared/99_restart_server.rb,\
+beaker/install/foss/80_run_agent_on_master.rb
 
 echo "Finished installing OSS Puppet Server!"
 

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-10.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-stable',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-10.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-10.json',
         server_version: [
                 type: "oss",
                 version: "stable"

--- a/simulation-runner/config/scenarios/foss25x-medium-10.json
+++ b/simulation-runner/config/scenarios/foss25x-medium-10.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo",
+    "nodes": [
+        {
+            "node_config": "FOSS25xPerfMedium.json",
+            "num_instances": 3,
+            "ramp_up_duration_seconds": 0,
+            "num_repetitions": 1,
+            "sleep_duration_seconds": 1
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds logic to perform an agent run on a FOSS SUT before
kicking off the Gatling run.  This is needed in order to ensure that all
of the necessary directories on the master have been created before
concurrent agent runs can be performed.  Without this step, some of the
first few agent runs performed via Gatling could fail due to PUP-6651.