### PR TITLE
(MAINT) Handle whitespace in latest agent version

### DIFF
--- a/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
+++ b/jenkins-integration/beaker/install/foss/30_install_dev_repos.rb
@@ -52,7 +52,8 @@ def get_latest_agent_version
     actions = json["actions"].find { |hash| hash["_class"] == "hudson.model.ParametersAction" }
     parameters = actions["parameters"]
     pkg_build_param = parameters.find { |hash| hash["name"] == "SUITE_COMMIT" }
-    pkg_build_param["value"]
+
+    pkg_build_param["value"].strip
   else
     Beaker::Log.notify("Unable to get last successful build from: #{url}, " +
            "error: #{response.code}, #{response.message}")


### PR DESCRIPTION
A job is failing because the sha returned by get_latest_agent_version has a
single space after it.

This commit updates the get_latest_agent_version fn to strip whitespace from
the returned sha