### PR TITLE
(SERVER-2017) More server simulations please

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -557,4 +557,69 @@ def multipass_pipeline(jobs) {
     }
 }
 
+def spin_up_puppetserver(job) {
+    // This is just a way of setting up a system that's easy to try stuff out
+    // with, reusing much of what we've written for the gatling tests. It won't
+    // actually run gatling.
+    node {
+        checkout scm
+
+        SKIP_SERVER_INSTALL = (SKIP_SERVER_INSTALL == "true")
+        SKIP_PROVISIONING = (SKIP_PROVISIONING == "true")
+
+        job_name = job['job_name']
+
+        stage '000-provision-sut'
+        step000_provision_sut(SKIP_PROVISIONING, SCRIPT_DIR)
+
+        stage '010-setup-beaker'
+        step010_setup_beaker(SCRIPT_DIR, job["server_version"])
+
+        server_era = get_server_era(job["server_version"])
+        agent_version = get_agent_version(job["agent_version"])
+
+        stage '020-install-server'
+        step020_install_server(SKIP_SERVER_INSTALL, SCRIPT_DIR, server_era, agent_version)
+
+        stage '025-collect-facter-data'
+        step025_collect_facter_data(job_name,
+                job['gatling_simulation_config'],
+                SCRIPT_DIR,
+                server_era)
+
+        stage '040-install-puppet-code'
+        step040_install_puppet_code(SCRIPT_DIR, job["code_deploy"], server_era)
+
+        stage '045-install-hiera-config'
+        step045_install_hiera_config(SCRIPT_DIR, job["code_deploy"], server_era)
+
+        stage '050-file-sync'
+        step050_file_sync(SCRIPT_DIR, server_era)
+
+        stage '060-classify-nodes'
+        step060_classify_nodes(SCRIPT_DIR,
+                job["gatling_simulation_config"],
+                server_era)
+
+        stage '070-validate-classification'
+        step070_validate_classification()
+
+        stage '075-customize-puppet-settings'
+        step075_customize_puppet_settings(SCRIPT_DIR, job['puppet_settings'])
+
+        stage '080-customize-java-args'
+        step080_customize_java_args(SCRIPT_DIR, job["server_heap_settings"], server_era)
+
+        stage '081-customize-jruby-jar'
+        step081_customize_jruby_jar(SCRIPT_DIR, job["jruby_jar"], server_era)
+
+        stage '085-customize-hocon-settings'
+        step085_customize_hocon_settings(SCRIPT_DIR, job['hocon_settings'], server_era)
+
+        stage '090-launch-bg-scripts'
+        step090_launch_bg_scripts(SCRIPT_DIR, job['background_scripts'])
+    }
+}
+
+
 return this;

--- a/jenkins-integration/jenkins-jobs/common/scripts/job-steps/000_provision_sut.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/job-steps/000_provision_sut.sh
@@ -23,6 +23,15 @@ case $SUT_HOST in
   puppetserver-perf-sut57.delivery.puppetlabs.net)
     RAZOR_NODE="node57"
     ;;
+  perf-bl11.delivery.puppetlabs.net)
+    RAZOR_NODE="node3994"
+    ;;
+  perf-bl12.delivery.puppetlabs.net)
+    RAZOR_NODE="node3995"
+    ;;
+  perf-bl13.delivery.puppetlabs.net)
+    RAZOR_NODE="node3996"
+    ;;
   *)
     echo "Unrecognized SUT_HOST: '${SUT_HOST}'!!  Don't know how to request razor reprovisioning."
     exit 1

--- a/jenkins-integration/jenkins-jobs/scenarios/spin-up-puppetserver/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/spin-up-puppetserver/Jenkinsfile
@@ -1,0 +1,35 @@
+node {
+    checkout scm
+    pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
+}
+
+pipeline.spin_up_puppetserver([
+        job_name: 'spin-up-puppetserver',
+        server_version: [
+                type: "oss",
+                version: "latest"
+        ],
+        agent_version: [
+                version: "latest"
+        ],
+        code_deploy: [
+                type: "r10k",
+                control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",
+                basedir: "/etc/puppetlabs/code/environments",
+                // Environments is overridden for the empty catalog, as it needs a special environment with no modules in the Puppetfile
+                environments: ["production"],
+                hiera_config_source_file: "/etc/puppetlabs/code/environments/production/root_files/hiera.yaml"
+        ],
+        background_scripts: [
+                "./jenkins-jobs/common/scripts/background/curl-server-metrics-loop.sh"
+        ],
+        jruby_jar: "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar",
+        hocon_settings: [
+                  [
+                    file: "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+                    path: "jruby-puppet.compile-mode",
+                    value: "jit"
+                  ]
+        ],
+        server_heap_settings: "-Xms2g -Xmx2g",
+])

--- a/jenkins-integration/razor/ensure_razor_objects.sh
+++ b/jenkins-integration/razor/ensure_razor_objects.sh
@@ -8,6 +8,8 @@ razor delete-policy --name puppetserver-perf-driver
 razor delete-tag --name puppetserver-perf-driver
 razor delete-policy --name puppetserver-perf-sut
 razor delete-tag --name puppetserver-perf-sut
+razor delete-policy --name puppetserver-perf-sut-small
+razor delete-tag --name puppetserver-perf-sut-small
 razor delete-broker --name puppetserver-perf-sut
 
 set -e
@@ -15,6 +17,8 @@ set -e
 razor create-broker --json ./puppetserver-perf-sut-broker.json
 razor create-tag --json ./puppetserver-perf-sut-tag.json
 razor create-policy --json ./puppetserver-perf-sut-policy.json
+razor create-tag --json ./puppetserver-perf-sut-tag-small.json
+razor create-policy --json ./puppetserver-perf-sut-policy-small.json
 razor create-tag --json ./puppetserver-perf-driver-tag.json
 razor create-policy --json ./puppetserver-perf-driver-policy.json
 razor create-tag --json ./puppetserver-perf-driver-dev-tag.json

--- a/jenkins-integration/razor/puppetserver-perf-sut-small-policy.json
+++ b/jenkins-integration/razor/puppetserver-perf-sut-small-policy.json
@@ -1,0 +1,10 @@
+{
+ "name": "puppetserver-perf-sut-small",
+ "hostname": "perf-bl${id}.delivery.puppetlabs.net",
+ "root-password": "puppet",
+ "tags": "puppetserver-perf-sut-small",
+ "repo": "centos-7",
+ "task": "puppetserver-sut-centos/7",
+ "broker": "puppetserver-perf-sut",
+ "node_metadata": {"sut_size": "small"}
+}

--- a/jenkins-integration/razor/puppetserver-perf-sut-small-tag.json
+++ b/jenkins-integration/razor/puppetserver-perf-sut-small-tag.json
@@ -1,0 +1,4 @@
+{
+ "name": "puppetserver-perf-sut-small",
+ "rule": ["or", ["=", ["fact", "macaddress"], "00:25:90:d8:82:b6"], ["=", ["fact", "macaddress"], "00:25:90:d8:82:fe"], ["=", ["fact", "macaddress"], "00:25:90:d8:82:ca"]]
+}


### PR DESCRIPTION
Create a new kind of pipeline that can be used to spin up a puppetserver
instance for some hands-on testing. This is basically a gatling run
without gatling or cleanup (so any desired artifacts will have to be
archived manually).

Mainly just want to see if this works since the dev workflow is a big hassle.
Still want to create a tool to simulate agent load without gatling, but
not sure that kicking it off immediately from this job is the right way
to go.