### PR TITLE
(maint) Move max requests per instance to string

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline.single_pipeline([
           [
             file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
             path: "jruby-puppet.max-requests-per-instance",
-            value: 100000
+            value: "100000"
           ]
         ]
 ])


### PR DESCRIPTION
Seems like hocon expects the value to be a string and not an int. I'm
not sure if this is a limitation in hocon or in beaker's hocon helper.