### PR TITLE
(QA-3457) Switch to using ABS for AWS provisioning

### DIFF
--- a/NEW_README.md
+++ b/NEW_README.md
@@ -15,12 +15,18 @@ At the end of the run, the gatling results and atop results will be copied back 
     *  export BEAKER_HOSTS=\<your hosts file>
 * Execute:
     * bundle install
-    * bundle exec rake performance_gatling (takes about 2 hours)
+    * bundle exec rake performance_gatling (takes about 4 hours)
+
+### Acceptance tests
+You can execute the 'acceptance' rake task which will run everything in VMPooler rather than AWS and do a much shorter gatling run. This is useful for quickly testing changes to the performance test setup. If you need to execute acceptance tests in the AWS environment, you can set the following env vars:
+
+`ABS_OS=centos-7-x86-64-west BEAKER_HOSTS=config/beaker_hosts/pe-perf-test.cfg`
 
 ### Set up Puppet Enterprise and Gatling but do not execute a gatling scenario
 Another use for the performance task would be to record and playback a new scenario either for one-off testing,
 or for a new scenario that will be checked in and used.  Additionally, you may just want to execute the setup standalone and then execute the tests later.
 * Follow the above instructions, but also `export BEAKER_TESTS=` and `BEAKER_PRESERVE_HOSTS=true` prior to executing the rake task to tell beaker not to execute any tests and preserve the machines.
+* Depending on your use case, you can also choose to execute the 'acceptance' task which will run in vmpooler rather than AWS. This is useful when testing/debugging but not for actual performance measurement.
 
 ### Record a Gatling run:
 Assuming that you ran the performance task with no tests, you can follow the directions below to record and then play back a recording manually.

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -7,15 +7,12 @@ At the end of the run, the gatling results and atop results will be copied back 
 * Clone the gatling-puppet-load-test repo locally: https://github.com/puppetlabs/gatling-puppet-load-test
 * cd into the gatling-puppet-load-test root directory
 * For apples to apples runs, you can use the checked-in hosts files: pe-perf-test.cfg or foss-perf-test.cfg (default for the performance rake task).
+* In order for us to take advantage of the new AWS account with access to internal network resources, you need to use ABS. The 'performance' task will automatically use ABS to provision 2 AWS instances and then execute tests against those instances.
+* If the hosts are preserved via Beaker's 'preserve_hosts' setting, then you will need to manually execute the 'performance_deprovision_with_abs' rake task when you are done with the hosts.
 * For a run against a PE build set BEAKER_INSTALL_TYPE=pe and provide values for BEAKER_PE_VER and BEAKER_PE_DIR environment variables
 * For a run against a FOSS build set BEAKER_INSTALL_TYPE=foss and provide values for PACKAGE_BUILD_VERSION and PUPPET_AGENT_VERSION environment variables
 * If you want to do something custom (which should not normally be necessary): create a beaker config file using one of the configs in this directory as a template: https://github.com/puppetlabs/gatling-puppet-load-test/blob/master/config/beaker_hosts/
     *  export BEAKER_HOSTS=\<your hosts file>
-* If you are using an aws puppet-bastion account
-    * Assume the ESO role
-        * aws sts assume-role --role-arn arn:aws:iam::028918822489:role/\<user> --role-session-name example --serial-number arn:aws:iam::103716600232:mfa/\<user> --token-code \<mfa token code>
-        * Place the returned creds in your .fog file
-            * Beaker-aws will look for the aws_access_key_id, aws_secret_access_key and aws_session_token keys
 * Execute:
     * bundle install
     * bundle exec rake performance_gatling (takes about 2 hours)
@@ -23,7 +20,7 @@ At the end of the run, the gatling results and atop results will be copied back 
 ### Set up Puppet Enterprise and Gatling but do not execute a gatling scenario
 Another use for the performance task would be to record and playback a new scenario either for one-off testing,
 or for a new scenario that will be checked in and used.  Additionally, you may just want to execute the setup standalone and then execute the tests later.
