### PR TITLE
(SERVER-2135) (SERVER-2103) (SERVER-2128) Various gatling job additions

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -435,12 +435,24 @@ def step900_collect_driver_artifacts() {
     archive "simulation-runner/results/**/*.log.gz"
 }
 
+def create_params_file(archive_dir) {
+    def keys = params.keySet()
+    def param_string = ""
+    for (i = 0 i < keys.length; i++) {
+        param_string += "${keys[i]}: ${params.get(keys[i])}\n"
+    }
+    sh "echo ${param_string} > ${archive_dir}/job_params.txt"
+}
+
 def step905_publish_artifacts_to_s3(job_name) {
     def archive_dir = job_name + '-' + (new Date().format("yyyy-MM-dd-HH:mm:ss"))
     sh "mkdir -p ${archive_dir}/results"
     // Copy all gatling output info into the dir to be uploaded
     sh "cp -R ./puppet-gatling/${job_name}/* ${archive_dir}"
     sh "cp simulation-runner/results/**/*.log.gz ${archive_dir}/results"
+
+    create_params_file(archive_dir)
+
     step([
         $class: 'S3BucketPublisher',
         entries: [

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -328,27 +328,17 @@ def step080_customize_java_args(script_dir, server_heap_settings, server_era) {
 
 def step081_customize_jruby_jar(script_dir, jruby_jar, server_era) {
     def jar_string = ""
-    def JRUBY_VERSION_SET = true
 
-    // This garbage can be replaced with either getBinding().hasVariable("JRUBY_VERSION")
-    // or via a params map (params.JRUBY_VERSION == null)
-    // https://wiki.jenkins.io/display/JENKINS/Pipeline+Groovy+Plugin#PipelineGroovyPlugin-2.18%28Sep23%2C2016%29
-    try {
-        println("JRUBY_VERSION is ${JRUBY_VERSION}")
-    } catch (MissingPropertyException e) {
-        JRUBY_VERSION_SET = false
-    }
-
-    if (!JRUBY_VERSION_SET) {
+    if (params.JRUBY_VERSION == null) {
         // Setting the jruby jar to an empty string will effectively cause the
         // beaker script to tell puppetserver to use the default jar path
         jar_string = jruby_jar ?: ""
     } else {
         // This branch indicates there is a JRUBY_VERSION parameter on the jenkins job,
         // so we use that instead.
-        if ("${JRUBY_VERSION}" == "1.7") {
+        if ("${params.JRUBY_VERSION}" == "1.7") {
             jar_string = "/opt/puppetlabs/server/apps/puppetserver/jruby-1_7.jar"
-        } else if ("${JRUBY_VERSION}" == "9k") {
+        } else if ("${params.JRUBY_VERSION}" == "9k") {
             jar_string = "/opt/puppetlabs/server/apps/puppetserver/jruby-9k.jar"
         }
     }

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -433,10 +433,6 @@ def step110_collect_sut_artifacts(script_dir, job_name, archive_sut_files) {
             }
 
         }
-        // Clean up the sut_archive_files so they don't appear in the next run by accident
-        dir("puppet-gatling/${job_name}/sut_archive_files") {
-            deleteDir()
-        }
     }
 }
 
@@ -447,15 +443,13 @@ def step900_collect_driver_artifacts() {
 
     // Always archive the simulation.log.gz from the run.
     archive "simulation-runner/results/**/*.log.gz"
-    dir('simulation-runner/results') {
-        deleteDir()
-    }
 }
 
 def step905_publish_artifacts_to_s3(job_name) {
     def archive_dir = job_name + '-' + (new Date().format("yyyy-MM-dd-HH:mm:ss"))
     sh "mkdir -p ${archive_dir}/results"
-    sh "cp -R ./puppet-gatling/${job_name}/sut_archive_files ${archive_dir}"
+    // Copy all gatling output info into the dir to be uploaded
+    sh "cp -R ./puppet-gatling/${job_name}/* ${archive_dir}"
     sh "cp simulation-runner/results/**/*.log.gz ${archive_dir}/results"
     step([
         $class: 'S3BucketPublisher',
@@ -476,6 +470,9 @@ SCRIPT_DIR = "./jenkins-integration/jenkins-jobs/common/scripts/job-steps"
 
 def single_configurable_pipeline(job) {
     node {
+        // Clear out anything left over from the last time this workspace was used
+        deleteDir()
+
         checkout scm
 
         SKIP_SERVER_INSTALL = (SKIP_SERVER_INSTALL == "true")
@@ -573,6 +570,9 @@ def single_configurable_pipeline(job) {
 
 def single_pipeline(job) {
     node {
+        // Clear out anything left over from the last time this workspace was used
+        deleteDir()
+
         checkout scm
 
         SKIP_SERVER_INSTALL = (SKIP_SERVER_INSTALL == "true")

--- a/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
+++ b/jenkins-integration/jenkins-jobs/scenarios/puppetserver-infinite/JobDSL.groovy
@@ -7,4 +7,6 @@ job.parameters {
     choiceParam('JRUBY_VERSION', ['9k', '1.7'], 'Version of jruby to use in the simulation.')
     choiceParam('CATALOG_SIZE', ['MEDIUM', 'EMPTY'], 'Catalog to use in simulation.')
     choiceParam('NODE_COUNT', ['600', '100', '200', '300', '900', '1200', '1500', '1800'], 'Number of nodes (these were selected as they produce an even node distribution) to include in simulation.')
+    stringParam('MAX_INSTANCES', 'default', 'Maximum number of JRuby instances. Specifying "default" will use number of CPUs - 1, with a max of 4.')
+    stringParam('MAX_REQUESTS_PER_INSTANCE', '0', 'Number of requests that will be handled by a JRuby instance before it gets recycled. 0 indicates "never recycle".')
 }


### PR DESCRIPTION
(SERVER-2135)
This commit exposes a parameter on the puppetserver-infinite job to
configure the max number of active JRuby instances allowed. When set to
'default', it will use puppetserver's default of the number of CPUs - 1.

(SERVER-2103)
This commit adds a param to the puppetserver-infinite job to configure
max-requests-per-instance. It defaults to 0, meaning JRubies are never
flushed.

(SERVER-2128)
This commit adds a groovy function that walks through the params map and
exports its keys and values into a file for upload to s3.