### PR TITLE
(SERVER-1662) Fix cron collisions, introduce server_config

### DIFF
--- a/jenkins-integration/jenkins-jobs/README_JOBDSL_SYNTAX.md
+++ b/jenkins-integration/jenkins-jobs/README_JOBDSL_SYNTAX.md
@@ -51,5 +51,13 @@ job.with {
   At the time of this writing, the only method is `overrideParameterDefault(job, param_name, new_default_value)`, which
   allows you to override the default value for a parameter such as `SUT_HOST`.
 
+* `serverConfig`: this is a map, containing some basic configuration information about the server that the job is
+  being created on.  The data for this is loaded from `./server_config.json`.  The keys that it will contain are:
+
+  * "hostname": the hostname of the server.
+  * "environment": an identifier that can be used to distinguish between different classes of servers; most common
+    values will be either "development" or "production".  You can use this as a condition in your JobDSL script,
+    e.g. to set up a time-based trigger for a job on production without doing so on dev servers.
+
 Theoretically you should be able to use any feature of the JobDSL within these scripts; refer to the
 [JobDSL API](https://jenkinsci.github.io/job-dsl-plugin/) for more info.

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
@@ -1,10 +1,14 @@
-job.with {
-    triggers {
-        // This should run the job at a semi-random time between 9:00 and 10:59PM,
-        //  on Mondays.
-        scm('H H(21-22) * * 1')
+// NOTE: we only want to cron this job and use a 'real' SUT hostname if the job
+// is running on a production server.
+if (serverConfig["environment"] == "production") {
+    job.with {
+        triggers {
+            // This should run the job at a semi-random time between 9:00 and 10:59PM,
+            //  on Mondays.
+            scm('H H(21-22) * * 1')
+        }
     }
-}
 
-helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
-helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
+    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
+    helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
+}

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
@@ -1,10 +1,14 @@
-job.with {
-    triggers {
-        // This should run the job at a semi-random time between 9:00 and 10:59PM,
-        //  on Tuesdays.
-        scm('H H(21-22) * * 2')
+// NOTE: we only want to cron this job and use a 'real' SUT hostname if the job
+// is running on a production server.
+if (serverConfig["environment"] == "production") {
+    job.with {
+        triggers {
+            // This should run the job at a semi-random time between 9:00 and 10:59PM,
+            //  on Tuesdays.
+            scm('H H(21-22) * * 2')
+        }
     }
-}
 
-helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
-helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
+    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
+    helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
+}

--- a/jenkins-integration/jenkins-jobs/server_config.json
+++ b/jenkins-integration/jenkins-jobs/server_config.json
@@ -1,0 +1,5 @@
+{
+  "puppetserver-perf-driver55.delivery.puppetlabs.net": {
+    "environment": "production"
+  }
+}


### PR DESCRIPTION
This commit introduces a new config file, `server_config.json`.
In it we can list out hostnames of jenkins servers, and set
attributes for them.  The attributes will be made available to the
`JobDSL.groovy` scripts via a local variable called `serverConfig`.

This allows JobDSL configurations to do things like conditionally
modify a job based on whether it is being created in a dev environment
vs. a production environment.