### PR TITLE
(SERVER-1549) Set OSS latest job to run automatically

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
@@ -1,0 +1,7 @@
+job.with {
+    triggers {
+        // This should run the job at a semi-random time between 9:00 and 10:59PM,
+        //  on Mondays.
+        scm('H H(21-22) * * 1')
+    }
+}


### PR DESCRIPTION
This commit adds a `JobDSL.groovy` file for the "OSS latest" job,
and schedules that job to run automatically, once a week, on
Monday evenings.