### PR TITLE
(SLV-100) Implement reports-only run

### DIFF
--- a/NEW_README.md
+++ b/NEW_README.md
@@ -86,7 +86,7 @@ You'll need to specify the name of the folder on the metrics node containing the
 Look in `~/gatling-puppet-load-test/simulation-runner/results` for a folder that starts with 'PerfTestLarge-' followed by the run id and verify that the folder contains a valid (non-empty) simulation.log file.
 
 If you find that the simulation.log file is not being populated during your run you may need to reduce the log buffer size from the 8kb default.
-Set `gatling.data.file.bufferSize` in gatling.conf to a smaller value like 256 (this may impact performance).
+Set `gatling.data.file.bufferSize` in `simulation-runner/gatling.conf` to a smaller value like 256 (this may impact performance).
 
 To run in reports-only mode, run as you normally would against previously provisioned hosts and set the environment variables PUPPET_GATLING_REPORTS_ONLY=true and PUPPET_GATLING_REPORTS_TARGET=<YOUR_RESULT_FOLDER>.
 

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -55,6 +55,7 @@ Assuming that you ran the performance task with no tests, you can follow the dir
     * When asked for the certname prefix enter any value containing the string ‘agent’. For example perf-agent-0
     * When asked for Puppet classes, enter the configuration which defaults to: role::by_size::large
         * You can use a different puppet class by specifying it as the `PUPPET_SCALE_CLASS` environment variable for the performance_gatling rake task.
+
 ### Getting a pre-recorded run started
 For the following steps, GatlingClassName is the value entered into the ClassName field during the recording step.
 From root of the gatling-puppet-load-test source dir on the Gatling driver (metrics):