-* Follow the above instructions, but also `export BEAKER_TESTS=` prior to executing the rake task to tell beaker not to execute any tests.
+* Follow the above instructions, but also `export BEAKER_TESTS=` and `BEAKER_PRESERVE_HOSTS=true` prior to executing the rake task to tell beaker not to execute any tests and preserve the machines.
 
 ### Record a Gatling run:
 Assuming that you ran the performance task with no tests, you can follow the directions below to record and then play back a recording manually.

--- a/config/beaker_hosts/foss-perf-test.cfg
+++ b/config/beaker_hosts/foss-perf-test.cfg
@@ -27,11 +27,11 @@ scale:
 HOSTS:
   perf-test-mom:
     amisize: c4.2xlarge
-    hypervisor: ec2
+    hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot
     volume_size: 300
-    vmname: *default_vmname
+    template: *default_vmname
     ssh:
     roles:
       - master
@@ -41,11 +41,11 @@ HOSTS:
       - dashboard
   perf-test-metrics:
     amisize: c4.large
-    hypervisor: ec2
+    hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot
     volume_size: 50
-    vmname: *default_vmname
+    template: *default_vmname
     ssh:
     ports:
       - 2003

--- a/config/beaker_hosts/pe-perf-test.cfg
+++ b/config/beaker_hosts/pe-perf-test.cfg
@@ -27,11 +27,11 @@ scale:
 HOSTS:
   perf-test-mom:
     amisize: c4.2xlarge
-    hypervisor: ec2
+    hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot
     volume_size: 300
-    vmname: *default_vmname
+    template: *default_vmname
     ssh:
     roles:
       - master
@@ -41,11 +41,11 @@ HOSTS:
       - dashboard
   perf-test-metrics:
     amisize: c4.2xlarge
-    hypervisor: ec2
+    hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot
     volume_size: 50
-    vmname: *default_vmname
+    template: *default_vmname
     ssh:
     ports:
       - 2003

--- a/config/beaker_hosts/pe-vmpooler.cfg
+++ b/config/beaker_hosts/pe-vmpooler.cfg
@@ -1,0 +1,38 @@
+:root_keys: true
+
+:answers:
+  :console_admin_password: puppetlabs
+:department: eso-dept
+:disable_iptables: false
+:project: scale-testing
+
+HOSTS:
+  perf-test-mom:
+    platform: el-7-x86_64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    roles:
+      - master
+      - default
+      - certificate_authority
+      - database
+      - dashboard
+  perf-test-metrics:
+    platform: el-7-x86_64
+    hypervisor: vmpooler
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    ports:
+      - 2003
+      - 7777
+      - 80
+    roles:
+      - metric
+      - frictionless
+      - agent
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/rakefile
+++ b/rakefile
@@ -12,9 +12,10 @@ desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and th
 rototiller_task :performance do
   Rake::Task["performance_provision_with_abs"].execute unless ENV['ABS_RESOURCE_HOSTS']
   Rake::Task["performance_without_provision"].execute
-  Rake::Task["performance_deprovision_with_abs"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' || ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0) && ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
+  Rake::Task["performance_deprovision_with_abs"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' ||
+      ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0)&&
+          ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
 end
-
 
 def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])
   req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
@@ -46,11 +47,15 @@ def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodie
 end
 
 desc 'Provision systems for the performance task with ABS - included in the performance task'
-rototiller_task :performance_provision_with_abs do
+rototiller_task :performance_provision_with_abs do |t|
+  t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
   # Creating a random job id, since this is required by ABS and needs to be unique. In CI, this task will not be executed.
   ENV['ABS_JOB_ID'] = rand(100000..999999).to_s unless ENV['ABS_JOB_ID']
   uri = URI("#{BASE_ABS_URI}request")
