### PR TITLE
(MAINT) Setup oss-puppetserver jobs to use 1250 agent, 2 hr scenario

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
@@ -16,5 +16,11 @@ pipeline.single_pipeline([
                 basedir: "/etc/puppetlabs/code/environments",
                 environments: ["production"],
                 hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
         ]
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-3.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1250.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-stable',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-3.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1250.json',
         server_version: [
                 type: "oss",
                 version: "stable"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
@@ -16,5 +16,11 @@ pipeline.single_pipeline([
                 basedir: "/etc/puppetlabs/code/environments",
                 environments: ["production"],
                 hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
         ]
 ])

--- a/simulation-runner/config/scenarios/foss25x-medium-1250.json
+++ b/simulation-runner/config/scenarios/foss25x-medium-1250.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo",
+    "nodes": [
+        {
+            "node_config": "FOSS25xPerfMedium.json",
+            "num_instances": 1250,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 4,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}


### PR DESCRIPTION
This commit changes the oss-puppetserver jobs to use the new
foss25x-medium-1250 scenario file - simulating 1250 agents for 4
iterations with a 30 minute sleep between runs, roughly 2 hours for the
total run.