### PR TITLE
(SERVER-2091) Always be gc logging

### DIFF
--- a/jenkins-integration/beaker/install/shared/copy_sut_archive_files.rb
+++ b/jenkins-integration/beaker/install/shared/copy_sut_archive_files.rb
@@ -10,7 +10,11 @@ step "Copy archive files from SUT" do
   FileUtils.mkdir_p(archive_dir)
 
   archive_files.each do |s|
-    Beaker::Log.notify("Copying archive file '#{s}'")
-    scp_from(master, s, archive_dir)
+    if on(master, "test -f '#{s}'", :acceptable_exit_codes => [0,1]).exit_code == 0
+      Beaker::Log.notify("Copying archive file '#{s}'")
+      scp_from(master, s, archive_dir)
+    else
+      Beaker::Log.warn("Not copying archive file '#{s}' as it does not seem to exist")
+    end
   end
 end

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -356,9 +356,18 @@ def step110_collect_sut_artifacts(script_dir, job_name, archive_sut_files) {
         for (f in archive_sut_files) {
             String filename = get_filename(f);
             String filePath = "puppet-gatling/${job_name}/sut_archive_files/${filename}"
-            echo "Archiving SUT file: '${filePath}'"
-            sh "if [ ! -f './${filePath}' ] ; then echo 'ERROR! FILE DOES NOT EXIST!'; false ; fi"
-            archive "${filePath}"
+            if (fileExists(filePath)) {
+                echo "Archiving SUT file: '${filePath}'"
+                sh "if [ ! -f './${filePath}' ] ; then echo 'ERROR! FILE DOES NOT EXIST!'; false; fi"
+                archive "${filePath}"
+            } else {
+                echo "Not archiving SUT file: '${filePath}' as it does not exist!"
+            }
+
+        }
+        // Clean up the sut_archive_files so they don't appear in the next run by accident
+        dir("puppet-gatling/${job_name}/sut_archive_files") {
+            deleteDir()
         }
     }
 }

--- a/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
+++ b/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
@@ -104,8 +104,8 @@ scenarios_dir.eachFileRecurse (FileType.FILES) { file ->
                         '',
                         'Setting to override the heap java args for a run.')
                 stringParam('JAVA_ARGS_ADDITIONS',
-                        '',
-                        'Custom java args to use for our friendly server. Will be added onto existing JAVA_ARGS for the job. Please be kind.')
+                        '-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:/var/log/puppetlabs/puppetserver/gc.log',
+                        'Custom java args to use for our friendly server. Will be added onto existing JAVA_ARGS for the job. Please be kind. Defaults to some good gc logging.')
                 booleanParam('SKIP_SERVER_INSTALL', false, 'If checked, will skip over the PE/OSS Server Install step.  Useful if you are doing development and already have a server SUT.')
                 booleanParam('SKIP_PROVISIONING', true, 'If checked, will skip over the Razor provisioning step.  Useful if you already have an SUT provisioned, e.g. via the VM Pooler.')
             }

--- a/jenkins-integration/jenkins-jobs/scenarios/latest-test-changes/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/latest-test-changes/Jenkinsfile
@@ -4,7 +4,7 @@ node {
 }
 
 pipeline.single_pipeline([
-        job_name: 'oss-latest',
+        job_name: 'latest-test-changes',
         gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1-node-1-iteration-test.json',
         server_version: [
                 type: "oss",

--- a/jenkins-integration/jenkins-jobs/scenarios/latest-test-changes/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/latest-test-changes/Jenkinsfile
@@ -21,6 +21,7 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ]
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-2.x/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-2.x/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
@@ -21,7 +21,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty/Jenkinsfile
@@ -21,7 +21,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x/Jenkinsfile
@@ -21,7 +21,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-1.7/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-9k/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
@@ -25,7 +25,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 server_heap_settings: "-Xms2g -Xmx2g",
         ],
@@ -50,7 +51,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
@@ -22,7 +22,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 hocon_settings: [
@@ -52,7 +53,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 hocon_settings: [
@@ -82,7 +84,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby1.7-various-heaps/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby1.7-various-heaps/Jenkinsfile
@@ -25,7 +25,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 server_heap_settings: "-Xms4g -Xmx4g",
         ],
@@ -50,7 +51,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 server_heap_settings: "-Xms8g -Xmx8g",
         ],
@@ -75,7 +77,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 server_heap_settings: "-Xms12g -Xmx12g",
         ],

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
@@ -25,7 +25,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 server_heap_settings: "-Xms4g -Xmx4g",
@@ -58,7 +59,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 server_heap_settings: "-Xms8g -Xmx8g",
@@ -91,7 +93,8 @@ pipeline.multipass_pipeline([
                         "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
                 ],
                 archive_sut_files: [
-                        "/var/log/puppetlabs/puppetserver/metrics.json"
+                        "/var/log/puppetlabs/puppetserver/metrics.json",
+                        "/var/log/puppetlabs/puppetserver/gc.log"
                 ],
                 jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
                 server_heap_settings: "-Xms12g -Xmx12g",

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
@@ -24,7 +24,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
@@ -21,7 +21,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         server_heap_settings: "-Xms2g -Xmx2g",
 ])

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
-        ]
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
+        ],
 ])


### PR DESCRIPTION
So far it has been advantageous to collect GC logs from our gatling runs
and it has a negligible perf impact, so this commit updates all of the
jobs to archive the gc log if it exists and also adds gc logging java
args as the default java args for all jobs. Archive collection is now
configured to skip files that don't exist instead of failing.