### PR TITLE
(SERVER-1559) Remove 1250-node sim for couch-no-static

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/couch-static-catalogs/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/couch-static-catalogs/Jenkinsfile
@@ -52,6 +52,10 @@ def static_catalogs_base_config() {
     ]
 }
 
+no_static_catalogs_250 = no_static_catalogs_base_config()
+no_static_catalogs_250.put('job_name', 'pe-couch-no-static-250')
+no_static_catalogs_250.put('gatling_simulation_config', '../simulation-runner/config/scenarios/pe-couch-medium-no-static-catalogs-250-2-hours.json')
+
 static_catalogs_500 = static_catalogs_base_config()
 static_catalogs_500.put('job_name', 'pe-couch-static-500')
 static_catalogs_500.put('gatling_simulation_config', '../simulation-runner/config/scenarios/pe-couch-medium-500-2-hours.json')
@@ -72,16 +76,11 @@ static_catalogs_1250 = static_catalogs_base_config()
 static_catalogs_1250.put('job_name', 'pe-couch-static-1250')
 static_catalogs_1250.put('gatling_simulation_config', '../simulation-runner/config/scenarios/pe-couch-medium-1250-2-hours.json')
 
-no_static_catalogs_1250 = no_static_catalogs_base_config()
-no_static_catalogs_1250.put('job_name', 'pe-couch-no-static-1250')
-no_static_catalogs_1250.put('gatling_simulation_config', '../simulation-runner/config/scenarios/pe-couch-medium-no-static-catalogs-1250-2-hours.json')
-
-
 pipeline.multipass_pipeline([
-    no_static_catalogs_500,
+    no_static_catalogs_250,
     static_catalogs_500,
-    no_static_catalogs_1000,
+    no_static_catalogs_500,
     static_catalogs_1000,
-    no_static_catalogs_1250,
+    no_static_catalogs_1000,
     static_catalogs_1250
 ])

--- a/simulation-runner/config/scenarios/pe-couch-medium-no-static-catalogs-250-2-hours.json
+++ b/simulation-runner/config/scenarios/pe-couch-medium-no-static-catalogs-250-2-hours.json
@@ -3,7 +3,7 @@
     "nodes": [
         {
             "node_config": "PECouchPerfMediumNoStaticCatalogs.json",
-            "num_instances": 1250,
+            "num_instances": 250,
             "ramp_up_duration_seconds": 1800,
             "num_repetitions": 4,
             "sleep_duration_seconds": 1800


### PR DESCRIPTION
The 1250-node simulation for no-static-catalogs for couch causes
too much load for our current SUT hardware to handle.

Switching it down to 250 agents to give us samples at 250,500,1000
for no static catalogs, and hopefully make the graphs more useful.