### PR TITLE
(SLV-112) update rakefile to use abs token

### DIFF
--- a/NEW_README.md
+++ b/NEW_README.md
@@ -6,8 +6,15 @@ At the end of the run, the gatling results and atop results will be copied back 
 
 * Clone the gatling-puppet-load-test repo locally: https://github.com/puppetlabs/gatling-puppet-load-test
 * cd into the gatling-puppet-load-test root directory
-* For apples to apples runs, you can use the checked-in hosts files: pe-perf-test.cfg or foss-perf-test.cfg (default for the performance rake task).
-* In order for us to take advantage of the new AWS account with access to internal network resources, you need to use ABS. The 'performance' task will automatically use ABS to provision 2 AWS instances and then execute tests against those instances.
+* For apples to apples runs, you can use the checked-in hosts files: [pe-perf-test.cfg](config/pe-perf-test.cfg) or [foss-perf-test.cfg](/config/foss-perf-test.cfg) (default for the performance rake task).
+* In order for us to take advantage of the new AWS account with access to internal network resources, you need to use [ABS](https://github.com/puppetlabs/always-be-scheduling). The 'performance' task will automatically use ABS to provision 2 AWS instances and then execute tests against those instances.
+* ABS requires a token when making requests. See the [Token operations](https://github.com/puppetlabs/always-be-scheduling#token-operations) section of the ABS README file for instructions to generate a token. 
+Once generated, either set the ABS_TOKEN environment variable with your token or add it to the .fog file in your home directory using the abs_token parameter. For example:
+```
+:default:
+  :abs_token: <your abs token>
+```
+
 * To run additional tests against an existing set of hosts, run the performance_against_already_provisioned task. This task is only intended to be run against the very latest set of provisioned hosts.
 * If the hosts are preserved via Beaker's 'preserve_hosts' setting, then you will need to manually execute the 'performance_deprovision_with_abs' rake task when you are done with the hosts.
 * For a run against a PE build set BEAKER_INSTALL_TYPE=pe and provide values for BEAKER_PE_VER and BEAKER_PE_DIR environment variables

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -6,7 +6,7 @@ At the end of the run, the gatling results and atop results will be copied back 
 
 * Clone the gatling-puppet-load-test repo locally: https://github.com/puppetlabs/gatling-puppet-load-test
 * cd into the gatling-puppet-load-test root directory
-* For apples to apples runs, you can use the checked-in hosts files: [pe-perf-test.cfg](config/pe-perf-test.cfg) or [foss-perf-test.cfg](/config/foss-perf-test.cfg) (default for the performance rake task).
+* For apples to apples runs, you can use the checked-in hosts files: [pe-perf-test.cfg](config/pe-perf-test.cfg) or [foss-perf-test.cfg](/config/foss-perf-test.cfg). These are the defaults for the performance rake task based on the specified BEAKER_INSTALL_TYPE (pe or foss).
 * In order for us to take advantage of the new AWS account with access to internal network resources, you need to use [ABS](https://github.com/puppetlabs/always-be-scheduling). The 'performance' task will automatically use ABS to provision 2 AWS instances and then execute tests against those instances.
 * ABS requires a token when making requests. See the [Token operations](https://github.com/puppetlabs/always-be-scheduling#token-operations) section of the ABS README file for instructions to generate a token. 
 Once generated, either set the ABS_TOKEN environment variable with your token or add it to the .fog file in your home directory using the abs_token parameter. For example:

--- a/rakefile
+++ b/rakefile
@@ -28,21 +28,27 @@ end
 def get_abs_token_from_fog_file
   home = ENV['HOME']
   fog_path = "#{home}/.fog"
+  token = nil
+
   if File.exist?(fog_path)
     fog = YAML.load(File.read(fog_path))
+    token = fog[:default][:abs_token]
   else
-    abort ".fog file not found in home directory: #{fog_path}"
+    puts ".fog file not found in home directory: #{fog_path}"
   end
 
-  token = fog[:default][:abs_token]
   if !token
-    abort "ABS token not found in .fog file at #{fog_path}"
+    puts "ABS token not found in .fog file at #{fog_path}"
   end
   token
 end
 
 def get_abs_token
-  ENV['ABS_TOKEN'] || get_abs_token_from_fog_file
+  ENV['ABS_TOKEN'] ? token = ENV['ABS_TOKEN'] : token = get_abs_token_from_fog_file
+  if !token
+    abort "An ABS token must be set in either the ABS_TOKEN environment variable or the abs_token parameter in the .fog file"
+  end
+  token
 end
 
 def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])

--- a/rakefile
+++ b/rakefile
@@ -3,6 +3,7 @@ require 'rspec/core/rake_task'
 require 'net/http'
 require 'timeout'
 require 'json'
+require 'yaml'
 
 BASE_ABS_URI = 'https://cinext-abs.delivery.puppetlabs.net/api/v2/'
 
@@ -24,8 +25,28 @@ rototiller_task :performance do
           ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
 end
 
+def get_abs_token_from_fog_file
+  home = ENV['HOME']
+  fog_path = "#{home}/.fog"
+  if File.exist?(fog_path)
+    fog = YAML.load(File.read(fog_path))
+  else
+    abort ".fog file not found in home directory: #{fog_path}"
+  end
+
+  token = fog[:default][:abs_token]
+  if !token
+    abort "ABS token not found in .fog file at #{fog_path}"
+  end
+  token
+end
+
+def get_abs_token
+  ENV['ABS_TOKEN'] || get_abs_token_from_fog_file
+end
+
 def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])
-  req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
+  req = Net::HTTP::Post.new(uri, {'Content-Type' => 'application/json', 'X-Auth-Token' => get_abs_token})
   req.body = body
   http = Net::HTTP.new(uri.host, uri.port)
   http.use_ssl = true


### PR DESCRIPTION
ABS now requires a token when making a request. The most common ways to store a token locally are in an environment variable or the user's .fog file.

`retry_abs_request` has been updated to call `get_abs_token` which first checks the ABS_TOKEN environment variable, then checks the user's .fog file for the `abs_token` parameter. If not found the test will abort.
