### PR TITLE
(slv-89) use beaker options files for various flavors of gplt setup

### DIFF
--- a/config/beaker_hosts/foss-vmpooler.cfg
+++ b/config/beaker_hosts/foss-vmpooler.cfg
@@ -1,0 +1,27 @@
+HOSTS:
+  perf-test-mom:
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: centos-7-x86_64
+    roles:
+      - master
+      - default
+      - certificate_authority
+      - database
+      - dashboard
+  perf-test-metrics:
+    hypervisor: vmpooler
+    platform: el-7-x86_64
+    template: centos-7-x86_64
+    ports:
+      - 2003
+      - 7777
+      - 80
+    roles:
+      - metric
+      - frictionless
+      - agent
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/rakefile
+++ b/rakefile
@@ -97,7 +97,11 @@ rototiller_task :performance_without_provision do |t|
   t.add_env({:name => 'ABS_RESOURCE_HOSTS', :message => 'The string returned from the ABS service describing your hosts'})
   t.add_env({:name => 'ENVIRONMENT_TYPE', :message => 'Either gatling or clamps', :default => 'gatling'})
   t.add_env({:name => 'PUPPET_GATLING_R10K_CONTROL_REPO', :default => 'git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git'})
-  t.add_env({:name => 'PUPPET_GATLING_R10K_BASEDIR', :default => '/etc/puppetlabs/code-staging/environments'})
+  if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
+    t.add_env({:name => 'PUPPET_GATLING_R10K_BASEDIR', :default => '/etc/puppetlabs/code/environments'})
+  else
+    t.add_env({:name => 'PUPPET_GATLING_R10K_BASEDIR', :default => '/etc/puppetlabs/code-staging/environments'})
+  end
   t.add_env({:name => 'PUPPET_GATLING_R10K_ENVIRONMENTS', :default => 'production'})
   t.add_env({:name => 'PUPPET_BIN_DIR', :default => '/opt/puppetlabs/puppet/bin'})
   t.add_env({:name => 'PUPPET_R10K_VERSION', :default => '2.3.0'})
@@ -107,15 +111,6 @@ rototiller_task :performance_without_provision do |t|
   t.add_env({:name => 'SUT_ARCHIVE_FILES', :default => ''})
   t.add_env({:name => 'PACKAGE_BUILD_VERSION', :default => 'latest'}) if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
   t.add_env({:name => 'PUPPET_AGENT_VERSION', :default => 'latest'}) if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
-
-  default_setup = 'setup/install'
-
-  # TODO: This is a temporary step... going to get a working workflow for gatling runs,
-  # then a separate workflow for clamps and then work on combining them.
-  if ENV['ENVIRONMENT_TYPE'] == 'gatling'
-    default_setup = 'setup/install_gatling'
-    default_tests = 'tests'
-  end
 
   # env vars needed for Beaker
   @beaker_cmd = t.add_command do |command|
@@ -131,12 +126,17 @@ rototiller_task :performance_without_provision do |t|
         arg.add_env({:name => 'BEAKER_HOSTS'})
       end
     end
-    command.add_option do |option|
-      option.name = '--keyfile'
-      option.message = 'The SSH key used to access a SUT'
-      option.add_argument do |arg|
-        arg.name = "#{ENV['HOME']}/.ssh/id_rsa-acceptance"
-        arg.add_env({:name => 'BEAKER_KEYFILE'})
+    # this is specified in the options file
+    #   this is here so it can be overridden in the rake task
+    #   there is no beaker built-in env var for this
+    unless (!ENV['BEAKER_KEYFILE'] || ENV['BEAKER_KEYFILE'] == '') #unless nil or empty
+      command.add_option do |option|
+        option.name = '--keyfile'
+        option.message = 'The SSH key used to access a SUT'
+        option.add_argument do |arg|
+          arg.name = "#{ENV['HOME']}/.ssh/id_rsa-acceptance"
+          arg.add_env({:name => 'BEAKER_KEYFILE'})
+        end
       end
     end
     command.add_option do |option|
