### PR TITLE
(MAINT) Make SUT archive file path consistent

### DIFF
--- a/jenkins-integration/beaker/install/shared/copy_sut_archive_files.rb
+++ b/jenkins-integration/beaker/install/shared/copy_sut_archive_files.rb
@@ -2,13 +2,15 @@ require 'fileutils'
 
 step "Copy archive files from SUT" do
   archive_files = ENV['SUT_ARCHIVE_FILES'].split("\n")
-  job_name = ENV['PUPPET_GATLING_JOB_NAME']
+  job_name = ENV['PUPPET_GATLING_SIMULATION_ID']
   Beaker::Log.notify("Copying #{archive_files.count} archive files from SUT")
 
-  FileUtils.mkdir_p("./sut_archive_files/#{job_name}")
+  archive_dir = "../puppet-gatling/#{job_name}/sut_archive_files"
+
+  FileUtils.mkdir_p(archive_dir)
 
   archive_files.each do |s|
     Beaker::Log.notify("Copying archive file '#{s}'")
-    scp_from(master, s, "./sut_archive_files/#{job_name}")
+    scp_from(master, s, archive_dir)
   end
 end

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -278,15 +278,12 @@ def step110_collect_sut_artifacts(script_dir, job_name, archive_sut_files) {
     } else {
         echo "Collecting SUT archive files for job '${job_name}'"
         withEnv(["SUT_ARCHIVE_FILES=${archive_sut_files.join("\n")}",
-                 "PUPPET_GATLING_JOB_NAME=${job_name}"]) {
+                 "PUPPET_GATLING_SIMULATION_ID=${job_name}"]) {
             sh "${script_dir}/110_archive_sut_files.sh"
         }
         for (f in archive_sut_files) {
             String filename = get_filename(f);
-            // TODO: probably would be nicer for the scripts to be saving
-            // the files somewhere outside of the git working directory,
-            // but didn't want to hassle with figuring that out for the moment.
-            String filePath = "jenkins-integration/sut_archive_files/${job_name}/${filename}"
+            String filePath = "puppet-gatling/${job_name}/sut_archive_files/${filename}"
             echo "Archiving SUT file: '${filePath}'"
             sh "if [ ! -f './${filePath}' ] ; then echo 'ERROR! FILE DOES NOT EXIST!'; false ; fi"
             archive "${filePath}"


### PR DESCRIPTION
Prior to this commit, we were writing the facter data and other
CSV files into a directory called 'puppet-gatling' and a subdirectory
named after the job_name in the Jenkinsfile.  We were then
creating a similar, redundant directory structure to store the 'archive'
files in.  This commit just tweaks the logic for the 'archive' files
to re-use the existing directory structure under 'puppet-gatling'
and put the files near the facter data files.