### PR TITLE
(SERVER-2121) Pin puppetserver-infinite job to released packages

### DIFF
--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
@@ -8,10 +8,10 @@ pipeline.single_pipeline([
         gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
         server_version: [
                 type: "oss",
-                version: "latest"
+                version: "5.2.0"
         ],
         agent_version: [
-                version: "latest"
+                version: "5.4.0"
         ],
         code_deploy: [
                 type: "r10k",


### PR DESCRIPTION
Now that agent 5.4.0 and server 5.2.0 are out, this commit pins the
puppetserver-infinite job to those versions to eliminate undesired
changes in our tests.