@@ -147,12 +147,24 @@ rototiller_task :performance_without_provision do |t|
         arg.add_env({:name => 'BEAKER_LOG_LEVEL'})
       end
     end
-    unless ENV['BEAKER_PRE_SUITE'] == ''
+    unless ENV['BEAKER_OPTIONS_FILE'] == ''
+      command.add_option do |option|
+        option.name = '--options'
+        option.message = 'Beaker options file'
+        option.add_argument do |arg|
+          arg.name = 'setup/options/options_pe.rb' if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
+          arg.name = 'setup/options/options_foss.rb' if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
+          arg.add_env({:name => 'BEAKER_OPTIONS_FILE'})
+        end
+      end
+    end
+    #FIXME this disallows rototiller from showing this env, when it doesn't exist
+    unless (!ENV['BEAKER_PRE_SUITE'] || ENV['BEAKER_PRE_SUITE'] == '') #unless nil or empty
       command.add_option do |option|
         option.name = '--pre-suite'
         option.message = 'Beaker pre-suite'
         option.add_argument do |arg|
-          arg.name = default_setup
+          arg.name = ''
           arg.add_env({:name => 'BEAKER_PRE_SUITE'})
         end
       end
@@ -172,17 +184,16 @@ rototiller_task :performance_without_provision do |t|
         option.name = '--tests'
         option.message = 'Beaker tests'
         option.add_argument do |arg|
-          arg.name = default_tests
+          arg.name = 'tests/'
           arg.add_env({:name => 'BEAKER_TESTS'})
         end
       end
     end
-    unless ENV['HELPER_PATH'] == ''
+    unless (!ENV['BEAKER_HELPER'] || ENV['BEAKER_HELPER'] == '') #unless nil or empty
       command.add_option do |option|
         option.name = '--helper'
-        option.message = 'Setup helper required for installing PE'
+        option.message = 'Setup helper ruby scripts, comma separated'
         option.add_argument do |arg|
-          arg.name = 'setup/helpers/classification_helper.rb,setup/helpers/ldap_helper.rb,setup/helpers/gatling_config_helper.rb'
           arg.add_env({:name => 'BEAKER_HELPER'})
         end
       end

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -206,6 +206,8 @@ SSH_CONFIG
         Beaker::Log.notify("Installing OSS Puppet AGENT version '#{puppet_agent_version}'")
         install_puppetlabs_dev_repo master, 'puppet-agent', puppet_agent_version,
                                     repo_config_dir, install_opts
+        install_puppetlabs_dev_repo agent, 'puppet-agent', puppet_agent_version,
+                                    repo_config_dir, install_opts
       else
         abort("Environment variable PUPPET_AGENT_VERSION required for package installs!")
       end
@@ -251,7 +253,15 @@ SSH_CONFIG
 
     step "Install Puppet Server." do
       install_package master, 'puppetserver'
+      on(master, "puppet config set --section master autosign true")
+      on(master, "service puppetserver start")
       on(master, "puppet agent -t --server #{master}")
+    end
+
+    step "Install Puppet Agent." do
+      install_package agent, 'puppet-agent'
+      on(agent, "puppet agent -t --server #{master}")
+      on(master, "puppet config remove --section master autosign")
     end
 
   end

--- a/setup/install_gatling/40_post_install/30_final_puppet_run.rb
+++ b/setup/install_gatling/40_post_install/30_final_puppet_run.rb
@@ -1,5 +1,6 @@
 test_name 'final puppet run' do
   step "run puppet on all nodes" do
+    on hosts, "puppet config set --section agent server #{master.hostname}"
     on hosts, 'puppet agent -t', :acceptable_exit_codes => [0, 2, 6]
   end
 end

