### PR TITLE
(SERVER-2071) Don't care if background script was already stopped

### DIFF
--- a/jenkins-integration/beaker/install/shared/stop_sut_background_scripts.rb
+++ b/jenkins-integration/beaker/install/shared/stop_sut_background_scripts.rb
@@ -7,7 +7,7 @@ step "Stop background scripts on SUT" do
   Beaker::Log.notify(JSON.pretty_generate(pids))
   pids.each do |k, v|
     Beaker::Log.notify("Stopping script '#{k}' with pid '#{v}'")
-    on(master, "kill #{v}")
+    on(master, "kill #{v}", :acceptable_exit_codes => [0, 1])
     Beaker::Log.notify("Waiting for bg script '#{k}' with pid '#{v}' to exit.")
     on(master, "while kill -0 #{v} 2>/dev/null; do sleep 0.5; done")
   end


### PR DESCRIPTION
Earlier today we saw a frivolous failed status for a job because this
task attempted to stop a background script, but that PID did not exist,
for reasons we couldn't determine. Since the harm in leaving that
running is minimal (nodes get wiped before reuse in most cases) but
results don't show up properly if the job is marked as a failure, we
want to ignore the case in which the PID did not exist and just
continue.