### PR TITLE
(SERVER-1790) Fix oss-puppetserver-latest run failures

### DIFF
--- a/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
+++ b/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
@@ -34,6 +34,11 @@ def get_latest_master_version(branch)
     branch = "master"
   end
 
+  # Scrape the puppetserver repo page for available puppetserver builds and
+  # filter down to only ones matching the specified branch.  The list of builds
+  # is ordered from most recent to oldest.  The resulting list is passed along
+  # to the get_cent7_repo routine, which returns a URL for the first build which
+  # has a cent7 repo in it.
   get_cent7_repo(
       response.lines.
           select { |l| l =~ /<td><a / }.
@@ -43,6 +48,11 @@ end
 def get_latest_agent_version
   response = Net::HTTP.get(URI(BASE_URL + '/puppet-agent/?C=M&O=D'))
 
+  # Scrape the puppet-agent repo page for available puppet-agent builds and
+  # filter down to only released builds (e.g., 1.2.3) vs.
+  # some mergely/SHA version.  The list of builds is ordered from most recent to
+  # oldest.  The resulting list is passed along to the get_cent7_repo routine,
+  # which returns a URL for the first build which has a cent7 repo in it.
   get_cent7_repo(
       response.lines.
           select { |l| l =~ /<td><a / }.

--- a/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
+++ b/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
@@ -3,50 +3,52 @@ repo_config_dir = 'tmp/repo_configs'
 
 require 'net/http'
 
-BASE_URL = 'http://builds.puppetlabs.lan/puppetserver'
+BASE_URL = 'http://builds.puppetlabs.lan'
 
-def has_cent7_repo?(version)
-  cent7_uri = URI("#{BASE_URL}/#{version}/repo_configs/rpm/pl-puppetserver-#{version}-el-7-x86_64.repo")
+def has_cent7_repo?(package, version)
+  cent7_uri = URI("#{BASE_URL}/#{package}/#{version}/repo_configs/rpm/pl-#{package}-#{version}-el-7-x86_64.repo")
 
   response_code = Net::HTTP.start(cent7_uri.host, cent7_uri.port) do |http|
     http.head(cent7_uri.path).code
   end
 
   if response_code != "200"
-    Beaker::Log.notify("Skipping version #{version} because it doesn't appear to have a cent7 repo")
+    Beaker::Log.notify("Skipping #{package} version #{version} because it doesn't appear to have a cent7 repo")
     false
   else
-    Beaker::Log.notify("Found Cent7 repo for version #{version}")
+    Beaker::Log.notify("Found Cent7 repo for #{package} version #{version}")
     true
   end
 end
 
+def get_cent7_repo(response_lines, package)
+  response_lines.
+      map { |l| l.match(/^.*href="([^"]+)\/\?C=M&amp;O=D".*$/)[1] }.
+      find { |v| has_cent7_repo?(package, v) }
+end
+
 def get_latest_master_version(branch)
-  response = Net::HTTP.get(URI(BASE_URL + '/?C=M&O=D'))
+  response = Net::HTTP.get(URI(BASE_URL + '/puppetserver/?C=M&O=D'))
 
   if branch == "latest"
     branch = "master"
   end
 
-  response.lines.
-      select { |l| l =~ /<td><a / }.
-      select { |l| l =~ /#{branch}/}.
-      map { |l| l.match(/^.*href="([^"]+)\/\?C=M&amp;O=D".*$/)[1] }.
-      find { |v| has_cent7_repo?(v) }
+  get_cent7_repo(
+      response.lines.
+          select { |l| l =~ /<td><a / }.
+          select { |l| l =~ /#{branch}/}, "puppetserver")
 end
 
 def get_latest_agent_version
-  response = Net::HTTP.get(URI('http://builds.puppetlabs.lan/puppet-agent/?C=M&O=D'))
+  response = Net::HTTP.get(URI(BASE_URL + '/puppet-agent/?C=M&O=D'))
 
-  response.lines do |l|
-    next unless l =~ /<td><a /
-    match = l.match(/^.*href="(\d+\.\d+\.\d+)\/\?C=M&amp;O=D".*$/)
-    next unless match
-    return match[1]
-  end
+  get_cent7_repo(
+      response.lines.
+          select { |l| l =~ /<td><a / }.
+          select { |l| l.match(/^.*href="(\d+\.\d+\.\d+)\/\?C=M&amp;O=D".*$/) },
+      "puppet-agent")
 end
-
-
 
 step "Setup Puppet Server repositories." do
   package_build_version = ENV['PACKAGE_BUILD_VERSION']

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -86,20 +86,33 @@ def get_oss_server_era(oss_version) {
     // TODO: eventually we will probably want to do something more sophisticated
     //  here; currently only support 'latest'/'master'/'stable' OSS puppetserver,
     //  and 'latest' agent
-    if (["latest", "master", "stable"].contains(oss_version)) {
-        return [type: "oss",
-                service_name: "puppetserver",
-                version: oss_version,
-                agent_version: "latest",
-                tk_auth: false,
-                puppet_bin_dir: "/opt/puppetlabs/puppet/bin",
-                r10k_version: "2.3.0",
-                file_sync_available: false,
-                file_sync_enabled: false,
-                node_classifier: false,
-                facter_structured_facts: true]
-    } else {
-        error "Unrecognized OSS version: '${oss_version}'"
+    switch (oss_version) {
+        case ["latest", "master"]:
+            return [type: "oss",
+                    service_name: "puppetserver",
+                    version: oss_version,
+                    agent_version: "latest",
+                    tk_auth: true,
+                    puppet_bin_dir: "/opt/puppetlabs/puppet/bin",
+                    r10k_version: "2.3.0",
+                    file_sync_available: false,
+                    file_sync_enabled: false,
+                    node_classifier: false,
+                    facter_structured_facts: true]
+        case "stable":
+            return [type: "oss",
+                    service_name: "puppetserver",
+                    version: oss_version,
+                    agent_version: "latest",
+                    tk_auth: false,
+                    puppet_bin_dir: "/opt/puppetlabs/puppet/bin",
+                    r10k_version: "2.3.0",
+                    file_sync_available: false,
+                    file_sync_enabled: false,
+                    node_classifier: false,
+                    facter_structured_facts: true]
+        default:
+            error "Unrecognized OSS version: '${oss_version}'"
     }
 }
 


### PR DESCRIPTION
This PR contains two changes:

1) Enable tk-auth for latest/master OSS Puppet Server runs.

Previously, all OSS Puppet Server jobs assumed that the
use-legacy-auth-conf setting was set to 'true' and so only tried to
reconfigure the Ruby Puppet auth.conf file to enable the permissive
access needed to perform multi-node runs.  As of Puppet 5, though,
use-legacy-auth-conf will be set to 'false' by default.  This commit
updates the server config to assume that for any builds being tested
from the Puppet Server master branch, the tk-auth configuration file is
setup for permissive access.

2) Skip non-existent cent7 puppet-agent builds

Previously, the logic which tried to determine which 'latest'
puppet-agent release build to install would assume that a cent7 build
was available on the repo server if its parent directory existed.  This
will sometimes not be true - e.g., where some artifacts may be built up
over the course of a few days near a release.

The logic for determining the latest puppetserver release skips over any
build where the repo folder exists but the cent7 build itself does not.
This commit reworks the logic for determining the latest build to be
more common for both puppet-agent and puppetserver.  As a result,
non-existent puppet-agent builds will be skipped over like puppetserver
ones have been.

We hit this one because the puppet-agent 1.10.1 directory existed on the
repo server but the cent7 builds did not yet, leading to puppet-agent failing
to be installed.  With the changes on this PR, 1.10.1 would have been
skipped over, leading to 1.10.0 being installed instead.