### PR TITLE
(MAINT) Pin beaker to 2.50.0

### DIFF
--- a/jenkins-integration/dev/Gemfile
+++ b/jenkins-integration/dev/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'beaker', '>=2.11.0'
+gem 'beaker', '2.50.0'


### PR DESCRIPTION
Tried to spin up a dev environment today, and the `bundle install`
command failed because it pulled in beaker 3.x, which requires
Ruby 2.2.5 or something, and I am currently using Ruby 2.1.x.

Can't think of any good reason why we need that version of beaker,
nor why we shouldn't pin this dev environment to a specific version,
so this commit pins us to 2.50.0.