### PR TITLE
(maint) Disable automatic oss-latest test runs for now

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/JobDSL.groovy
@@ -5,7 +5,8 @@ if (serverConfig["environment"] == "production") {
         triggers {
             // This should run the job at a semi-random time between 9:00 and 10:59PM,
             //  on Mondays.
-            cron('H H(21-22) * * 1')
+            // Disabling via comment for now as this is getting in the way of other tests.
+            //cron('H H(21-22) * * 1')
         }
     }
 


### PR DESCRIPTION
Right now automated runs are clobbering existing instances that may be
running tests, which is frustrating. Until we have a solid footing on
tunings to use against latest 9k, we should be disabling the job to
avoid sadness.