### PR TITLE
(SLV-77) Add report-utils

### DIFF
--- a/report-utils/README.md
+++ b/report-utils/README.md
@@ -1,0 +1,87 @@
+## Report Utilities
+
+Gatling produces a detailed HTML report from the simulation.log file. 
+However, our Apples to Apples test reports include a summarized comparison of the data from two test runs.
+Producing this report currently requires manually copying the data from each HTML report into the corresponding table in a Google Sheets doc.
+
+These utility scripts have been created to assist in that process. They are a work-in-progress. Some manual steps are still required, but this gets us closer to a fully automated process.
+
+#### extract-csv.rb
+
+This script parses the JSON results file for a specified test run and creates a CSV file with the data used in our Apples to Apples test report.
+
+How to use it:
+
+In this example the result folder for our performance run will be `gatling-puppet-load-test/PERF_1524862584`. 
+`PERF_1524862584` contains the following folders:
+
+* `ip-10-227-0-132.amz-dev.puppet.net`
+* `ip-10-227-3-213.amz-dev.puppet.net`
+
+If you know which is your metrics node, start there; otherwise, it will be the one containing a `root` folder.
+In our example the metrics node is `ip-10-227-0-132.amz-dev.puppet.net`. You'll need to provide the script with the full path to the result folder, for example:
+
+```
+bill.claytor:~> cd /Users/bill.claytor/RubymineProjects/gatling-puppet-load-test/report-utils 
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ls
+README.md		compare-results.rb	extract-csv.rb
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ruby extract-csv.rb /Users/bill.claytor/RubymineProjects/gatling-puppet-load-test/PERF_1524862584/ip-10-227-0-132.amz-dev.puppet.net/root/gatling-puppet-load-test/simulation-runner/results/PerfTestLarge-1524848074511
+Creating PerfTestLarge-1524848074511.csv
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ls
+PerfTestLarge-1524848074511.csv	README.md			compare-results.rb		extract-csv.rb
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> 
+
+```
+
+If the script succeeds, a CSV file with the name of the performance run will be created. 
+In this example the file is 'PerfTestLarge-1524848074511.csv'. 
+
+#### compare-results.rb
+
+This script parses two CSV files created by extract-csv.rb (or using the same format) and creates a comparison CSV file. 
+In the previous example we used the result folder `gatling-puppet-load-test/PERF_1524862584` which created the CSV file 'PerfTestLarge-1524848074511.csv'.
+We'll use this as the 'A' in our 'A to B' comparison. In this example the 'B' results folder is `gatling-puppet-load-test/PERF_1525125295`.
+
+```
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ruby extract-csv.rb /Users/bill.claytor/RubymineProjects/gatling-puppet-load-test/PERF_1525125295/ip-10-227-1-189.amz-dev.puppet.net/root/gatling-puppet-load-test/simulation-runner/results/PerfTestLarge-1525110786021
+Creating PerfTestLarge-1525110786021.csv
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ls
+PerfTestLarge-1524848074511.csv	README.md			extract-csv.rb
+PerfTestLarge-1525110786021.csv	compare-results.rb
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> 
+
+```
+
+Running extract-csv.rb against our second test results folder produced the 'PerfTestLarge-1525110786021.csv' file.
+
+Run compare-results.rb by providing it with the CSV files to compare:
+
+`ruby compare-results.rb A.csv B.csv`
+
+Be sure to specify the A and B result files in the right order.
+
+For example:
+
+```
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ls
+PerfTestLarge-1524848074511.csv	PerfTestLarge-1525110786021.csv	README.md			compare-results.rb		extract-csv.rb
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ruby compare-results.rb PerfTestLarge-1524848074511.csv PerfTestLarge-1525110786021.csv
+Comparing PerfTestLarge-1524848074511 and PerfTestLarge-1525110786021
+Creating PerfTestLarge-1524848074511_vs_PerfTestLarge-1525110786021.csv
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> ls
+PerfTestLarge-1524848074511.csv					README.md
+PerfTestLarge-1524848074511_vs_PerfTestLarge-1525110786021.csv	compare-results.rb
+PerfTestLarge-1525110786021.csv					extract-csv.rb
+bill.claytor:~/RubymineProjects/gatling-puppet-load-test/report-utils> 
+```
+
+In this example the file 'PerfTestLarge-1524848074511_vs_PerfTestLarge-1525110786021.csv' was created. 
+This file is structured to match the test report template so you should be able to copy and paste all of the values at once.
+I created a Google Sheets template to use as an intermediate step for easier formatting:
+
+https://docs.google.com/spreadsheets/d/1H731HTm-l6Uk_aIxu-Z0aCw_HPK6GB0rRcBAiPiX1-w/edit?usp=sharing
+
+Make a copy of this template and paste the data cells from the CSV file into it using 'Paste Special / Values Only'. 
+Then copy the updated table and paste it into the Google Doc for your Apples to Apples test report.
+
+Future updates will fix bugs, address pain points, and remove manual steps. 