@@ -75,3 +76,17 @@ From root of the gatling-puppet-load-test source dir on the Gatling driver (metr
     * scp them locally and you can view them in your browser.
 * atop files containing cpu, mem, disk and network usage overall and broken down per process are available to view on the mom: atop -r /var/log/atop/atop_\<date>
     * See the atop man file for interactive commands
+    
+### Aborting a test run
+The easiest way to immediately kill a test run is to kill the corresponding Java process on the metrics node. Find the process id with top and then use `kill <PID>`.
+
+### Generating reports for aborted runs
+If a Gatling scenario is aborted the reports may not be generated. In this case you can run Gatling in reports-only mode to generate the reports for a previous run. 
+You'll need to specify the name of the folder on the metrics node containing the simulation.log file for the run. 
+Look in `~/gatling-puppet-load-test/simulation-runner/results` for a folder that starts with 'PerfTestLarge-' followed by the run id and verify that the folder contains a valid simulation.log file.
+
+If you find that the simulation.log file is not being populated during your run you may need to reduce the log buffer size from the 8kb default.
+Set `gatling.data.file.bufferSize` in gatling.conf to a smaller value like 256 (this may impact performance).
+
+To run in reports-only mode set PUPPET_GATLING_REPORTS_ONLY=true and PUPPET_GATLING_REPORTS_TARGET=<YOUR_RESULT_FOLDER>. 
+After the run you should see that the report files have been generated within the result folder and copied to your local machine.

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -26,7 +26,7 @@ You can execute the 'acceptance' rake task which will run everything in VMPooler
 ### Set up Puppet Enterprise and Gatling but do not execute a gatling scenario
 Another use for the performance task would be to record and playback a new scenario either for one-off testing,
 or for a new scenario that will be checked in and used.  Additionally, you may just want to execute the setup standalone and then execute the tests later.
-* Follow the above instructions, but also `export BEAKER_TESTS=` and `BEAKER_PRESERVE_HOSTS=true` prior to executing the rake task to tell beaker not to execute any tests and preserve the machines.
+* Follow the above instructions, but also `export BEAKER_TESTS=` and `BEAKER_PRESERVE_HOSTS=always` prior to executing the rake task to tell beaker not to execute any tests and preserve the machines.
 * Depending on your use case, you can also choose to execute the 'acceptance' task which will run in vmpooler rather than AWS. This is useful when testing/debugging but not for actual performance measurement.
 
 ### Record a Gatling run:
@@ -81,12 +81,15 @@ From root of the gatling-puppet-load-test source dir on the Gatling driver (metr
 The easiest way to immediately kill a test run is to kill the corresponding Java process on the metrics node. Find the process id with top and then use `kill <PID>`.
 
 ### Generating reports for aborted runs
-If a Gatling scenario is aborted the reports may not be generated. In this case you can run Gatling in reports-only mode to generate the reports for a previous run. 
+If a Gatling scenario is aborted the reports may not be generated. In this case you can run Gatling in reports-only mode to generate the reports for a previous run (assuming that the hosts have been preserved). 
 You'll need to specify the name of the folder on the metrics node containing the simulation.log file for the run. 
-Look in `~/gatling-puppet-load-test/simulation-runner/results` for a folder that starts with 'PerfTestLarge-' followed by the run id and verify that the folder contains a valid simulation.log file.
+Look in `~/gatling-puppet-load-test/simulation-runner/results` for a folder that starts with 'PerfTestLarge-' followed by the run id and verify that the folder contains a valid (non-empty) simulation.log file.
 
 If you find that the simulation.log file is not being populated during your run you may need to reduce the log buffer size from the 8kb default.
 Set `gatling.data.file.bufferSize` in gatling.conf to a smaller value like 256 (this may impact performance).
 
-To run in reports-only mode set PUPPET_GATLING_REPORTS_ONLY=true and PUPPET_GATLING_REPORTS_TARGET=<YOUR_RESULT_FOLDER>. 
+To run in reports-only mode, run as you normally would against previously provisioned hosts and set the environment variables PUPPET_GATLING_REPORTS_ONLY=true and PUPPET_GATLING_REPORTS_TARGET=<YOUR_RESULT_FOLDER>.
+
+For example: `bundle exec rake performance_against_already_provisioned BEAKER_INSTALL_TYPE=pe BEAKER_PRE_SUITE= BEAKER_PRESERVE_HOSTS=always BEAKER_HOSTS=log/hosts_preserved.yml PUPPET_GATLING_REPORTS_ONLY=true PUPPET_GATLING_REPORTS_TARGET=PerfTestLarge-1524773045554`
+
 After the run you should see that the report files have been generated within the result folder and copied to your local machine.

--- a/rakefile
+++ b/rakefile
@@ -10,6 +10,10 @@ task :default => :performance
 
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
 rototiller_task :performance do
+  if ENV['PUPPET_GATLING_REPORTS_ONLY'] == 'true' && (!ENV['PUPPET_GATLING_REPORTS_TARGET'] || ENV['PUPPET_GATLING_REPORTS_TARGET'] == '')
+    abort 'A valid result folder (i.e. PerfTestLarge-1524848074511) must be specified for PUPPET_GATLING_REPORTS_TARGET if PUPPET_GATLING_REPORTS_ONLY=true'
+  end
+
   Rake::Task["performance_provision_with_abs"].execute unless ENV['ABS_RESOURCE_HOSTS'] ||
       (ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' && ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg')
   Rake::Task["performance_without_provision"].execute

--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/runner/PuppetGatlingRunner.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/runner/PuppetGatlingRunner.scala
@@ -25,6 +25,12 @@ object PuppetGatlingRunner {
     props.simulationClass(simClass)
     props.runDescription(config.runDescription)
     props.outputDirectoryBaseName(config.simulationId)
+
+    // This checks the values set in gatling_kickoff.rb
+    if (sys.env("PUPPET_GATLING_REPORTS_ONLY") == "true") {
+      props.reportsOnly(sys.env("PUPPET_GATLING_REPORTS_TARGET"))
+    }
+
     Gatling.fromMap(props.build)
 
   }

--- a/tests/gatling_kickoff.rb
+++ b/tests/gatling_kickoff.rb
@@ -6,11 +6,24 @@ test_name 'Kickoff Gatling' do
 
   begin
     step "Execute gatling scenario" do
+
+      # Should gatling run reports only?
+      if ENV['PUPPET_GATLING_REPORTS_ONLY'] == "true"
+        reports_only = "true"
+        reports_target = ENV['PUPPET_GATLING_REPORTS_TARGET']
+      else
+        reports_only = "false"
+        reports_target = ""
+      end
+
       on metric, "cd /root/gatling-puppet-load-test/simulation-runner/ && " +
           "PUPPET_GATLING_MASTER_BASE_URL=https://#{master.hostname}:8140 " +
           "PUPPET_GATLING_SIMULATION_CONFIG=config/scenarios/#{ENV['PUPPET_GATLING_SCENARIO']} " +
+          "PUPPET_GATLING_REPORTS_ONLY=#{reports_only} " +
+          "PUPPET_GATLING_REPORTS_TARGET=/root/gatling-puppet-load-test/simulation-runner/results/#{reports_target} " +
           "PUPPET_GATLING_SIMULATION_ID=PerfTestLarge sbt run",
          {:accept_all_exit_codes => true}
+
     end
 
   ensure


### PR DESCRIPTION
If a Gatling scenario is aborted the reports may not be generated. Gatling can be run in reports only mode to create the reports for a previous run by setting the `reportsOnly` property when running via `Gatling.fromMap(props.build)`. The path of the result folder containing a valid `simulation.log` file must be specified.

`gatling_kickoff.rb` has been updated to check the value of the environment variable `PUPPET_GATLING_REPORTS_ONLY`. If it is equal to "true" that value and the value of the `PUPPET_GATLING_REPORTS_TARGET` variable are passed with the `sbt run` command on the metrics node. Otherwise these variables are passed with "false" and "".

`PuppetGatlingRunner.scala` has been updated to check `PUPPET_GATLING_REPORTS_ONLY`; if it is equal to true the `reportsOnly` property is set with the value of `PUPPET_GATLING_REPORTS_TARGET`.

This was tested with short acceptance runs using vmpooler. One issue encountered during this testing is that the `simulation.log` file was not actually populated with data during the run. When beaker was aborted locally Gatling would actually complete the run on the metrics node, then populate the log file and generate the reports. If the run was aborted by killing the Java process on the metrics node the result was an empty log file. Attempting to run reports for an empty log file results in an exception.

It turns out the default buffer for the log file was too large. Setting `gatling.data.file.bufferSize` to 256 in `gatling.conf` allowed the log file to be populated during a short acceptance run. In this case the reports only run is successful and the reports are generated and copied locally as expected.