-  req_body = {'resources': {'centos-7-x86-64-west': 2},'job': { 'id': "#{ENV['ABS_JOB_ID']}", 'tags': {'user': "#{ENV['USER']}"}}}.to_json
+
+  # Allows us to switch between AWS and VMPooler by selecting different ABS os's.
+  # centos-7-x86-64-west is an AWS image, centos-7-x86_64 is vmpooler
+  req_body = {'resources': {"#{ENV['ABS_OS']}": 2},'job': { 'id': "#{ENV['ABS_JOB_ID']}", 'tags': {'user': "#{ENV['USER']}"}}}.to_json
 
   # Wait up to 20 minutes for a response from ABS with provisioned hosts
   res = retry_abs_request(uri, req_body, 1200, 10, ['', nil])
@@ -171,7 +176,7 @@ rototiller_task :performance_without_provision do |t|
     end
     command.add_option do |option|
       option.name = '--preserve-hosts'
-      option.message = 'Whether to preserve hosts or not, if using the default ABS workflow, this will not be respected.'
+      option.message = 'Whether to preserve hosts or not.'
       option.add_argument do |arg|
         arg.name = 'always'
         arg.add_env({:name => 'BEAKER_PRESERVE_HOSTS'})
@@ -211,6 +216,9 @@ desc 'Run Performance setup and a very short iteration of gatling tests'
 rototiller_task :acceptance do |t|
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['PUPPET_GATLING_SCENARIO'] = 'acceptance.json'
+  ENV['BEAKER_HOSTS'] ||= 'config/beaker_hosts/pe-vmpooler.cfg'
+  # Need to change this from an AWS OS image to a vmpooler OS image
+  ENV['ABS_OS'] ||= 'centos-7-x86_64'
   Rake::Task["performance"].execute
 end
 

--- a/rakefile
+++ b/rakefile
@@ -1,13 +1,80 @@
 require 'rototiller'
 require 'rspec/core/rake_task'
+require 'net/http'
+require 'timeout'
+require 'json'
+
+BASE_ABS_URI = 'https://cinext-abs.delivery.puppetlabs.net/api/v2/'
 
 task :default => :performance
 
-desc 'Run Performance setup'
-rototiller_task :performance do |t|
+desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
+rototiller_task :performance do
+  Rake::Task["performance_provision_with_abs"].execute unless ENV['ABS_RESOURCE_HOSTS']
+  Rake::Task["performance_without_provision"].execute
+  Rake::Task["performance_deprovision_with_abs"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' || ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0) && ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
+end
+
+
+def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])
+  req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
+  req.body = body
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true
+
+  puts "sending request body: #{body}"
+  puts "to uri: #{uri}"
+
+  res = nil
+  Timeout::timeout(timeout) do
+    while res.nil? || invalid_response_bodies.include?(res.body) || !valid_response_codes.include?(res.code)
+      begin
+        res = http.request(req)
+      rescue => ex
+        puts ex
+        puts ex.backtrace
+      end
+      if res.nil? || invalid_response_bodies.include?(res.body)
+        puts "#{Time.now} - Retrying ABS request..."
+        sleep(time_increment)
+      else
+        break
+      end
+    end
+  end
+  res
+end
+
+desc 'Provision systems for the performance task with ABS - included in the performance task'
+rototiller_task :performance_provision_with_abs do
+  # Creating a random job id, since this is required by ABS and needs to be unique. In CI, this task will not be executed.
+  ENV['ABS_JOB_ID'] = rand(100000..999999).to_s unless ENV['ABS_JOB_ID']
+  uri = URI("#{BASE_ABS_URI}request")
+  req_body = {'resources': {'centos-7-x86-64-west': 2},'job': { 'id': "#{ENV['ABS_JOB_ID']}", 'tags': {'user': "#{ENV['USER']}"}}}.to_json
+
+  # Wait up to 20 minutes for a response from ABS with provisioned hosts
+  res = retry_abs_request(uri, req_body, 1200, 10, ['', nil])
+
+  ENV['ABS_RESOURCE_HOSTS'] = res.body
+  puts "ABS_RESOURCE_HOSTS=#{ENV['ABS_RESOURCE_HOSTS']}"
+end
+
+desc 'Task to deprovision systems that were provisioned with ABS - included in the performance task following the rules of BEAKER_PRESERVE_HOSTS env var.'
+rototiller_task :performance_deprovision_with_abs do
+  raise 'performance_deprovision_with_abs task requires values for env variables: ABS_RESOURCE_HOSTS and ABS_JOB_ID' unless ENV['ABS_RESOURCE_HOSTS'] && ENV['ABS_JOB_ID']
+  uri = URI("#{BASE_ABS_URI}return")
+  req_body = {'job_id': ENV['ABS_JOB_ID'], 'hosts': JSON.parse(ENV['ABS_RESOURCE_HOSTS'])}.to_json
+
+  # Wait up to 30 seconds for a non error response from ABS when de-provisioning
+  retry_abs_request(uri, req_body, 30, 5)
+end
+
+desc 'Execute beaker performance setup and tests against existing hosts specified by ABS_RESOURCE_HOSTS env var, intended to be used in CI - use task "performance" for local/dev execution'
+rototiller_task :performance_without_provision do |t|
   raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
       ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
 