--- a/report-utils/compare-results.rb
+++ b/report-utils/compare-results.rb
@@ -1,0 +1,32 @@
+require 'csv'
+
+def diff(a, b)
+  result = ( (b.to_f - a.to_f) / a.to_f ) * 100
+  "#{result.round(2).to_s}%"
+end
+
+raise Exception, 'you must provide two csv files to compare' unless ARGV[1]
+
+result_a_name = ARGV[0].split('/')[ARGV[0].split('/').length - 1].gsub('.csv','')
+result_b_name = ARGV[1].split('/')[ARGV[1].split('/').length - 1].gsub('.csv','')
+comp_name = "#{result_a_name}_vs_#{result_b_name}.csv"
+
+puts "Comparing #{result_a_name} and #{result_b_name}"
+puts "Creating #{comp_name}"
+
+result_a = CSV.read(ARGV[0])
+result_b = CSV.read(ARGV[1])
+
+CSV.open("./#{comp_name}", "wb") do |csv|
+  csv << ['','A', '', '', 'B', '', '']
+  csv << ["Duration", "max ms", "mean ms", "std dev", "max ms", "mean ms", "std dev", "% (mean) diff"]
+
+  csv << ["Total", result_a[1][1], result_a[1][2], result_a[1][3], result_b[1][1], result_b[1][2], result_b[1][3], diff(result_a[1][2], result_b[1][2])]
+  csv << ["catalog", result_a[2][1], result_a[2][2], result_a[2][3], result_b[2][1], result_b[2][2], result_b[2][3], diff(result_a[2][2], result_b[2][2])]
+  csv << ["filemeta mco plugins", result_a[3][1], result_a[3][2], result_a[3][3], result_b[3][1], result_b[3][2], result_b[3][3], diff(result_a[3][2], result_b[3][2])]
+  csv << ["filemeta plugins", result_a[4][1], result_a[4][2], result_a[4][3], result_b[4][1], result_b[4][2], result_b[4][3], diff(result_a[4][2], result_b[4][2])]
+  csv << ["filemeta pluginfacts", result_a[5][1], result_a[5][2], result_a[5][3], result_b[5][1], result_b[5][2], result_b[5][3], diff(result_a[5][2], result_b[5][2])]
+  csv << ["locales", result_a[1][1], result_a[6][2], result_a[6][3], result_b[6][1], result_b[6][2], result_b[6][3], diff(result_a[6][2], result_b[6][2])]
+  csv << ["node", result_a[7][1], result_a[7][2], result_a[7][3], result_b[7][1], result_b[7][2], result_b[7][3], diff(result_a[7][2], result_b[7][2])]
+  csv << ["report", result_a[8][1], result_a[8][2], result_a[8][3], result_b[8][1], result_b[8][2], result_b[8][3], diff(result_a[8][2], result_b[8][2])]
+end

--- a/report-utils/extract-csv.rb
+++ b/report-utils/extract-csv.rb
@@ -1,0 +1,46 @@
+require 'json'
+require 'csv'
+
+raise Exception, 'you must provide a result folder' unless ARGV[0]
+
+result_folder_name = ARGV[0].split('/')[ARGV[0].split('/').length - 1]
+
+puts "Creating #{result_folder_name}.csv"
+
+stats_path = ARGV[0] + '/js/stats.json'
+stats = JSON.parse(File.open(stats_path).read)
+
+# the 'group' name will be something like 'group_nooptestwithout-9eb19'
+group_keys = stats['contents'].keys.select { |key| key.to_s.match(/group/) }
+group_node = stats['contents'][group_keys[0]]
+
+MAX = 'maxResponseTime'
+MEAN = 'meanResponseTime'
+STD = 'standardDeviation'
+TOTAL = 'total'
+
+# totals row is in the 'stats' node
+totals = group_node['stats']
+
+# transaction rows are in the 'contents' node
+contents = group_node['contents']
+
+catalog = contents[contents.keys[4]]['stats']
+filemeta_mco_plugins = contents[contents.keys[5]]['stats']
+filemeta_plugins = contents[contents.keys[2]]['stats']
+filemeta_pluginfacts = contents[contents.keys[1]]['stats']
+locales = contents[contents.keys[3]]['stats']
+node = contents[contents.keys[0]]['stats']
+report = contents[contents.keys[6]]['stats']
+
+CSV.open("./#{result_folder_name}.csv", "wb") do |csv|
+  csv << ["Duration","max ms","mean ms","std dev"]
+  csv << ["Total", totals[MAX][TOTAL], totals[MEAN][TOTAL], totals[STD][TOTAL]]
+  csv << ["catalog", catalog[MAX][TOTAL], catalog[MEAN][TOTAL], catalog[STD][TOTAL]]
+  csv << ["filemeta mco plugins", filemeta_mco_plugins[MAX][TOTAL], filemeta_mco_plugins[MEAN][TOTAL], filemeta_mco_plugins[STD][TOTAL]]
+  csv << ["filemeta plugins", filemeta_plugins[MAX][TOTAL], filemeta_plugins[MEAN][TOTAL], filemeta_plugins[STD][TOTAL]]
+  csv << ["filemeta pluginfacts", filemeta_pluginfacts[MAX][TOTAL], filemeta_pluginfacts[MEAN][TOTAL], filemeta_pluginfacts[STD][TOTAL]]
+  csv << ["locales", locales[MAX][TOTAL], locales[MEAN][TOTAL], locales[STD][TOTAL]]
+  csv << ["node", node[MAX][TOTAL], node[MEAN][TOTAL], node[STD][TOTAL]]
+  csv << ["report", report[MAX][TOTAL], report[MEAN][TOTAL], report[STD][TOTAL]]
+end


### PR DESCRIPTION
This update adds the extract-csv.rb and compare-results.rb utilities used to extract result data from the Gatling HTML report (actually the JSON files used by the HTML report) and compare the data from two runs. This is a work in progress but I wanted to make these available for other team members to use.

Please see the README.md file for more details and instructions for use.