### PR TITLE
(SERVER-1605) Support configuration of maximum build history for job

### DIFF
--- a/jenkins-integration/jenkins-jobs/README.md
+++ b/jenkins-integration/jenkins-jobs/README.md
@@ -16,9 +16,24 @@ Currently:
   eventually it'd be nice to figure out another way to bootstrap this seed job so we can get
   rid of JJB and all of its dependencies, since we are no longer using them for anything else.)
 
-* The `scenarios` directory is where you go to create new perf testing jobs.  Create a subdirectory
-  therein, and add a `Jenkinsfile` defining your new job.  For more info on the syntax
-  of a `Jenkinsfile`, see [README_JENKINSFILE_SYNTAX.md](./README_JENKINSFILE_SYNTAX.md).
+* The `scenarios` directory is where you go to create new perf testing jobs.  Each subdirectory
+  inside the `scenarios` directory can define a single perf testing job on the Jenkins server.
+  There are two files that you can create inside these subdirectories:
+
+  * Required: a `Jenkinsfile` defining your new job.  This file defines the behavior of your
+    job once it is launched and executing.  It uses the [Jenkins Pipeline Plugin](https://jenkins.io/solutions/pipeline/),
+    and specifically the [Pipeline DSL syntax](https://jenkins.io/doc/pipeline/steps/).  The
+    presence of this file is what will cause the seed job to create your perf testing job on
+    the Jenkins server.  For more info on the syntax of one of these `Jenkinsfile`s, see
+    [README_JENKINSFILE_SYNTAX.md](./README_JENKINSFILE_SYNTAX.md).
+
+  * Optional: a `JobDSL.groovy` file.  This can be used to configure *metadata* about your job;
+    for example, overriding the number of builds to retain history for, scheduling the job to run
+    automatically on a cron-type interval, adding extra build parameters, etc.  Basically anything
+    about the configuration of the job *before* it begins executing.  Note that this file uses
+    the [Jenkins JobDSL plugin](https://github.com/jenkinsci/job-dsl-plugin/wiki) to configure jobs;
+    the JobDSL API is a completely distinct API/DSL from the Pipeline DSL used in the `Jenkinsfile`.
+    For more information on the syntax of one of these files, see [README_JOBDSL_SYNTAX.md](./README_JOBDSL_SYNTAX.md).
 
   You can also look at the existing jobs for examples.  A couple of noteworthy
   ones:
@@ -38,6 +53,10 @@ Currently:
      you'd specified, serially, and for each one, spin up a new SUT and run the test.
      At the end it can aggregate perf data (e.g. gatling reports) for all of the
      runs and visualize them compared to one another.
+
+  * `scenarios/oss-puppetserver-latest-1-week/JobDSL.groovy`: this contains an example
+    of how to use the JobDSL to override the maximum number of builds of a specific job
+    that should be retained in the history stored on the Jenkins server.
 
 * The `common/scripts/jenkins` directory contains groovy library code that can be re-used
   across multiple perf test jobs; typically you'll load this code via your Jenkinsfile.

--- a/jenkins-integration/jenkins-jobs/README_JOBDSL_SYNTAX.md
+++ b/jenkins-integration/jenkins-jobs/README_JOBDSL_SYNTAX.md
@@ -1,0 +1,49 @@
+## gatling-puppet-load-test `JobDSL.groovy` syntax
+
+In each scenario directory where you have created a `Jenkinsfile` to define a
+gatling-puppet-load-test perf testing job, you may optionally also create a file
+named `JobDSL.groovy`.  If such a file is found, the seed job will use it to
+configure additional metadata about the job.
+
+If this doesn't make sense yet, make sure you've read the [main README.md](./README.md)
+about defining perf testing jobs, and the [Jenkinsfile README.md](./README_JENKINSFILE_SYNTAX.md)
+about what the `Jenkinsfile`s look like.
+
+Basically, the `Jenkinsfile` is used to define what happens once a job is
+launched, and the `JobDSL.groovy` file (optionally) configures metadata about the
+job before it is launched.  Examples might be:
+
+* modifying the number of runs to retain in the build history for a job
+* scheduling the job to automatically run at a certain time interval
+
+The `JobDSL.groovy` file should just be a plain-old groovy script (no need to
+define any classes or functions, though you should be able to define functions
+for your own use if you like).  It uses the [Jenkins JobDSL plugin](https://github.com/jenkinsci/job-dsl-plugin/wiki).
+There is some [pretty solid API documentation for this DSL](https://jenkinsci.github.io/job-dsl-plugin/)
+available if you're not sure how to modify some type of job configuration that
+you are interested in.  (It's worth calling out again that the JobDSL DSL/API
+is completely distinct from the Jenkins Pipeline DSL that is used in the
+`Jenkinsfile`.)
+
+When the script is run, it will be executed with
+a binding context that makes two variables available in it's local scope:
+
+* `out`: this is the [JobDSL logging stream](https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-DSL-Commands#logging).
+  Basically, you can call `println` on this object to have log messages show up
+  in the Jenkins console output when the seed job (`refresh-gplt-jobs`) is run.
+* `job`: this variable will contain a reference to
+  [the actual job definition](https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-DSL-Commands#job)
+  that the seed job is building up.  To make changes to the job, you call `job.with { ... }`, where the code inside
+  of those braces will be calls to the JobDSL to modify the job.  Here's an example of how you could change the
+  maximum number of builds stored in the job history to 10:
+
+```groovy
+job.with {
+    logRotator {
+        numToKeep(10)
+    }
+}
+```
+
+Theoretically you should be able to use any feature of the JobDSL within these scripts; refer to the
+[JobDSL API](https://jenkinsci.github.io/job-dsl-plugin/) for more info.

--- a/jenkins-integration/jenkins-jobs/README_JOBDSL_SYNTAX.md
+++ b/jenkins-integration/jenkins-jobs/README_JOBDSL_SYNTAX.md
@@ -26,7 +26,7 @@ is completely distinct from the Jenkins Pipeline DSL that is used in the
 `Jenkinsfile`.)
 
 When the script is run, it will be executed with
-a binding context that makes two variables available in it's local scope:
+a binding context that makes two variables available in its local scope:
 
 * `out`: this is the [JobDSL logging stream](https://github.com/jenkinsci/job-dsl-plugin/wiki/Job-DSL-Commands#logging).
   Basically, you can call `println` on this object to have log messages show up

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week/JobDSL.groovy
@@ -1,0 +1,8 @@
+job.with {
+    // Override the maximum number of builds to retain history for.  Because this job will run for an entire week,
+    // the Gatling simulation data will eat up a very large amount of disk space, so we will only retain the
+    // history for the last 10 runs instead of the default of 50.
+    logRotator {
+        numToKeep(10)
+    }
+}


### PR DESCRIPTION
The goal of this commit was to give us a mechanism for configuring the
maximum number of builds that would be retained in the history for a given
job on the Jenkins server.  The commit sets up a default value of 50
for all jobs, but also overrides this to 10 for our large 1-week job,
since history for that job will consume significantly more disk space.

It ended up that there was a solution to this particular issue that
is pretty general, and will allow users to tweak other metadata about
the jobs beyond just the build history, so that is the approach that
this commit takes.  It allows you to define a JobDSL.groovy file
alongside your Jenkinsfile, and then make calls to the JobDSL API
to modify the job.