### PR TITLE
(PDB-3209) Add a PDB metrics collection script

### DIFF
--- a/jenkins-integration/beaker/install/shared/install_deps.rb
+++ b/jenkins-integration/beaker/install/shared/install_deps.rb
@@ -1,0 +1,3 @@
+step "Install jq" do
+  install_package master, 'jq'
+end

--- a/jenkins-integration/dev/README.md
+++ b/jenkins-integration/dev/README.md
@@ -46,7 +46,9 @@ bundle exec beaker \
 	--tests beaker/
 ```
 
-If everything goes well, the beaker output should show no errors.
+Note that =~/.ssh/id_rsa-acceptance= is the private key used to ssh
+into the driver. If using VMPooler VM, this is the VMPooler private
+key. If everything goes well, the beaker output should show no errors.
 
 Jenkins should be available on port `8080` of your "driver" machine.  There should
 be one or more initial jobs configured; for more detail on what these jobs do,
@@ -79,6 +81,9 @@ followed the steps above.)  To run it:
 e.g.:
 
     ./add-public-key.sh ~/.ssh/id_rsa-acceptance  yw72peu78u7zcxv.delivery.puppetlabs.net
+
+If using a VMPooler VM, this key will likely be the same one used in
+the beaker invocation above.
 
 ##### SUT vmpooler node - disk space
 
@@ -120,6 +125,12 @@ On a CentOS 7 VM, perform the following steps:
 
 The VM should now have increased disk space. Mounting or symlinking the new disk
 should not be necessary.
+
+## Metrics
+
+After the test run completes successfuly, metrics are downloaded from
+the SUT. Those metrics are available in the archive associated with
+the Jenkins job and is downloadable via the Jenkins UI.
 
 ## Working on Jobs
 

--- a/jenkins-integration/dev/target_machine.yml
+++ b/jenkins-integration/dev/target_machine.yml
@@ -6,8 +6,8 @@ HOSTS:
     pe_upgrade_dir:
     pe_upgrade_ver:
     hypervisor: none
-    platform: el-6-x86_64
-    template: centos-6-x86_64
+    platform: el-7-x86_64
+    template: centos-7-x86_64
     roles:
     - jenkins
 CONFIG:

--- a/jenkins-integration/jenkins-jobs/common/scripts/background/curl-puppetdb-metrics-loop.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/background/curl-puppetdb-metrics-loop.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -x
+
+MBEANS_FILE=/var/log/puppetlabs/puppetdb/pdb-mbeans.json
+METRICS_FILE=/var/log/puppetlabs/puppetdb/pdb-metrics.json.gz
+PDB_METRICS_URL=http://localhost:8080/metrics/v1/mbeans
+
+rm -rf "${MBEANS_FILE}"
+rm -rf "${METRICS_FILE}"
+
+curl -sS -w "\n" -k "${PDB_METRICS_URL}" | jq  -j 'keys' > "${MBEANS_FILE}"
+
+while true ; do
+  curl -sS -H "Content-Type: application/json" -X POST -d @"${MBEANS_FILE}" "${PDB_METRICS_URL}" | gzip -c >> "${METRICS_FILE}"
+  sleep 300
+done

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -168,6 +168,8 @@ def step020_install_server(SKIP_SERVER_INSTALL, script_dir, server_era) {
         } else {
             error "Unsupported server type: ${server_era["type"]}"
         }
+
+        sh "${script_dir}/021_install_common.sh"
     }
 }
 

--- a/jenkins-integration/jenkins-jobs/common/scripts/job-steps/021_install_common.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/job-steps/021_install_common.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+pushd jenkins-integration
+source jenkins-jobs/common/scripts/job-steps/initialize_ruby_env.sh
+
+# This job sets up the following:
+# - Specified OSS Puppet Server / puppet-agent versions installed on provided master
+
+set -x
+set -e
+
+# Setup SSH agent for SSH access to the SUT
+eval $(ssh-agent -t 24h -s)
+ssh-add ${HOME}/.ssh/id_rsa
+
+bundle exec beaker \
+        --config hosts.yaml \
+        --type aio \
+        --load-path lib \
+        --log-level debug \
+        --no-color \
+        --tests \
+beaker/install/shared/install_deps.rb
+
+echo "Finished installing supporting dependencies"
+
+# without this set +x, rvm will log 10 gigs of garbage
+set +x
+popd
+
+

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetdb-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetdb-latest/Jenkinsfile
@@ -1,0 +1,31 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'pe-latest',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-1250-2-hours.json',
+        server_version: [
+                type: "pe",
+                pe_version: "2017.1",
+                find_latest: true
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code-staging/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
+        ],
+        server_java_args: "-Xms2g -Xmx2g",
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh",
+                "./jenkins-jobs/common/scripts/background/curl-puppetdb-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetdb/pdb-mbeans.json",
+                "/var/log/puppetlabs/puppetdb/pdb-metrics.json.gz"
+        ]
+])


### PR DESCRIPTION
This commit adds a new background script that will collect all PDB JMX
metrics and dump them to a compressed file, similar to how metrics are
collected for puppetserver.

Note that this is currently a work in progress. It won't work right now due to https://github.com/puppetlabs/trapperkeeper-metrics/pull/39. Once that's merged, released, lein parent bumped and puppetdb is bumped to that new version and released, this should be able to run.