### PR TITLE
(MAINT) Run puppetserver oss and pe jobs on cron instead of scm poll

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
@@ -5,7 +5,7 @@ if (serverConfig["environment"] == "production") {
         triggers {
             // This should run the job at a semi-random time between 9:00 and 10:59PM,
             //  on Mondays.
-            scm('H H(21-22) * * 1')
+            cron('H H(21-22) * * 1')
         }
     }
 

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
@@ -5,7 +5,7 @@ if (serverConfig["environment"] == "production") {
         triggers {
             // This should run the job at a semi-random time between 9:00 and 10:59PM,
             //  on Tuesdays.
-            scm('H H(21-22) * * 2')
+            cron('H H(21-22) * * 2')
         }
     }
 


### PR DESCRIPTION
Previously, the oss and pe puppetserver latest jobs were configured to
run weekly on an scm poll.  This would cause Jenkins to only perform the
full Gatling job run if a commit in the gatling-puppet-load-test repo
had changed since the last job that was run.  For these jobs, we're
interested in running the jobs even if nothing in the GPLT repo has
changed - for example, if a new puppetserver nightly is available.

In this commit, the jobs have been changed to run on a cron rather than
an scm poll.  This should ensure that the jobs run every week even if
nothing in the GPLT repo itself has changed from week to week.