### PR TITLE
(SERVER-2071) Always have jit on for jruby9k

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
@@ -23,5 +23,12 @@ pipeline.single_pipeline([
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
         ],
-        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+        hocon_settings: [
+                  [
+                    file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                    path: "jruby-puppet.compile-mode",
+                    value: "jit"
+                  ]
+                ]
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
@@ -51,5 +51,12 @@ pipeline.multipass_pipeline([
                 archive_sut_files: [
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
-                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ]])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
@@ -24,7 +24,14 @@ pipeline.multipass_pipeline([
                 archive_sut_files: [
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
-                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ],
         [
                 job_name: 'oss-latest-jruby-9k-1000-agents',
@@ -46,7 +53,14 @@ pipeline.multipass_pipeline([
                 archive_sut_files: [
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
-                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ],
         [
                 job_name: 'oss-latest-jruby-9k-1250-agents',
@@ -68,5 +82,12 @@ pipeline.multipass_pipeline([
                 archive_sut_files: [
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
-                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+                jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ]])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-json-vs-pson/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-json-vs-pson/Jenkinsfile
@@ -28,6 +28,13 @@ pipeline.multipass_pipeline([
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ],
         [
                 job_name: 'oss-latest-jruby9k-pson',
@@ -53,5 +60,12 @@ pipeline.multipass_pipeline([
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ],
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
@@ -1,0 +1,42 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'oss-latest-jruby9k',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        agent_version: [
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ],
+        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+        hocon_settings: [
+          [
+            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+            path: "jruby-puppet.compile-mode",
+            value: "jit"
+          ],
+          [
+            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+            path: "jruby-puppet.max-requests-per-instance",
+            value: 100000
+          ]
+        ]
+])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
@@ -29,6 +29,13 @@ pipeline.multipass_pipeline([
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 server_java_args: "-Xms4g -Xmx4g",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ],
         [
                 job_name: 'oss-latest-9k-8g-heap',
@@ -55,6 +62,13 @@ pipeline.multipass_pipeline([
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 server_java_args: "-Xms8g -Xmx8g",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ],
         [
                 job_name: 'oss-latest-9k-12g-heap',
@@ -81,5 +95,12 @@ pipeline.multipass_pipeline([
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 server_java_args: "-Xms12g -Xmx12g",
+                hocon_settings: [
+                          [
+                            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                            path: "jruby-puppet.compile-mode",
+                            value: "jit"
+                          ]
+                        ]
         ],
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
@@ -26,5 +26,12 @@ pipeline.single_pipeline([
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
         ],
-        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+        hocon_settings: [
+                  [
+                    file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                    path: "jruby-puppet.compile-mode",
+                    value: "jit"
+                  ]
+                ]
 ])


### PR DESCRIPTION
Jruby 9k does not perform adequately without jit on, so this commit
makes sure jit is always on with 9k.