### PR TITLE
(SERVER-1465) Add 2-hour scenarios for pe33 vs. couch

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
@@ -22,7 +22,7 @@ node {
 
 pipeline.multipass_pipeline([
         [job_name: 'pe33-medium',
-         gatling_simulation_config: '../simulation-runner/config/scenarios/pe33-medium-3.json',
+         gatling_simulation_config: '../simulation-runner/config/scenarios/pe33-medium-500-2-hours.json',
          server_version: [
                  type: "pe",
                  pe_version: "3.3.2"
@@ -36,7 +36,7 @@ pipeline.multipass_pipeline([
                  hiera_config_datadir: "/etc/puppetlabs/puppet/environments/%{environment}/hieradata"
          ]],
         [job_name: 'pe-couch-medium',
-         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-3.json',
+         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-500-2-hours.json',
          server_version: [
                  type: "pe",
                  pe_version: "2016.2.0"

--- a/simulation-runner/config/scenarios/pe-couch-medium-500-2-hours.json
+++ b/simulation-runner/config/scenarios/pe-couch-medium-500-2-hours.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo",
+    "nodes": [
+        {
+            "node_config": "PECouchPerfMedium.json",
+            "num_instances": 500,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 4,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}

--- a/simulation-runner/config/scenarios/pe33-medium-500-2-hours.json
+++ b/simulation-runner/config/scenarios/pe33-medium-500-2-hours.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo",
+    "nodes": [
+        {
+            "node_config": "PE33PerfMedium.json",
+            "num_instances": 500,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 4,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds scenarios for 2 hours, 500 agents for PE 3.3 vs. Couch.
The agent runtimes we've seen for PE3.3 so far are so long that I wanted
to start with a low-ish number of agents.  If the run goes well we could
try one with more agents.