### PR TITLE
(SERVER-2108) Expose jruby version to puppetserver-infinite job

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -321,9 +321,21 @@ def step080_customize_java_args(script_dir, server_heap_settings, server_era) {
 }
 
 def step081_customize_jruby_jar(script_dir, jruby_jar, server_era) {
-    // Setting the jruby jar to an empty string will effectively cause the
-    // beaker script to tell puppetserver to use the default jar path
-    def jar_string = jruby_jar ?: ""
+    def jar_string = ""
+
+    if ("${JRUBY_VERSION}" == "") {
+        // Setting the jruby jar to an empty string will effectively cause the
+        // beaker script to tell puppetserver to use the default jar path
+        jar_string = jruby_jar ?: ""
+    } else {
+        // This branch indicates there is a JRUBY_VERSION parameter on the jenkins job,
+        // so we use that instead.
+        if ("${JRUBY_VERSION}" == "1.7") {
+            jar_string = "/opt/puppetlabs/server/apps/puppetserver/jruby-1_7.jar"
+        } else if ("${JRUBY_VERSION}" == "9k") {
+            jar_string = "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
+        }
+    }
 
     withEnv(["PUPPET_SERVER_SERVICE_NAME=${server_era["service_name"]}",
              "PUPPET_GATLING_JRUBY_JAR=${jar_string}"

--- a/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
+++ b/jenkins-integration/jenkins-jobs/job_bootstrap.groovy
@@ -104,8 +104,8 @@ scenarios_dir.eachFileRecurse (FileType.FILES) { file ->
                         '',
                         'Setting to override the heap java args for a run.')
                 stringParam('JAVA_ARGS_ADDITIONS',
-                        '-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:/var/log/puppetlabs/puppetserver/gc.log',
-                        'Custom java args to use for our friendly server. Will be added onto existing JAVA_ARGS for the job. Please be kind. Defaults to some good gc logging.')
+                        '-XX:+PrintTenuringDistribution -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:/var/log/puppetlabs/puppetserver/gc.log',
+                        'Custom java args to use for our friendly server. Will be added onto existing JAVA_ARGS for the job. Please be kind. Defaults to some really good gc logging.')
                 booleanParam('SKIP_SERVER_INSTALL', false, 'If checked, will skip over the PE/OSS Server Install step.  Useful if you are doing development and already have a server SUT.')
                 booleanParam('SKIP_PROVISIONING', false, 'If checked, will skip over the Razor provisioning step.  Useful if you already have an SUT provisioned, e.g. via the VM Pooler.')
             }

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
@@ -30,7 +30,6 @@ pipeline.single_pipeline([
                 "/etc/sysconfig/puppetserver",
                 "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf"
         ],
-        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
         hocon_settings: [
                   [
                     file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
@@ -1,5 +1,6 @@
 job.parameters {
     stringParam('NUMBER_OF_HOURS', '2', 'Length of time to run the gatling simulation.')
+    choiceParam('JRUBY_VERSION', ['9k', '1.7'], 'Version of jruby to use in the simulation.')
     choiceParam('CATALOG_SIZE', ['MEDIUM', 'EMPTY'], 'Catalog to use in simulation.')
     choiceParam('NODE_COUNT', ['600', '100', '200', '300', '900', '1200', '1500', '1800'], 'Number of nodes (these were selected as they produce an even node distribution) to include in simulation.')
 }


### PR DESCRIPTION
When running tests it is desireable to be able to choose between 9k and
1.7, so this commit adds such functionality to the puppetserver-infinite
job.
PR also includes updating the default java args to include full timestamps and tenuring details.