### PR TITLE
(SERVER-2080) Add s3 upload step to puppetserver-infinite pipeline

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -551,6 +551,9 @@ def single_configurable_pipeline(job) {
 
         stage '900-collect-driver-artifacts'
         step900_collect_driver_artifacts()
+
+        stage '905-publish-artifacts-to-s3'
+        step905_publish_artifacts_to_s3()
     }
 }
 


### PR DESCRIPTION
The puppetserver-infinite job uses a different base pipeline from the
other job. This commit adds the s3 upload step to it.