### PR TITLE
(SERVER-2089) Add scenarios and simulation configs for 12/24hr jobs

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
@@ -1,0 +1,29 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'oss-latest-1.7-12hr',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-12-hours.json',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        agent_version: [
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ]
+])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
@@ -1,0 +1,37 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'oss-latest-9k-12hr',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-12-hours.json',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        agent_version: [
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ],
+        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+        hocon_settings: [
+          [
+            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+            path: "jruby-puppet.compile-mode",
+            value: "jit"
+          ]
+        ]
+])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
@@ -1,0 +1,29 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'oss-latest-1.7-24hr',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-24-hours.json',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        agent_version: [
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ]
+])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
@@ -1,0 +1,37 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'oss-latest-9k-24hr',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-24-hours.json',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        agent_version: [
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ],
+        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+        hocon_settings: [
+          [
+            file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+            path: "jruby-puppet.compile-mode",
+            value: "jit"
+          ]
+        ]
+])

--- a/simulation-runner/config/scenarios/foss5x-medium-1250-12-hours.json
+++ b/simulation-runner/config/scenarios/foss5x-medium-1250-12-hours.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo, 1250 agents, 12 hr",
+    "nodes": [
+        {
+            "node_config": "FOSS5xPerfMedium.json",
+            "num_instances": 1250,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 24,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}

--- a/simulation-runner/config/scenarios/foss5x-medium-1250-24-hours.json
+++ b/simulation-runner/config/scenarios/foss5x-medium-1250-24-hours.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo, 1250 agents, 24 hours",
+    "nodes": [
+        {
+            "node_config": "FOSS5xPerfMedium.json",
+            "num_instances": 1250,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 48,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}


### PR DESCRIPTION
Previously we only had 2 hour and 1 week runs, but having something in
the middle like 12 hr and 24 hr will be useful for chasing down some
timeouts and GC tuning. This commit adds 12 and 24 hour scenario config
files and jenkins jobs for both jruby 9k and 1.7.