### PR TITLE
(SERVER-2110) Update num_instances to avoid gaps and hotspots

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-2.x/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-2.x/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-2.x',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1200-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "2\\.\\d+\\.\\d+.SNAPSHOT"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty-jruby9k/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-5.x-puppetserver-empty-jruby9k',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-empty-500-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-empty-600-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "5\\.\\d+\\.\\d+.SNAPSHOT"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x-empty/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-5.x-puppetserver-empty',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-empty-500-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-empty-600-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "5\\.\\d+\\.\\d+.SNAPSHOT"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-5.x/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-5.x',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "5\\.\\d+\\.\\d+.SNAPSHOT"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-1.7/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-1-week',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-1-week.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-1-week.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-1-week-9k/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-1-week',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-1-week.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-1-week.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-1.7/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-1.7-12hr',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-12-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-12-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-12hr-9k/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-9k-12hr',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-12-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-12-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-1.7/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-1.7-24hr',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-24-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-24-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-24hr-9k/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-9k-24hr',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-24-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-24-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-1.7-vs-9k/Jenkinsfile
@@ -6,7 +6,7 @@ node {
 pipeline.multipass_pipeline([
         [
                 job_name: 'oss-latest-jruby-1.7-for-comparison-vs-9k',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"
@@ -32,7 +32,7 @@ pipeline.multipass_pipeline([
         ],
         [
                 job_name: 'oss-latest-jruby-9k-for-comparison-vs-1.7',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby-9k-varying-agents/Jenkinsfile
@@ -6,7 +6,7 @@ node {
 pipeline.multipass_pipeline([
         [
                 job_name: 'oss-latest-jruby-9k-500-agents',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-500-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-600-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"
@@ -37,7 +37,7 @@ pipeline.multipass_pipeline([
         ],
         [
                 job_name: 'oss-latest-jruby-9k-1000-agents',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1000-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-900-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"
@@ -68,7 +68,7 @@ pipeline.multipass_pipeline([
         ],
         [
                 job_name: 'oss-latest-jruby-9k-1250-agents',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss25x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby1.7-various-heaps/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby1.7-various-heaps/Jenkinsfile
@@ -6,7 +6,7 @@ node {
 pipeline.multipass_pipeline([
         [
                 job_name: 'oss-latest-1.7-4g-heap',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"
@@ -32,7 +32,7 @@ pipeline.multipass_pipeline([
         ],
         [
                 job_name: 'oss-latest-1.7-8g-heap',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"
@@ -58,7 +58,7 @@ pipeline.multipass_pipeline([
         ],
         [
                 job_name: 'oss-latest-1.7-12g-heap',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-max-request-per-instance/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-jruby9k-max-requests-per-instance',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k-various-heaps/Jenkinsfile
@@ -6,7 +6,7 @@ node {
 pipeline.multipass_pipeline([
         [
                 job_name: 'oss-latest-9k-4g-heap',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"
@@ -40,7 +40,7 @@ pipeline.multipass_pipeline([
         ],
         [
                 job_name: 'oss-latest-9k-8g-heap',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"
@@ -74,7 +74,7 @@ pipeline.multipass_pipeline([
         ],
         [
                 job_name: 'oss-latest-9k-12g-heap',
-                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+                gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
                 server_version: [
                         type: "oss",
                         version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest-jruby9k/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest-jruby9k',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/oss-puppetserver-latest/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'oss-latest',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetdb-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetdb-latest/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'pe-latest',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-1200-2-hours.json',
         server_version: [
                 type: "pe",
                 pe_version: "2017.2",

--- a/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/pe-puppetserver-latest/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline.single_pipeline([
         job_name: 'pe-latest',
         // TODO: take a new recording for flanders, just using the existing couch
         // recording right now to get things up and running.
-        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/pe-couch-medium-1200-2-hours.json',
         server_version: [
                 type: "pe",
                 pe_version: "2017.1",

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
@@ -5,7 +5,7 @@ node {
 
 pipeline.single_pipeline([
         job_name: 'puppetserver-infinite',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1250-2-hours.json',
+        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
         server_version: [
                 type: "oss",
                 version: "latest"

--- a/simulation-runner/config/scenarios/README.md
+++ b/simulation-runner/config/scenarios/README.md
@@ -16,7 +16,7 @@ Here is an example "scenario" configuration file:
     "nodes": [
         {
             "node_config": "PECouchPerfMedium.json",
-            "num_instances": 1250,
+            "num_instances": 1200,
             "ramp_up_duration_seconds": 1800,
             "num_repetitions": 4,
             "sleep_duration_seconds": 1800
@@ -34,8 +34,11 @@ Here is a breakdown of the fields:
   * `node_config`: this is the name of the node config json file in [the `../nodes` directory](../nodes).  This ends up
    providing us with the information about how to create and classify a node group for this node, as well as indicating
    which Gatling recording we should be playing back.
-  * `num_instance`: this tells gatling how many concurrent instances of this particular node to simulate.  This is basically
+  * `num_instances`: this tells gatling how many concurrent instances of this particular node to simulate.  This is basically
    equivalent to specifying the number of agents that will be running against our Puppet Server instance during the test.
+   NOTE: Due to issues with how gatling distributes agents, choosing a value for `num_instances` that does not divide
+   `ramp_up_duration_seconds` will result in gaps between intervals or extra agents at the end of intervals. This can be
+   avoided by choosing, for example, 100, 200, 300, 600, 900, 1200, 1500, 1800 for an 1800 second `ramp_up_duration_seconds`.
   * `ramp_up_duration_seconds`: this is akin to puppet's `splay` setting.  Gatling will spread out the initial launching
    of the simulated agents, evenly, over this amount of time.  We typically set this to 30 minutes (1800 seconds), meaning
    that the load will be distributed roughly evenly over a 30-minute interval, because this mimics the puppet agent's

--- a/simulation-runner/config/scenarios/foss25x-medium-1200-2-hours.json
+++ b/simulation-runner/config/scenarios/foss25x-medium-1200-2-hours.json
@@ -1,9 +1,9 @@
 {
-    "run_description": "'medium' role from perf control repo, 1250 agents, 2 hours",
+    "run_description": "'medium' role from perf control repo, 1200 agents, 2 hours",
     "nodes": [
         {
             "node_config": "FOSS25xPerfMedium.json",
-            "num_instances": 1250,
+            "num_instances": 1200,
             "ramp_up_duration_seconds": 1800,
             "num_repetitions": 4,
             "sleep_duration_seconds": 1800

--- a/simulation-runner/config/scenarios/foss25x-medium-600-2-hours.json
+++ b/simulation-runner/config/scenarios/foss25x-medium-600-2-hours.json
@@ -1,9 +1,9 @@
 {
-    "run_description": "'medium' role from perf control repo, 1000 agents, 2 hours",
+    "run_description": "'medium' role from perf control repo, 600 agents, 2 hours",
     "nodes": [
         {
             "node_config": "FOSS25xPerfMedium.json",
-            "num_instances": 1000,
+            "num_instances": 600,
             "ramp_up_duration_seconds": 1800,
             "num_repetitions": 4,
             "sleep_duration_seconds": 1800

--- a/simulation-runner/config/scenarios/foss25x-medium-900-2-hours.json
+++ b/simulation-runner/config/scenarios/foss25x-medium-900-2-hours.json
@@ -1,9 +1,9 @@
 {
-    "run_description": "'medium' role from perf control repo, 500 agents, 2 hours",
+    "run_description": "'medium' role from perf control repo, 900 agents, 2 hours",
     "nodes": [
         {
             "node_config": "FOSS25xPerfMedium.json",
-            "num_instances": 500,
+            "num_instances": 900,
             "ramp_up_duration_seconds": 1800,
             "num_repetitions": 4,
             "sleep_duration_seconds": 1800

--- a/simulation-runner/config/scenarios/foss5x-empty-600-2-hours.json
+++ b/simulation-runner/config/scenarios/foss5x-empty-600-2-hours.json
@@ -1,9 +1,9 @@
 {
-    "run_description": "'empty' role from perf control repo, 500 agents, 2 hours",
+    "run_description": "'empty' role from perf control repo, 600 agents, 2 hours",
     "nodes": [
         {
             "node_config": "FOSS5xEmptyRepo.json",
-            "num_instances": 500,
+            "num_instances": 600,
             "ramp_up_duration_seconds": 1800,
             "num_repetitions": 4,
             "sleep_duration_seconds": 1800

--- a/simulation-runner/config/scenarios/foss5x-medium-1200-1-week.json
+++ b/simulation-runner/config/scenarios/foss5x-medium-1200-1-week.json
@@ -1,11 +1,11 @@
 {
-    "run_description": "'medium' role from perf control repo, 1250 agents, 12 hr",
+    "run_description": "'medium' role from perf control repo, 1200 agents, 1 week",
     "nodes": [
         {
             "node_config": "FOSS5xPerfMedium.json",
-            "num_instances": 1250,
+            "num_instances": 1200,
             "ramp_up_duration_seconds": 1800,
-            "num_repetitions": 24,
+            "num_repetitions": 336,
             "sleep_duration_seconds": 1800
         }
     ]

--- a/simulation-runner/config/scenarios/foss5x-medium-1200-12-hours.json
+++ b/simulation-runner/config/scenarios/foss5x-medium-1200-12-hours.json
@@ -1,11 +1,11 @@
 {
-    "run_description": "'medium' role from perf control repo, 1250 agents, 2 hours",
+    "run_description": "'medium' role from perf control repo, 1200 agents, 12 hr",
     "nodes": [
         {
             "node_config": "FOSS5xPerfMedium.json",
-            "num_instances": 1250,
+            "num_instances": 1200,
             "ramp_up_duration_seconds": 1800,
-            "num_repetitions": 4,
+            "num_repetitions": 24,
             "sleep_duration_seconds": 1800
         }
     ]

--- a/simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json
+++ b/simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json
@@ -1,11 +1,11 @@
 {
-    "run_description": "'medium' role from perf control repo, 1250 agents, 1 week",
+    "run_description": "'medium' role from perf control repo, 1200 agents, 2 hours",
     "nodes": [
         {
             "node_config": "FOSS5xPerfMedium.json",
-            "num_instances": 1250,
+            "num_instances": 1200,
             "ramp_up_duration_seconds": 1800,
-            "num_repetitions": 336,
+            "num_repetitions": 4,
             "sleep_duration_seconds": 1800
         }
     ]

--- a/simulation-runner/config/scenarios/foss5x-medium-1200-24-hours.json
+++ b/simulation-runner/config/scenarios/foss5x-medium-1200-24-hours.json
@@ -1,9 +1,9 @@
 {
-    "run_description": "'medium' role from perf control repo, 1250 agents, 24 hours",
+    "run_description": "'medium' role from perf control repo, 1200 agents, 24 hours",
     "nodes": [
         {
             "node_config": "FOSS5xPerfMedium.json",
-            "num_instances": 1250,
+            "num_instances": 1200,
             "ramp_up_duration_seconds": 1800,
             "num_repetitions": 48,
             "sleep_duration_seconds": 1800


### PR DESCRIPTION
Gatling seems to have trouble evenly distributing certain number of
agent counts, which causes gaps and hotspots. In order to avoid this,
this commit updates the scenarios to use a specific range of
num_instances (600, 900, 1200). Readme is also updated and files renamed
to reflect the changes.