--- a/setup/options/options_common.rb
+++ b/setup/options/options_common.rb
@@ -1,0 +1,16 @@
+{
+  :ssh                         => {
+    :keys => ["id_rsa_acceptance", "#{ENV['HOME']}/.ssh/id_rsa-acceptance"],
+  },
+  :helper                      => [
+    'setup/helpers/classification_helper.rb',
+    'setup/helpers/ldap_helper.rb',
+    'setup/helpers/gatling_config_helper.rb',
+  ],
+  :xml                         => true,
+  :timesync                    => false,
+  :repo_proxy                  => true,
+  :add_el_extras               => false,
+  :forge_host                  => 'forge-aio01-petest.puppetlabs.com',
+  :'master-start-curl-retries' => 30,
+}

--- a/setup/options/options_foss.rb
+++ b/setup/options/options_foss.rb
@@ -1,0 +1,24 @@
+{
+  :type                        => 'foss',
+  :pre_suite                   => [
+    'setup/install_gatling/00_pre_install/05_initialize_helpers.rb',
+    'setup/install_gatling/00_pre_install/20_rpm_setup.rb',
+    'setup/install_gatling/00_pre_install/30_r10k_git_setup.rb',
+    'setup/install_gatling/20_foss_install/10_install_dev_repos.rb',
+    'setup/install_gatling/30_classification/10_r10k_deploy.rb',
+    'setup/install_gatling/30_classification/50_classify_nodes_via_site_pp.rb',
+    'setup/install_gatling/40_post_install/10_install_hiera_config.rb',
+    'setup/install_gatling/40_post_install/30_final_puppet_run.rb',
+    'setup/install_gatling/40_post_install/40_configure_gatling_auth.rb',
+    'setup/install_gatling/40_post_install/50_configure_permissive_server_auth.rb',
+    'setup/install_gatling/40_post_install/60_restart_server.rb',
+    'setup/install_gatling/40_post_install/70_disable_firewall.rb',
+    'setup/install_gatling/40_post_install/80_install_deps.rb',
+    'setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb',
+  ],
+  'is_puppetserver'            => true,
+  'use-service'                => true, # use service scripts to start/stop stuff
+  'puppetservice'              => 'puppetserver',
+  'puppetserver-confdir'       => '/etc/puppetlabs/puppetserver/conf.d',
+  'puppetserver-config'        => '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
+}.merge(eval File.read('setup/options/options_common.rb'))

--- a/setup/options/options_pe.rb
+++ b/setup/options/options_pe.rb
@@ -1,0 +1,26 @@
+{
+  :type                        => 'pe',
+  :pre_suite                   => [
+    'setup/install_gatling/00_pre_install/05_initialize_helpers.rb',
+    'setup/install_gatling/00_pre_install/20_rpm_setup.rb',
+    'setup/install_gatling/00_pre_install/30_r10k_git_setup.rb',
+    'setup/install_gatling/10_pe_install/10_install_pe.rb',
+    'setup/install_gatling/30_classification/10_r10k_deploy.rb',
+    'setup/install_gatling/30_classification/20_enable_file_sync.rb',
+    'setup/install_gatling/30_classification/30_sync_codedir.rb',
+    'setup/install_gatling/30_classification/40_classify_nodes_via_nc.rb',
+    'setup/install_gatling/40_post_install/10_install_hiera_config.rb',
+    'setup/install_gatling/40_post_install/30_final_puppet_run.rb',
+    'setup/install_gatling/40_post_install/40_configure_gatling_auth.rb',
+    'setup/install_gatling/40_post_install/50_configure_permissive_server_auth.rb',
+    'setup/install_gatling/40_post_install/60_restart_server.rb',
+    'setup/install_gatling/40_post_install/70_disable_firewall.rb',
+    'setup/install_gatling/40_post_install/80_install_deps.rb',
+    'setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb',
+  ],
+  'is_puppetserver'            => true,
+  'use-service'                => true, # use service scripts to start/stop stuff
+  'puppetservice'              => 'pe-puppetserver',
+  'puppetserver-confdir'       => '/etc/puppetlabs/puppetserver/conf.d',
+  'puppetserver-config'        => '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
+}.merge(eval File.read('setup/options/options_common.rb'))


### PR DESCRIPTION
This gets us closer to an easier to use setup.  It also helps because we can tell exactly which setup file is needed and in what order, for foss vs. pe.

