### PR TITLE
(maint) Use `hostname` to designate puppet's server

### DIFF
--- a/jenkins-integration/beaker/install/foss/80_run_agent_on_master.rb
+++ b/jenkins-integration/beaker/install/foss/80_run_agent_on_master.rb
@@ -5,5 +5,9 @@ test_name 'Run puppet agent on the master to prime directories' do
   # ahead of the Gatling run avoids collisions in the priming that can happen
   # when multiple agent runs happen at the same time.  See PUP-6651 for more
   # information.
-  on(master, "puppet agent -t --server #{master}")
+  #
+  # We have to use `hostname` here instead of "master" because some of the
+  # perf blades use their razor ID as their hostname instead of the node
+  # name used by beaker, which comes from DNS.
+  on(master, "puppet agent -t --server `hostname`")
 end


### PR DESCRIPTION
The value of beaker's `master` variable is not always the same as a perf
node's `hostname`. When invoking puppet on these hosts, we need
to use the hostname as the server to contact, and not the external alias
given to beaker. This commit updates the `puppet agent` invocation to use
`hostname`, which works in both cases.