### PR TITLE
(maint) Disable pe-puppetserver-latest cron

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/JobDSL.groovy
@@ -5,7 +5,7 @@ if (serverConfig["environment"] == "production") {
         triggers {
             // This should run the job at a semi-random time between 9:00 and 10:59PM,
             //  on Tuesdays.
-            cron('H H(21-22) * * 2')
+//            cron('H H(21-22) * * 2')
         }
     }
 


### PR DESCRIPTION
Having pe-puppetserver tests run automatically may someday be
desireable, but right now this just gets in the way by nuking SUTs that
are running tests and by causing conflicts with FOSS puppetserver. Also
this job is installing flanders. This commit disables the cron for now.