### PR TITLE
(BKR-487) host_preserved.yml fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SOURCE'] || 'http://rubygems.delivery.puppetlabs.net'
 
-gem 'beaker', '~>3.2'
+gem 'beaker', :git => 'https://github.com/puppetlabs/beaker.git', :branch => 'fix/master/BKR-487_preserved_hosts_yml_fix'
 gem 'beaker-pe', '~>1.4'
 gem 'beaker-pe-large-environments', '~>0.2'
 gem 'scooter', '~>4.0'


### PR DESCRIPTION
changed gemfile to pick up a special version of beaker that has a fix to convert the AWS objects to hashs.
This will enable the host_preserved.yml to be read in, but will not enable it to use anything that leveraged
the aws instance object... like killing the instances.

This is a temp fxi until QE does the longer term fix and makes a release.