### PR TITLE
(maint) Add '/' to file path of s3 upload

### DIFF
--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -467,7 +467,7 @@ def step905_publish_artifacts_to_s3(job_name) {
             [
                 bucket: 'puppetserver-perf-data',
                 selectedRegion: 'us-west-2',
-                sourceFile: "${archive_dir}",
+                sourceFile: "${archive_dir}/",
                 storageClass: 'STANDARD',
             ]
         ],


### PR DESCRIPTION
The s3 upload plugin requires directories to be specified with a
trailing slash, otherwise it will look for a single file with the
specified name and fail to find one. This commit adds a slash to the
folder name we want to upload.