### PR TITLE
(SERVER-2078) Add HEAP_OVERRIDES, JAVA_ARGS_ADDITIONS param to jobs

### DIFF
--- a/jenkins-integration/jenkins-jobs/README_JENKINSFILE_SYNTAX.md
+++ b/jenkins-integration/jenkins-jobs/README_JENKINSFILE_SYNTAX.md
@@ -67,7 +67,7 @@ yet.  So they are just raw maps for now.
              environments: ["production"],
              hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
     ],
-    server_java_args: "-Xms12g -Xmx12g",
+    server_heap_settings: "-Xms12g -Xmx12g",
     puppet_settings: [
              master: [
                      "static_catalogs": "false"
@@ -104,7 +104,7 @@ Here's some info about each of these sections:
    for the configured PE/Puppet Server setup.  NOTE: the path is expected to be a local file on the SUT, so the easiest
    way to get this working is to include the control repo so that it will be available at a known location on the SUT
    after the r10k deploy.
-* `server_java_args`: if you wish to override any of the Java args (for Puppet Server only, at this time), specify the
+* `server_heap_settings`: if you wish to override the heap settings of the Java args (for Puppet Server only, at this time), specify the
   args here.
 * `puppet_settings`: if you wish to modify any of the settings in puppet.conf, provide a nested map here.  The first level
   in the map controls the section of puppet.conf that the setting should go in, and then the next level has setting key/value

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -280,7 +280,7 @@ def step080_customize_java_args(script_dir, server_heap_settings, server_era) {
             server_heap_settings = ""
         }
 
-        if ("${HEAP_OVERRIDES}" != "" && "${HEAP_OVERRIDES}" != null) {
+        if ("${HEAP_OVERRIDES}" != "") {
             server_heap_settings = "${HEAP_OVERRIDES}"
         }
 

--- a/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
+++ b/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
@@ -100,6 +100,12 @@ scenarios_dir.eachFileRecurse (FileType.FILES) { file ->
                 stringParam('SUT_HOST',
                         'foo-sut.delivery.puppetlabs.net',
                         'The host/IP address of the system to use as the SUT')
+                stringParam('HEAP_OVERRIDES',
+                        '',
+                        'Setting to override the heap java args for a run.')
+                stringParam('JAVA_ARGS_ADDITIONS',
+                        '',
+                        'Custom java args to use for our friendly server. Will be added onto existing JAVA_ARGS for the job. Please be kind.')
                 booleanParam('SKIP_SERVER_INSTALL', false, 'If checked, will skip over the PE/OSS Server Install step.  Useful if you are doing development and already have a server SUT.')
                 booleanParam('SKIP_PROVISIONING', true, 'If checked, will skip over the Razor provisioning step.  Useful if you already have an SUT provisioned, e.g. via the VM Pooler.')
             }

--- a/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/compare-3.3-to-couch/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline.multipass_pipeline([
                  environments: ["production"],
                  hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
          ],
-         server_java_args: "-Xms12g -Xmx12g",
+         server_heap_settings: "-Xms12g -Xmx12g",
          puppet_settings: [
                  master: [
                     "static_catalogs": "false"
@@ -74,7 +74,7 @@ pipeline.multipass_pipeline([
                  environments: ["production"],
                  hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
          ],
-         server_java_args: "-Xms12g -Xmx12g",
+         server_heap_settings: "-Xms12g -Xmx12g",
          background_scripts: [
                  "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
          ],

--- a/jenkins-integration/jenkins-jobs/scenarios/couch-environment-timeout/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/couch-environment-timeout/Jenkinsfile
@@ -15,7 +15,7 @@ def environment_timeout_0_base_config() {
              environments: ["production"],
              hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
      ],
-     server_java_args: "-Xms12g -Xmx12g",
+     server_heap_settings: "-Xms12g -Xmx12g",
      puppet_settings: [
              main: [
                      "environment_timeout": "0"
@@ -45,7 +45,7 @@ def environment_timeout_unlimited_base_config() {
              environments: ["production"],
              hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
      ],
-     server_java_args: "-Xms12g -Xmx12g",
+     server_heap_settings: "-Xms12g -Xmx12g",
      puppet_settings: [
              main: [
                      "environment_timeout": "unlimited"

--- a/jenkins-integration/jenkins-jobs/scenarios/couch-static-catalogs/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/couch-static-catalogs/Jenkinsfile
@@ -15,7 +15,7 @@ def no_static_catalogs_base_config() {
              environments: ["production"],
              hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
      ],
-     server_java_args: "-Xms12g -Xmx12g",
+     server_heap_settings: "-Xms12g -Xmx12g",
      puppet_settings: [
              master: [
                      "static_catalogs": "false"
@@ -42,7 +42,7 @@ def static_catalogs_base_config() {
              environments: ["production"],
              hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
      ],
-     server_java_args: "-Xms12g -Xmx12g",
+     server_heap_settings: "-Xms12g -Xmx12g",
      background_scripts: [
              "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
      ],

--- a/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/multi-pass-scenario/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline.multipass_pipeline([
                  basedir: "/etc/puppetlabs/code-staging/environments",
                  environments: ["production"],
                  hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"],
-         server_java_args: "-Xms12g -Xmx12g",
+         server_heap_settings: "-Xms12g -Xmx12g",
          background_scripts: [
                  "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
          ],
@@ -34,7 +34,7 @@ pipeline.multipass_pipeline([
                  basedir: "/etc/puppetlabs/code-staging/environments",
                  environments: ["production"],
                  hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"],
-         server_java_args: "-Xms12g -Xmx12g",
+         server_heap_settings: "-Xms12g -Xmx12g",
          background_scripts: [
                  "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
          ],

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline.multipass_pipeline([
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
-                server_java_args: "-Xms4g -Xmx4g",
+                server_heap_settings: "-Xms4g -Xmx4g",
         ],
         [
                 job_name: 'oss-latest-9k-8g-heap',
@@ -54,7 +54,7 @@ pipeline.multipass_pipeline([
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
-                server_java_args: "-Xms8g -Xmx8g",
+                server_heap_settings: "-Xms8g -Xmx8g",
         ],
         [
                 job_name: 'oss-latest-9k-12g-heap',
@@ -80,6 +80,6 @@ pipeline.multipass_pipeline([
                         "/var/log/puppetlabs/puppetserver/metrics.json"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
-                server_java_args: "-Xms12g -Xmx12g",
+                server_heap_settings: "-Xms12g -Xmx12g",
         ],
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetdb-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetdb-latest/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline.single_pipeline([
                 environments: ["production"],
                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
         ],
-        server_java_args: "-Xms2g -Xmx2g",
+        server_heap_settings: "-Xms2g -Xmx2g",
         background_scripts: [
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh",
                 "./jenkins-jobs/common/scripts/background/curl-puppetdb-metrics-loop.sh"

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline.single_pipeline([
                 environments: ["production"],
                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
         ],
-        server_java_args: "-Xms12g -Xmx12g",
+        server_heap_settings: "-Xms12g -Xmx12g",
         background_scripts: [
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],

--- a/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/single-pass-scenario/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline.single_pipeline([
                 environments: ["production"],
                 hiera_config_source_file: "/etc/puppetlabs/code-staging/environments/production/root_files/hiera.yaml"
         ],
-        server_java_args: "-Xms12g -Xmx12g",
+        server_heap_settings: "-Xms12g -Xmx12g",
         background_scripts: [
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],


### PR DESCRIPTION
Previously changing gatling job parameters such as heap settings or
which garbage collector to use was impossible. This commit adds two new
parameters to all of the gatling jenkins jobs that will allow us to
override heap settings and to supply additional java args to jobs such
as garbage collector.