### PR TITLE
(SERVER-2123) Create job to run gatling against puppet branch

### DIFF
--- a/jenkins-integration/beaker/install/shared/clone_and_rsync.rb
+++ b/jenkins-integration/beaker/install/shared/clone_and_rsync.rb
@@ -24,6 +24,8 @@ step "Cleanup the directory first"
 on(master, 'rm -rf puppet')
 
 step "Cloning desired puppet repo '#{ENV['PUPPET_REMOTE']}'"
+# Add github known_hosts entry otherwise host verification will fail
+on(master, "ssh-keyscan -H github.com >> ~/.ssh/known_hosts")
 clone_puppet_repo(ENV['PUPPET_REMOTE'])
 
 step "Checking out desired ref '#{ENV['PUPPET_REF']} from puppet repo"

--- a/jenkins-integration/beaker/install/shared/clone_and_rsync.rb
+++ b/jenkins-integration/beaker/install/shared/clone_and_rsync.rb
@@ -1,0 +1,33 @@
+def clone_puppet_repo(repo)
+  on(master, "git clone #{repo}")
+end
+
+def checkout_puppet_ref(ref)
+  on(master, "pushd puppet; git checkout #{ref}; popd")
+end
+
+def rsync_puppet
+  on(master, 'rsync -avg ~/puppet/lib/* /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/')
+end
+
+step "ensure git and rsync are installed" do
+  if !check_for_package(master, 'git')
+    install_package(master, 'git')
+  end
+
+  if !check_for_package(master, 'rsync')
+    install_package(master, 'rsync')
+  end
+end
+
+step "Cleanup the directory first"
+on(master, 'rm -rf puppet')
+
+step "Cloning desired puppet repo '#{ENV['PUPPET_REMOTE']}'"
+clone_puppet_repo(ENV['PUPPET_REMOTE'])
+
+step "Checking out desired ref '#{ENV['PUPPET_REF']} from puppet repo"
+checkout_puppet_ref(ENV['PUPPET_REF'])
+
+step "Rsyncing puppet into place on top of the packaged version"
+rsync_puppet()

--- a/jenkins-integration/jenkins-jobs/common/scripts/job-steps/021_clone_and_rsync.sh
+++ b/jenkins-integration/jenkins-jobs/common/scripts/job-steps/021_clone_and_rsync.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+pushd jenkins-integration
+source jenkins-jobs/common/scripts/job-steps/initialize_ruby_env.sh
+
+# This job does the following:
+# - clones a fork of puppet
+# - checks out a ref
+# - rsyncs the libdir ontop of the puppet-agent puppet libdir
+
+set -x
+set -e
+
+# Setup SSH agent for SSH access to the SUT
+eval $(ssh-agent -t 24h -s)
+ssh-add ${HOME}/.ssh/id_rsa
+
+# TODO: get rid of references to ops-deployment
+
+bundle exec beaker \
+        --config hosts.yaml \
+        --load-path lib \
+        --log-level debug \
+        --no-color \
+        --tests \
+beaker/install/shared/clone_and_rsync.rb
+
+# without this set +x, rvm will log 10 gigs of garbage
+set +x
+popd
+
+

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/Jenkinsfile
@@ -3,16 +3,8 @@ node {
     pipeline = load 'jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy'
 }
 
-pipeline.single_pipeline([
+pipeline.single_configurable_pipeline([
         job_name: 'puppetserver-infinite',
-        gatling_simulation_config: '../simulation-runner/config/scenarios/foss5x-medium-1200-2-hours.json',
-        server_version: [
-                type: "oss",
-                version: "5.2.0"
-        ],
-        agent_version: [
-                version: "5.4.0"
-        ],
         code_deploy: [
                 type: "r10k",
                 control_repo: "git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git",

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
@@ -1,5 +1,9 @@
 job.parameters {
     stringParam('NUMBER_OF_HOURS', '2', 'Length of time to run the gatling simulation.')
+    stringParam('AGENT_VERSION', '5.4.0', 'Version of puppet-agent to install for the simulation. (e.g. b203f0585865a53c6f3beb590250defc41192bf5 or 5.3.4)')
+    stringParam('SERVER_VERSION', '5.2.0', 'Version of puppetserver to install for the simulation (e.g. 5.2.1.master.SNAPSHOT.2018.02.15T0124).')
+    stringParam('PUPPET_REMOTE', 'git@github.com:puppetlabs/puppet', 'Puppet remote to use to drive the simulation (leave empty to use the default agent)')
+    stringParam('PUPPET_REF', 'refs/tags/5.4.0', 'Puppet ref/branch to checkout for the simulation (leave empty to use the default agent).')
     choiceParam('JRUBY_VERSION', ['9k', '1.7'], 'Version of jruby to use in the simulation.')
     choiceParam('CATALOG_SIZE', ['MEDIUM', 'EMPTY'], 'Catalog to use in simulation.')
     choiceParam('NODE_COUNT', ['600', '100', '200', '300', '900', '1200', '1500', '1800'], 'Number of nodes (these were selected as they produce an even node distribution) to include in simulation.')


### PR DESCRIPTION
In order to be able to better test how some changes to puppet affect
performance, this commit adds a job that can run gatling against a
puppet branch or ref. It clones and checks out the ref locally and
rsyncs it on top of the puppet-agent installation, which is gross, but
ultimately far simpler and faster than crafting a vanagon pipeline.