### PR TITLE
(SERVER-1562) A-B test for jruby's jit mode

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/compare-oss-puppetserver-stable-jit-on-off/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/compare-oss-puppetserver-stable-jit-on-off/Jenkinsfile
@@ -1,0 +1,63 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.multipass_pipeline([
+        [
+                job_name: 'oss-stable-jit-off',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1250-2-hours.json',
+                server_version: [
+                        type: "oss",
+                        version: "stable"
+                ],
+                code_deploy: [
+                        type: "r10k",
+                        control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                        basedir: "/etc/puppetlabs/code/environments",
+                        environments: ["production"],
+                        hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+                ],
+                background_scripts: [
+                        "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+                ],
+                archive_sut_files: [
+                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                ],
+                hocon_settings: [
+                        [
+                                file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                                path: "jruby-puppet.compile-mode",
+                                value: "off"
+                        ]
+                ]
+        ],
+        [
+                job_name: 'oss-stable-jit-on',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1250-2-hours.json',
+                server_version: [
+                        type: "oss",
+                        version: "stable"
+                ],
+                code_deploy: [
+                        type: "r10k",
+                        control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                        basedir: "/etc/puppetlabs/code/environments",
+                        environments: ["production"],
+                        hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+                ],
+                background_scripts: [
+                        "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+                ],
+                archive_sut_files: [
+                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                ],
+                hocon_settings: [
+                        [
+                                file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                                path: "jruby-puppet.compile-mode",
+                                value: "jit"
+                        ]
+                ]
+        ]
+])


### PR DESCRIPTION
Adds a job which runs two oss-stable pipelines: one with jit on, and one with jit off