### PR TITLE
(maint) Set a heap size of 2gb unless specified

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-2.x/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-2.x/Jenkinsfile
@@ -25,5 +25,6 @@ pipeline.single_pipeline([
         ],
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
@@ -30,5 +30,6 @@ pipeline.single_pipeline([
                     path: "jruby-puppet.compile-mode",
                     value: "jit"
                   ]
-                ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty/Jenkinsfile
@@ -23,4 +23,5 @@ pipeline.single_pipeline([
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
         ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x/Jenkinsfile
@@ -22,5 +22,6 @@ pipeline.single_pipeline([
         ],
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-1.7/Jenkinsfile
@@ -25,5 +25,6 @@ pipeline.single_pipeline([
         ],
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-9k/Jenkinsfile
@@ -33,5 +33,6 @@ pipeline.single_pipeline([
             path: "jruby-puppet.compile-mode",
             value: "jit"
           ]
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
@@ -25,5 +25,6 @@ pipeline.single_pipeline([
         ],
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
@@ -33,5 +33,6 @@ pipeline.single_pipeline([
             path: "jruby-puppet.compile-mode",
             value: "jit"
           ]
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
@@ -25,5 +25,6 @@ pipeline.single_pipeline([
         ],
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
@@ -33,5 +33,6 @@ pipeline.single_pipeline([
             path: "jruby-puppet.compile-mode",
             value: "jit"
           ]
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
@@ -26,7 +26,8 @@ pipeline.multipass_pipeline([
                 ],
                 archive_sut_files: [
                         "/var/log/puppetlabs/puppetserver/metrics.json"
-                ]
+                ],
+                server_heap_settings: "-Xms2g -Xmx2g",
         ],
         [
                 job_name: 'oss-latest-jruby-9k-for-comparison-vs-1.7',
@@ -58,5 +59,6 @@ pipeline.multipass_pipeline([
                             path: "jruby-puppet.compile-mode",
                             value: "jit"
                           ]
-                        ]
+                ],
+                server_heap_settings: "-Xms2g -Xmx2g",
         ]])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
@@ -31,7 +31,8 @@ pipeline.multipass_pipeline([
                             path: "jruby-puppet.compile-mode",
                             value: "jit"
                           ]
-                        ]
+                ],
+                server_heap_settings: "-Xms2g -Xmx2g",
         ],
         [
                 job_name: 'oss-latest-jruby-9k-1000-agents',
@@ -60,7 +61,8 @@ pipeline.multipass_pipeline([
                             path: "jruby-puppet.compile-mode",
                             value: "jit"
                           ]
-                        ]
+                ],
+                server_heap_settings: "-Xms2g -Xmx2g",
         ],
         [
                 job_name: 'oss-latest-jruby-9k-1250-agents',
@@ -89,5 +91,6 @@ pipeline.multipass_pipeline([
                             path: "jruby-puppet.compile-mode",
                             value: "jit"
                           ]
-                        ]
+                ],
+                server_heap_settings: "-Xms2g -Xmx2g",
         ]])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
@@ -38,5 +38,6 @@ pipeline.single_pipeline([
             path: "jruby-puppet.max-requests-per-instance",
             value: "100000"
           ]
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
@@ -33,5 +33,6 @@ pipeline.single_pipeline([
                     path: "jruby-puppet.compile-mode",
                     value: "jit"
                   ]
-                ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
@@ -22,5 +22,6 @@ pipeline.single_pipeline([
         ],
         archive_sut_files: [
                 "/var/log/puppetlabs/puppetserver/metrics.json"
-        ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
 ])


### PR DESCRIPTION
We've run into a couple of cases where the heap size was not specified
and the jvm defaulted to 1/4 of system memory. To avoid that, this
commit makes explicit a default of 2gb heap for all tests that don't
specify it. HEAP_OVERRIDES will still win, so this can be altered at the
job build screen.