### PR TITLE
(SERVER-2108) Add dynamic gatling job

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -127,6 +127,28 @@ def get_agent_version(agent_version) {
   }
 }
 
+String generate_gatling_scenario(hours, size, count) {
+    repetitions = hours.toInteger() * 2
+    filename = "foss5x-${size}-${count}-${hours}-hours-dynamic.json"
+    node_configs = [
+            EMPTY: "FOSS5xEmptyRepo.json",
+            MEDIUM: "FOSS5xPerfMedium.json",
+    ]
+    scenario_hash = [
+            run_description: "${size} role from perf control repo, ${count} agents, ${hours} hours",
+            nodes: [[
+                            node_config: node_configs[size],
+                            num_instances: count.toInteger(),
+                            ramp_up_duration_seconds: 1800,
+                            num_repetitions: repetitions,
+                            sleep_duration_seconds: 1800,
+                    ]]
+    ]
+    scenario_json = JsonOutput.toJson(scenario_hash)
+    writeFile(file: filename, text: scenario_json)
+    return filename
+}
+
 def step000_provision_sut(SKIP_PROVISIONING, script_dir) {
     echo "SKIP PROVISIONING?: ${SKIP_PROVISIONING} (${SKIP_PROVISIONING.class})"
     if (!SKIP_PROVISIONING) {
@@ -385,6 +407,17 @@ def single_pipeline(job) {
         SKIP_PROVISIONING = (SKIP_PROVISIONING == "true")
 
         job_name = job['job_name']
+
+        if (job_name == "puppetserver-infinite") {
+
+            dir('simulation-runner/config/scenarios') {
+                job["gatling_simulation_config"] = generate_gatling_scenario(NUMBER_OF_HOURS, CATALOG_SIZE, NODE_COUNT)
+            }
+
+            if (CATALOG_SIZE == "EMPTY") {
+                job["code_deploy"]["environments"] = ['20171208_empty_repo']
+            }
+        }
 
         stage '000-provision-sut'
         step000_provision_sut(SKIP_PROVISIONING, SCRIPT_DIR)

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -128,6 +128,10 @@ def get_agent_version(agent_version) {
 }
 
 String generate_gatling_scenario(hours, size, count) {
+    // Note: the caller of this method needs to make sure it is called in the
+    // correct directory (simulation-runner/config/scenarios), otherwise the
+    // referenced node_config will not be where the rest of the automation
+    // expects it to be (which is relative to the scenario config).
     repetitions = hours.toInteger() * 2
     filename = "foss5x-${size}-${count}-${hours}-hours-dynamic.json"
     node_configs = [

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
@@ -1,0 +1,39 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.single_pipeline([
+        job_name: 'puppetserver-infinite',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        agent_version: [
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                // Environments is overridden for the empty catalog, as it needs a special environment with no modules in the Puppetfile
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        archive_sut_files: [
+                "/var/log/puppetlabs/puppetserver/metrics.json"
+        ],
+        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+        hocon_settings: [
+                  [
+                    file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                    path: "jruby-puppet.compile-mode",
+                    value: "jit"
+                  ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
+])

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
@@ -1,6 +1,5 @@
 job.parameters {
     stringParam('NUMBER_OF_HOURS', '2', 'Length of time to run the gatling simulation.')
     choiceParam('CATALOG_SIZE', ['MEDIUM', 'EMPTY'], 'Catalog to use in simulation.')
-    // NODE_COUNT is offered as a list because gatling will not handle values that don't divide 1800 evenly (multiples of 300 also seem fine, which is why 1200 and 1500 are also there).
-    choiceParam('NODE_COUNT', ['600', '100', '200', '300', '900', '1200', '1500', '1800'], 'Number of nodes to include in simulation.')
+    choiceParam('NODE_COUNT', ['600', '100', '200', '300', '900', '1200', '1500', '1800'], 'Number of nodes (these were selected as they produce an even node distribution) to include in simulation.')
 }

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
@@ -1,0 +1,5 @@
+job.parameters {
+    stringParam('NUMBER_OF_HOURS', '2', 'Length of time to run the gatling simulation.')
+    choiceParam('CATALOG_SIZE', ['MEDIUM', 'EMPTY'], 'Catalog to use in simulation.')
+    choiceParam('NODE_COUNT', ['600', '100', '200', '300', '900', '1200', '1500', '1800'], 'Number of nodes to include in simulation.')
+}

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
@@ -1,5 +1,6 @@
 job.parameters {
     stringParam('NUMBER_OF_HOURS', '2', 'Length of time to run the gatling simulation.')
     choiceParam('CATALOG_SIZE', ['MEDIUM', 'EMPTY'], 'Catalog to use in simulation.')
+    // NODE_COUNT is offered as a list because gatling will not handle values that don't divide 1800 evenly (multiples of 300 also seem fine, which is why 1200 and 1500 are also there).
     choiceParam('NODE_COUNT', ['600', '100', '200', '300', '900', '1200', '1500', '1800'], 'Number of nodes to include in simulation.')
 }


### PR DESCRIPTION
Currently in order to test new combinations of node count, duration, or
catalog size a new job and scenario must be constructed. This is slow
and tedious, so this commit adds a new jenkins job that constructs a
custom gatling scenario on the fly and uses it to kick off a job against
a node config for the desired catalog size.