+  t.add_env({:name => 'ABS_RESOURCE_HOSTS', :message => 'The string returned from the ABS service describing your hosts'})
   t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'ENVIRONMENT_TYPE', :message => 'Either gatling or clamps', :default => 'gatling'})
@@ -33,7 +100,7 @@ rototiller_task :performance do |t|
   end
 
   # env vars needed for Beaker
-  t.add_command do |command|
+  @beaker_cmd = t.add_command do |command|
     command.name = "bundle exec beaker"
     command.add_env({:name => 'BEAKER_EXECUTABLE'})
 
@@ -104,7 +171,7 @@ rototiller_task :performance do |t|
     end
     command.add_option do |option|
       option.name = '--preserve-hosts'
-      option.message = 'Whether to preserve hosts or not'
+      option.message = 'Whether to preserve hosts or not, if using the default ABS workflow, this will not be respected.'
       option.add_argument do |arg|
         arg.name = 'always'
         arg.add_env({:name => 'BEAKER_PRESERVE_HOSTS'})
@@ -125,6 +192,7 @@ rototiller_task :performance do |t|
     # setup/helpers/classification_helper.rb,setup/helpers/ldap_helper.rb,setup/helpers/gatling_config_helper.rb
     # --preserve-hosts always --type pe"
   end
+
 end
 
 desc 'Run Performance setup for clamps'
@@ -151,4 +219,3 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = ['--color']
   t.pattern = 'spec/'
 end
-

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -2,11 +2,9 @@ require 'scooter'
 require 'tmpdir'
 require 'yaml'
 require 'beaker'
+require 'net/http'
 
 module PerfHelper
-  def perf_init
-    @install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
-  end
   BASE_URL = 'http://builds.puppetlabs.lan'
   R10K_DIR = '/opt/puppetlabs/scratch/perf_testing/r10k'
   R10K_CONFIG_PATH = "#{R10K_DIR}/r10k.yaml"
@@ -108,34 +106,6 @@ SSH_CONFIG
     end
   end
 
-  def cloud_config(host)
-    if host.file_exist?("/etc/cloud/cloud.cfg")
-      on host, "if grep 'preserve_hostname: true' /etc/cloud/cloud.cfg ; then echo 'already set' ; else echo 'preserve_hostname: true' >> /etc/cloud/cloud.cfg ; fi"
-    end
-  end
-
-  def ec2_workarounds
-    step 'Fix cloud.cfg' do
-      hosts.each do |host|
-        cloud_config(host)
-      end
-    end
-
-    step 'Download Puppet installer and set pe_dir' do
-      # If the installer download is on the internal network, EC2 instance can't access it, so copy it locally.
-      if master['pe_dir'] =~ /puppetlabs\.net/ && ENV['BEAKER_INSTALL_TYPE'] == 'pe'
-        tmp_dir = Dir.mktmpdir
-        file = "puppet-enterprise-#{master[:pe_ver]}-#{master[:platform]}.tar"
-        curl_cmd = "curl -o #{tmp_dir}/#{file} #{master[:pe_dir]}/#{file}"
-        puts curl_cmd
-        system(curl_cmd)
-        hosts.each do |host|
-          host[:pe_dir] = tmp_dir
-        end
-      end
-    end
-  end
-
   def perf_install_pe
     if !is_pre_aio_version?
       # Must include the dashboard so that split installs add these answers to classification
