### PR TITLE
(maint) Convert KeySet to Array before attempting to index

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -436,7 +436,7 @@ def step900_collect_driver_artifacts() {
 }
 
 def create_params_file(archive_dir) {
-    def keys = params.keySet()
+    def keys = params.keySet().toArray()
     def param_string = ""
     for (i = 0; i < keys.size(); i++) {
         param_string += "${keys[i]}: ${params.get(keys[i])}\n"


### PR DESCRIPTION
Java's set type does not allow indexing with bracket notation, since it
is optimized for membership rather than for iteration. This commit
converts the params key set to an array before attempting to iterate
through it.