### PR TITLE
(MAINT) Set facter_structured_facts to true for oss server_era

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -89,7 +89,8 @@ def get_oss_server_era(oss_version) {
                 r10k_version: "2.3.0",
                 file_sync_available: false,
                 file_sync_enabled: false,
-                node_classifier: false]
+                node_classifier: false,
+                facter_structured_facts: true]
     } else {
         error "Unrecognized OSS version: '${oss_version}'"
     }


### PR DESCRIPTION
This commit sets facter_structured_facts to `true` for the OSS
`server_era`.  This presumes that we'll only be installing `facter` 2.x
or later for our OSS simulations, which seems safe for now.