### PR TITLE
(SERVER-2063) Collect the simulation.log.gz from runs

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -367,6 +367,12 @@ def step900_collect_driver_artifacts() {
     // NOTE: this DSL step requires the puppet-gatling-jenkins plugin.  It also
     // depends on some data that gets created via 025_collect_facter_data.sh
     puppetGatlingArchive()
+
+    // Always archive the simulation.log.gz from the run.
+    archive "simulation-runner/results/**/*.log.gz"
+    dir('simulation-runner/results') {
+        deleteDir()
+    }
 }
 
 SCRIPT_DIR = "./jenkins-integration/jenkins-jobs/common/scripts/job-steps"

--- a/jenkins-integration/jenkins-jobs/scenarios/latest-test-changes/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/latest-test-changes/Jenkinsfile
@@ -1,0 +1,26 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'oss-latest',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1-node-1-iteration-test.json',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ]
+])

--- a/simulation-runner/config/scenarios/foss5x-medium-1-node-1-iteration-test.json
+++ b/simulation-runner/config/scenarios/foss5x-medium-1-node-1-iteration-test.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'medium' role from perf control repo, 1 agent, 1 iteration for testing changes",
+    "nodes": [
+        {
+            "node_config": "FOSS5xPerfMedium.json",
+            "num_instances": 1,
+            "ramp_up_duration_seconds": 10,
+            "num_repetitions": 1,
+            "sleep_duration_seconds": 10
+        }
+    ]
+}


### PR DESCRIPTION
This commit begins archiving the simulation.log.gz from each run. In
order to do this effectively we also clean up the simulation logs from
the workspace after collection.