@@ -217,8 +187,7 @@ puppet_enterprise::master::code_manager::timeouts_deploy: 600
 
     if response.code == "200"
       json = JSON.parse(response.body)
-      @install_opts[:puppet_agent_commit] = json["suite-commit"].strip
-      @install_opts[:puppet_agent_version] = json["suite-version"].strip
+      json["suite-commit"].strip
     else
       Beaker::Log.notify("Unable to get last successful build from: #{url}, " +
                              "error: #{response.code}, #{response.message}")
@@ -234,100 +203,37 @@ puppet_enterprise::master::code_manager::timeouts_deploy: 600
     # some mergely/SHA version.  The list of builds is ordered from most recent to
     # oldest.  The resulting list is passed along to the get_cent7_repo routine,
     # which returns a URL for the first build which has a cent7 repo in it.
-    opts[:puppet_agent_version] = get_cent7_repo(
+    get_cent7_repo(
         response.lines.
             select { |l| l =~ /<td><a / }.
             select { |l| l.match(/^.*href="(\d+\.\d+\.\d+)\/\?C=M&amp;O=D".*$/) },
         "puppet-agent")
   end
 
-  # Mostly copied from: install_puppet_agent_dev_repo_on in Beaker's foss_utils.rb
-  def install_puppet_agent_dev_repo_from_local_file( host, opts )
-    opts[:copy_base_local]    ||= File.join('tmp', 'repo_configs')
-    opts = FOSS_DEFAULT_DOWNLOAD_URLS.merge(opts)
-
-    variant, version, arch, codename = host['platform'].to_array
-    add_role(host, 'aio') #we are installing agent, so we want aio role
-    copy_dir_local = File.join(opts[:copy_base_local], variant)
-    onhost_copy_base = opts[:copy_dir_external] || host.external_copy_base
-
-    release_path_end, release_file = host.puppet_agent_dev_package_info(
-        "PC1", opts[:puppet_agent_version], opts )
-    release_path = "#{opts[:dev_builds_url]}/puppet-agent/#{ opts[:puppet_agent_commit] }/repos/"
-    release_path << release_path_end
-    logger.trace("#install_puppet_agent_dev_repo_on: dev_package_info, continuing...")
-
-    if variant =~ /eos/
-      host.get_remote_file( "#{release_path}/#{release_file}" )
-    else
-      onhost_copied_file = File.join(onhost_copy_base, release_file)
-      fetch_http_file( release_path, release_file, copy_dir_local)
-      scp_to host, File.join(copy_dir_local, release_file), onhost_copy_base
-    end
-
-    case variant
-      when /eos/
-        host.install_from_file( release_file )
-      when /^(sles|aix|fedora|el|centos)$/
-        # NOTE: AIX does not support repo management. This block assumes
-        # that the desired rpm has been mirrored to the 'repos' location.
-        # NOTE: the AIX 7.1 package will only install on 7.2 with
-        # --ignoreos. This is a bug in package building on AIX 7.1's RPM
-        if variant == "aix" and version == "7.2"
-          aix_72_ignoreos_hack = "--ignoreos"
-        end
-        on host, "rpm -ivh #{aix_72_ignoreos_hack} #{onhost_copied_file}"
-      when /^windows$/
-        result = on host, "echo #{onhost_copied_file}"
-        onhost_copied_file = result.raw_output.chomp
-        msi_opts = { :debug => host[:pe_debug] || opts[:pe_debug] }
-        install_msi_on(host, onhost_copied_file, {}, msi_opts)
-      when /^osx$/
-        host.install_package("puppet-agent-#{opts[:puppet_agent_version]}*")
-      when /^solaris$/
-        host.solaris_install_local_package( release_file, onhost_copy_base )
-    end
-    configure_type_defaults_on( host )
-
-  end
-
-  def install_repo_configs(host, buildserver_url, package_name, build_version, copy_dir)
-    filename =  "#{package_name}-#{build_version.sub('master.SNAPSHOT', 'master-0.1SNAPSHOT')}.el7.noarch.rpm"
-    repo_config_folder_url = "%s/%s/%s/repos/el/7/puppet5/x86_64" %
-        [ buildserver_url, package_name, build_version ]
-
-    puppetserver_installer_url = "#{ repo_config_folder_url }/#{ filename }"
-    Beaker::Log.info puppetserver_installer_url
-    system "curl -O #{puppetserver_installer_url}"
-    scp_to host, filename, "/tmp/#{filename}"
-    on host, "yum install -y /tmp/#{filename}"
-  end
-
   def perf_install_foss
+    install_opts = options.merge( { :dev_builds_repos => ["PC1"] })
     repo_config_dir = 'tmp/repo_configs'
 
-    step "Setup Puppet agents" do
+    step "Setup Puppet repositories" do
       puppet_agent_version = ENV['PUPPET_AGENT_VERSION']
 
       case puppet_agent_version
         when "latest"
-          get_latest_agent_version
+          puppet_agent_version = get_latest_agent_version
         when "latest-release"
-          get_latest_release_agent_version
+          puppet_agent_version = get_latest_release_agent_version
       end
 
-      if @install_opts[:puppet_agent_version]
-        Beaker::Log.notify("Installing OSS Puppet AGENT version '#{@install_opts[:puppet_agent_version]}'")
-        #install_puppet_agent_dev_repo_on hosts, @install_opts
-        hosts.each do |host|
-          install_puppet_agent_dev_repo_from_local_file host, @install_opts
-        end
+      if puppet_agent_version
+        Beaker::Log.notify("Installing OSS Puppet AGENT version '#{puppet_agent_version}'")
+        install_puppetlabs_dev_repo master, 'puppet-agent', puppet_agent_version,
+                                    repo_config_dir, install_opts
       else
         abort("Environment variable PUPPET_AGENT_VERSION required for package installs!")
       end
     end
 
-    step "Setup Puppet Server." do
+    step "Setup Puppet Server repositories." do
       package_build_version = ENV['PACKAGE_BUILD_VERSION']
 
       if package_build_version == "latest"
@@ -343,19 +249,33 @@ puppet_enterprise::master::code_manager::timeouts_deploy: 600
       if package_build_version
         Beaker::Log.notify("Installing OSS Puppet Server version '#{package_build_version}'")
         install_puppetlabs_dev_repo master, 'puppetserver', package_build_version,
-                                    repo_config_dir, @install_opts
+                                    repo_config_dir, install_opts
       else
         abort("Environment variable PACKAGE_BUILD_VERSION required for package installs!")
       end
-
-      on master, 'puppet resource service puppetserver ensure=running enable=true'
     end
 
-    step "Sign agent certificates" do
-      # Failed agent run will request a certificate
-      on agents, 'puppet agent -t', {:accept_all_exit_codes => true}
-      on master, 'puppet cert sign --all'
+    step "Upgrade nss to version that is hopefully compatible with jdk version puppetserver will use." do
+      nss_package=nil
+      variant, _, _, _ = master['platform'].to_array
+      case variant
+        when /^(debian|ubuntu)$/
+          nss_package_name="libnss3"
+        when /^(redhat|el|centos)$/
+          nss_package_name="nss"
+      end
+      if nss_package_name
+        master.upgrade_package(nss_package_name)
+      else
+        Beaker::Log.warn("Don't know what nss package to use for #{variant} so not installing one")
+      end
     end
+
+    step "Install Puppet Server." do
+      install_package master, 'puppetserver'
+      on(master, "puppet agent -t --server #{master}")
+    end
+
   end
 
   ## TODO This probably needs more work to finish hooking up everything that
@@ -570,22 +490,6 @@ node 'default' {}
 
     scp_to(host, @local_hiera_config_path, @target_hiera_config_path)
     on(host, "chmod 644 #{@target_hiera_config_path}")
-  end
-
-  def use_internal_ips
-    step "modify /etc/hosts to use internal ip" do
-      hosts.each do |host|
-        if host[:private_ip]
-          manifest =<<-EOS.gsub /^\s+/, ""
-          host { '#{host.hostname}':
-            \tensure       => present,
-            \tip           => '#{host[:private_ip]}',
-          }
-          EOS
-          apply_manifest_on(metric, manifest)
-        end
-      end
-    end
   end
 
   def configure_gatling_auth

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -572,7 +572,9 @@ authorization: {
     end
     step 'install rvm, bundler' do
       on metric, 'gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3'
-      on metric, 'curl -sSL https://get.rvm.io | bash -s stable --ruby=2.2.5'
+      on metric, 'curl -sSL https://get.rvm.io | bash -s stable'
+      # Work around install issue in Centos7: https://github.com/rvm/rvm/issues/4234
+      on metric, 'rvm install 2.2.5 --disable-binary'
       on metric, 'gem install bundler'
     end
     step 'create key for metrics to talk to primary master' do

--- a/setup/install_gatling/00_pre_install/05_initialize_helpers.rb
+++ b/setup/install_gatling/00_pre_install/05_initialize_helpers.rb
@@ -1,3 +1,2 @@
 require File.expand_path('../../../../setup/helpers/perf_helper', __FILE__)
 Beaker::TestCase.class_eval { include PerfHelper }
-perf_init

--- a/setup/install_gatling/00_pre_install/10_etc_hosts.rb
+++ b/setup/install_gatling/00_pre_install/10_etc_hosts.rb
@@ -1,5 +1,0 @@
-test_name 'set loadbalancer as puppet in /etc/hosts' do
-  step 'modify /etc/hosts' do
-    set_etc_hosts
-  end
-end

--- a/setup/install_gatling/00_pre_install/40_ec2_fixes.rb
+++ b/setup/install_gatling/00_pre_install/40_ec2_fixes.rb
@@ -1,3 +1,0 @@
-test_name 'Workaround various EC2 host config issues.' do
-  ec2_workarounds
-end

--- a/setup/install_gatling/20_foss_install/10_install_dev_repos.rb
+++ b/setup/install_gatling/20_foss_install/10_install_dev_repos.rb
@@ -1,6 +1,4 @@
-require 'net/http'
-
 test_name 'install Puppet dev repos' do
   skip_test 'Installing PE, not FOSS' unless ENV['BEAKER_INSTALL_TYPE'] == 'foss'
-
+  perf_install_foss
 end

--- a/setup/install_gatling/40_post_install/20_use_internal_ips.rb
+++ b/setup/install_gatling/40_post_install/20_use_internal_ips.rb
@@ -1,3 +1,0 @@
-test_name 'use internal ips on the metric node' do
-  use_internal_ips
-end


### PR DESCRIPTION
Updated hosts files to use ABS hypervisor
Broke out rake tasks into multiple tasks, one to provision, one to execute beaker, one to encapsulate both of those and finally, one to deprovision.
Removed workarounds for AWS that are no longer necessary: 10_etc_hosts.rb, 40_ec2_fixes.rb, 20_use_internal_ips.rb and some of the FOSS install code in perf_helper.rb
Fixed 20_foss_install/10_install_dev_repos.rb - it was missing the call to the helper method