### PR TITLE
(SERVER-2108) Fix scenario file path

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -424,7 +424,8 @@ def single_pipeline(job) {
         if (job_name == "puppetserver-infinite") {
 
             dir('simulation-runner/config/scenarios') {
-                job["gatling_simulation_config"] = generate_gatling_scenario(NUMBER_OF_HOURS, CATALOG_SIZE, NODE_COUNT)
+                scenario_name = generate_gatling_scenario(NUMBER_OF_HOURS, CATALOG_SIZE, NODE_COUNT)
+                job["gatling_simulation_config"] = "../simulation-runner/config/scenarios/${scenario_name}"
             }
 
             if (CATALOG_SIZE == "EMPTY") {


### PR DESCRIPTION
Previously the custom scenario file was set to just the filename, and
not the full path to the scenario file, when being generated. This
unfortunately meant that none of the functions could find the file
later. This commit prepends the path to the filename to ensure it can be
found.