### PR TITLE
(maint) Add workaround for MODULES-6687

### DIFF
--- a/jenkins-integration/lib/puppet/gatling/config.rb
+++ b/jenkins-integration/lib/puppet/gatling/config.rb
@@ -202,7 +202,9 @@ def set_service_environment_variable(host, filepath, variable_name, value)
   tmp_module_dir = master.tmpdir('configure_inifile')
 
   step 'Configure inifile module' do
-    on(master, puppet('module', 'install', 'puppetlabs-inifile', '--codedir', tmp_module_dir))
+    # Workaround for MODULES-6687 where the inifile won't manage existing configfile lines
+    # on puppet > 5.4.0 and inifile >= 1.6.0. 1.5.0 is the last inifile release before the refreshonly param went in.
+    on(master, puppet('module', 'install', 'puppetlabs-inifile', '--codedir', tmp_module_dir, '--version', '1.5.0'))
   end
 
   teardown do


### PR DESCRIPTION
Until MODULES-6687 is addressed, we need to pin to an earlier version of
the inifile module, prior to refreshonly being added. This commit
updates the helper to install the 1.5.0 version of the module instead of
latest.