### PR TITLE
(MAINT) Switch oss and pe-puppetserver jobs from sut54 to sut56

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
@@ -9,6 +9,6 @@ if (serverConfig["environment"] == "production") {
         }
     }
 
-    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
+    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut56.delivery.puppetlabs.net")
     helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
 }

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
@@ -9,6 +9,6 @@ if (serverConfig["environment"] == "production") {
         }
     }
 
-    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
+    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut56.delivery.puppetlabs.net")
     helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
 }


### PR DESCRIPTION
This commit switches the target sut for the oss and pe-puppetserver
latest jobs from sut54 to sut56.  The hardware which corresponded to
sut54 appears to be out of commission, for now at least.  We may switch
this back later when the hardware is rehabilitated.