### PR TITLE
(PE-18258) Add recurring test for pe-latest

### DIFF
--- a/jenkins-integration/Gemfile
+++ b/jenkins-integration/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gem 'beaker', '~>3.2.0'
-gem 'beaker-hostgenerator', '0.3.2'
+gem 'beaker-hostgenerator', '0.8.0'
 gem 'beaker-pe', '~>1.4'
 
 gem 'scooter', :git => 'git@github.com:puppetlabs/scooter.git', :tag => '3.2.19'

--- a/jenkins-integration/beaker/install/pe/10_install_pe.rb
+++ b/jenkins-integration/beaker/install/pe/10_install_pe.rb
@@ -7,4 +7,4 @@ test_name 'Install PE'
 # The environment variables need to be specified on the CLI when invoking beaker,
 # or alternately they can be set on the master host in the hosts.yaml file.
 
-install_pe_on(master, {})
+install_pe_on(master, options)

--- a/jenkins-integration/jenkins-jobs/common/scripts/job-steps/010_setup_beaker.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/job-steps/010_setup_beaker.sh
@@ -20,10 +20,7 @@ bundle install --path vendor/bundle
 
 # NOTE that this beaker task uses the `pe_version` and `pe_family`
 # environment variables, which are set in `pipeline.groovy`.
-        bundle exec beaker-hostgenerator centos7-64mdca \
-        | sed -e "s/centos7-64-1/$SUT_HOST/1" \
-        | sed -e 's/hypervisor: vmpooler/hypervisor: none/1' \
-        > hosts.yaml
+        bundle exec beaker-hostgenerator --pe_dir "${pe_dir}" --hypervisor "none" centos7-64mdca{hostname=${SUT_HOST}} > hosts.yaml
 
 echo "CREATED HOSTS.YAML FILE:"
 cat hosts.yaml

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
@@ -1,0 +1,30 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'pe-latest',
+        // TODO: take a new recording for flanders, just using the existing couch
+        // recording right now to get things up and running.
+        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-1250-2-hours.json',
+        server_version: [
+                type: "pe",
+                pe_version: "2017.1",
+                find_latest: true
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code-staging/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
+        ],
+        server_java_args: "-Xms12g -Xmx12g",
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ]
+])

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
@@ -1,0 +1,10 @@
+job.with {
+    triggers {
+        // This should run the job at a semi-random time between 9:00 and 10:59PM,
+        //  on Tuesdays.
+        scm('H H(21-22) * * 2')
+    }
+}
+
+helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
+helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)


### PR DESCRIPTION
This commit adds a new job, `pe-puppetserver-latest`, which installs
the latest flanders build and runs our normal 2-hour test against it.

The JobDSL.groovy file schedules this job to run weekly on Tuesday
evenings.