### PR TITLE
(maint) updated BEAKER_HOSTS check in performance task

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -11,7 +11,9 @@ task :default => :performance
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
 rototiller_task :performance do
   Rake::Task["performance_provision_with_abs"].execute unless ENV['ABS_RESOURCE_HOSTS'] ||
-      (ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' && ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg')
+      (ENV['BEAKER_HOSTS'] &&
+          ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' &&
+          ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg')
   Rake::Task["performance_without_provision"].execute
   Rake::Task["performance_deprovision_with_abs"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' ||
       ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0)&&


### PR DESCRIPTION
After the previous fix to the BEAKER_HOSTS check in performance_provision_with_abs the acceptance task works as expected if BEAKER_HOSTS is not specified as this task provides a default. However, the performance task fails when BEAKER_HOSTS isn't specified because the default isn't set until later in performance_without_provision, so performance_provision_with_abs is never executed. 

This fix updates the performance task to only skip calling performance_provision_with_abs if BEAKER_HOSTS is specified but is not pe-perf-test.cfg or foss-perf-test.cfg. With this fix you can run the performance task without specifying BEAKER_HOSTS and the default value will be used based on the value specified for BEAKER_INSTALL_TYPE (as expected).