### PR TITLE
(SERVER-1559) Standalone static catalogs test

### DIFF
--- a/jenkins-integration/jenkins-jobs/couch-static-catalogs/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/couch-static-catalogs/Jenkinsfile
@@ -1,0 +1,54 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.multipass_pipeline([
+//        [job_name: 'pe-couch-medium-no-static-catalogs',
+//         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-no-static-catalogs-1000-2-hours.json',
+//         server_version: [
+//                 type: "pe",
+//                 pe_version: "2016.2.0"
+//         ],
+//         code_deploy: [
+//                 type: "r10k",
+//                 control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+//                 basedir: "/etc/puppetlabs/code-staging/environments",
+//                 environments: ["production"],
+//                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
+//         ],
+//         server_java_args: "-Xms12g -Xmx12g",
+//         puppet_settings: [
+//                 master: [
+//                    "static_catalogs": "false"
+//                 ]
+//         ],
+//         background_scripts: [
+//                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+//         ],
+//         archive_sut_files: [
+//                 "/var/log/puppetlabs/puppetserver/metrics.json"
+//         ]
+//        ],
+        [job_name: 'pe-couch-static-catalogs',
+         gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-1500-1-hour.json',
+         server_version: [
+                 type: "pe",
+                 pe_version: "2016.2.0"
+         ],
+         code_deploy: [
+                 type: "r10k",
+                 control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                 basedir: "/etc/puppetlabs/code-staging/environments",
+                 environments: ["production"],
+                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
+         ],
+         server_java_args: "-Xms12g -Xmx12g",
+         background_scripts: [
+                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+         ],
+         archive_sut_files: [
+                 "/var/log/puppetlabs/puppetserver/metrics.json"
+         ]
+        ]
+])

--- a/simulation-runner/config/scenarios/pe-couch-medium-1500-1-hour.json
+++ b/simulation-runner/config/scenarios/pe-couch-medium-1500-1-hour.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo",
+    "nodes": [
+        {
+            "node_config": "PECouchPerfMedium.json",
+            "num_instances": 1500,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 2,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}


### PR DESCRIPTION
In the previous PRs for this ticket, I added a "no static catalogs"
setup to the existing pe33-vs-couch job.  This worked fine, but
because both couch configurations perform so much better than the PE3.3
run, it was hard to visualize the perf delta between the two couch
runs (with and without static catalogs).  This commit introduces
a new job that will strictly focus on couch, with and without
static catalogs.

The first few iterations of this are just going to be used to establish
a baseline for how many agents the server can handle, given a 12G heap
size.  This is intended to be run on the dev jenkins server, not the
production one.  Once we have some data about that, I'll file
a cleanup PR that sets up the final configurations for use in production,
and will run multiple scenarios with varying numbers of agents to
see how the load affects overall performance.