### PR TITLE
(maint) Updated perf_helper and spec steps

### DIFF
--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -42,11 +42,6 @@ module PerfHelper
       on agents, 'yum install -y nc || true'
     end
 
-    step 'install atop, lsof for metrics gathering' do
-      on hosts, 'yum install -y atop || true'
-      on hosts, 'yum install -y lsof || true'
-    end
-
     step 'ensure iptables chkconfig is disabled on el6' do
       hosts.each { |host|
         if host['platform'] == 'el-6-x86_64'

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -34,10 +34,6 @@ describe PerfHelperClass do
       expect(subject).to receive(:on).with(hosts, 'setenforce 0 || true').once
       expect(subject).to receive(:on).with(hosts, "sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux && cat /etc/sysconfig/selinux").once
       expect(subject).to receive(:on).with(hosts, 'yum install -y nc || true').once
-      expect(subject).to receive(:on).with(hosts, 'yum install -y atop || true').once
-      expect(subject).to receive(:on).with(hosts, 'yum install -y lsof || true').once
-      expect(subject).to receive(:on).with(hosts, 'chkconfig atop on').once
-      expect(subject).to receive(:on).with(hosts, 'service atop start').once
       subject.install_epel_packages
     end
 


### PR DESCRIPTION
- Updated `perf_helper.rb` to remove the `atop` and `lsof` steps
- Updated `perf_helper_spec.rb` to remove the corresponding test steps