### PR TITLE
(SERVER-1862) Introduce latest vs latest-release agent_version config

### DIFF
--- a/jenkins-integration/jenkins-jobs/README_JENKINSFILE_SYNTAX.md
+++ b/jenkins-integration/jenkins-jobs/README_JENKINSFILE_SYNTAX.md
@@ -88,7 +88,7 @@ Here's some info about each of these sections:
 * `gatling_simulation_config`: path to the [scenario config file](../simulation-runner/config/scenarios) that you want to
   use for this perf test.
 * `server_version`: used to choose whether to do a PE install or an OSS puppetserver install, and to specify the version.
-* `agent_version`: used to specify the version of puppet agent to install alongside puppetserver. Specify 'latest' to retrieve latest tagged build.
+* `agent_version`: used to specify the version of puppet agent to install alongside puppetserver. Specify `latest` to retrieve latest successful build from the puppet-agent master branch or `latest-release` to retrieve the latest tagged release of puppet-agent.
 * `code_deploy`: specifies what puppet code we need to deploy to the server in order to be able to compile the catalogs for
   the selected gatling simulation.  Currently only supports a `type` value of `r10k`, with the following additional arguments:
   * `control_repo`: the URL for the r10k control repo

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-stable/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline.single_pipeline([
                 type: "oss",
                 version: "stable"
         ],
+        agent_version: [
+                version: "latest-release"
+        ],
         code_deploy: [
                 type: "r10k",
                 control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",


### PR DESCRIPTION
This commit changes the agent_version parameter for OSS jobs to use a
distinction between 'latest' (latest successful puppet-agent build from
the master branch) vs. 'latest-release' (latest release of puppet-agent).
The oss-puppetserver-stable job now uses the 'latest-release' value for
puppet-agent whereas the other oss-puppetserver jobs continue to
implicitly use the default value of 'latest' (via not specifying a
discrete value for agent_version).