### PR TITLE
(SERVER-1603) Add check for cent7 repo, fallback when looking for build

### DIFF
--- a/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
+++ b/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
@@ -3,21 +3,37 @@ repo_config_dir = 'tmp/repo_configs'
 
 require 'net/http'
 
+BASE_URL = 'http://builds.puppetlabs.lan/puppetserver'
+
+def has_cent7_repo?(version)
+  cent7_uri = URI("#{BASE_URL}/#{version}/repo_configs/rpm/pl-puppetserver-#{version}-el-7-x86_64.repo")
+
+  response_code = Net::HTTP.start(cent7_uri.host, cent7_uri.port) do |http|
+    http.head(cent7_uri.path).code
+  end
+
+  if response_code != "200"
+    Beaker::Log.notify("Skipping version #{version} because it doesn't appear to have a cent7 repo")
+    false
+  else
+    Beaker::Log.notify("Found Cent7 repo for version #{version}")
+    true
+  end
+end
+
 def get_latest_master_version(branch)
-  response = Net::HTTP.get(URI('http://builds.puppetlabs.lan/puppetserver/?C=M&O=D'))
+  response = Net::HTTP.get(URI(BASE_URL + '/?C=M&O=D'))
 
   if branch == "latest"
     branch = "master"
   end
 
-  response.lines do |l|
-    next unless l =~ /<td><a /
-    next unless l =~ /#{branch}/
-    match = l.match(/^.*href="([^"]+)\/\?C=M&amp;O=D".*$/)
-    return match[1]
-  end
+  response.lines.
+      select { |l| l =~ /<td><a / }.
+      select { |l| l =~ /#{branch}/}.
+      map { |l| l.match(/^.*href="([^"]+)\/\?C=M&amp;O=D".*$/)[1] }.
+      find { |v| has_cent7_repo?(v) }
 end
-
 
 def get_latest_agent_version
   response = Net::HTTP.get(URI('http://builds.puppetlabs.lan/puppet-agent/?C=M&O=D'))


### PR DESCRIPTION
Prior to this commit, when the framework was looking for the latest
OSS Puppet Server build (from either the stable or master) branch,
it would simply look for the latest build *directory* that existed
on the builds server.  However, it is possible (and not particularly
uncommon) for a build directory to exist but not have a cent7 repo/artifact
in it (due to either the build still being in progress, or due to
cent7 not being included in the target platform list for that build).

This commit makes the script a little smarter, so that it will validate
the existence of a cent7 repo inside of the directory on the build
server before choosing that build.  If the cent7 repo doesn't exist,
the script will fall back and try the next most recent build.