### PR TITLE
(maint) Fix site.pp generation

### DIFF
--- a/jenkins-integration/beaker/install/shared/60_classify_nodes_via_site_pp.rb
+++ b/jenkins-integration/beaker/install/shared/60_classify_nodes_via_site_pp.rb
@@ -8,9 +8,8 @@ def generate_sitepp(node_configs)
       map { |klass| "include #{klass}" }.
       insert(0, "node /#{config['certname_prefix']}.*/ {").
       push('}').
-      push("node 'default' {}").
       join("\n")
-  end.join("\n").strip
+  end.push("node 'default' {}").join("\n").strip
 end
 
 def classify_foss_nodes(host, nodes)


### PR DESCRIPTION
Fixes site.pp generation when multiple nodes are specified so that it
only emits a `default` node rule once.