### PR TITLE
(MAINT) Add beaker-pe to Gemfile

### DIFF
--- a/jenkins-integration/Gemfile
+++ b/jenkins-integration/Gemfile
@@ -1,7 +1,8 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-gem 'beaker', '>=3.2.0'
+gem 'beaker', '~>3.2.0'
 gem 'beaker-hostgenerator', '0.3.2'
+gem 'beaker-pe', '~>1.4'
 
 gem 'scooter', :git => 'git@github.com:puppetlabs/scooter.git', :tag => '3.2.19'
 # Pin to the last version of net-ldap that works on ruby 1.9.3. We can get rid


### PR DESCRIPTION
We recently upgraded to the new 3.x series of beaker, which
no longer includes PE functionality by default.  This commit
adds an explicit dependency on the beaker-pe gem to regain
that functionality.