### PR TITLE
(MAINT) Switch oss and pe-puppetserver jobs from sut56 to sut54

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
@@ -9,6 +9,6 @@ if (serverConfig["environment"] == "production") {
         }
     }
 
-    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut56.delivery.puppetlabs.net")
+    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
     helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
 }

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
@@ -9,6 +9,6 @@ if (serverConfig["environment"] == "production") {
         }
     }
 
-    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut56.delivery.puppetlabs.net")
+    helper.overrideParameterDefault(job, "SUT_HOST", "puppetserver-perf-sut54.delivery.puppetlabs.net")
     helper.overrideParameterDefault(job, "SKIP_PROVISIONING", false)
 }


### PR DESCRIPTION
Hardware for sut54 is working again but sut56 is offline.  sut54 was
showing more consistent results from run to run than sut56 was when it
was working.  Switching back to sut54 to see if stability returns.