### PR TITLE
(SERVER-2091) Collect gc logs from configurable job

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
@@ -25,7 +25,8 @@ pipeline.single_pipeline([
                 "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
         ],
         archive_sut_files: [
-                "/var/log/puppetlabs/puppetserver/metrics.json"
+                "/var/log/puppetlabs/puppetserver/metrics.json",
+                "/var/log/puppetlabs/puppetserver/gc.log"
         ],
         jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [


### PR DESCRIPTION
As the gc work was in flight at the same time as the configurable job,
the new job did not get the gc logging added to the Jenkinsfile. This
commit add it so the log will be collected.