### PR TITLE
(SERVER-2107) Remove some steps that don't work yet

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -603,12 +603,6 @@ def spin_up_puppetserver(job) {
         stage '020-install-server'
         step020_install_server(SKIP_SERVER_INSTALL, SCRIPT_DIR, server_era, agent_version)
 
-        stage '025-collect-facter-data'
-        step025_collect_facter_data(job_name,
-                job['gatling_simulation_config'],
-                SCRIPT_DIR,
-                server_era)
-
         stage '040-install-puppet-code'
         step040_install_puppet_code(SCRIPT_DIR, job["code_deploy"], server_era)
 
@@ -617,14 +611,6 @@ def spin_up_puppetserver(job) {
 
         stage '050-file-sync'
         step050_file_sync(SCRIPT_DIR, server_era)
-
-        stage '060-classify-nodes'
-        step060_classify_nodes(SCRIPT_DIR,
-                job["gatling_simulation_config"],
-                server_era)
-
-        stage '070-validate-classification'
-        step070_validate_classification()
 
         stage '075-customize-puppet-settings'
         step075_customize_puppet_settings(SCRIPT_DIR, job['puppet_settings'])


### PR DESCRIPTION
Removing the collection of facter data and node classification steps
because they are tightly coupled to the gatling simulation vars in a way
that's difficult to untangle, and I don't need them yet (if at all,
might just write my own steps for this).