### PR TITLE
(SLV-122) Add abs_helper and spec, update rakefile to use awsdirect endpoints

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -47,7 +47,7 @@ end
 # TODO: replace original version and remove '_awsdirect'
 desc 'Task to deprovision systems that were provisioned with ABS - included in the performance task following the rules of BEAKER_PRESERVE_HOSTS env var.'
 rototiller_task :performance_deprovision_with_abs_awsdirect do
-  abs_resource_hosts = return_abs_resource_hosts
+  abs_resource_hosts = abs_return_resource_hosts
   raise 'Failed to deprovision ABS hosts' unless abs_resource_hosts
 end
 

--- a/rakefile
+++ b/rakefile
@@ -1,6 +1,5 @@
 require 'rototiller'
 require 'rspec/core/rake_task'
-require 'net/http'
 
 require './setup/helpers/abs_helper'
 include AbsHelper

--- a/rakefile
+++ b/rakefile
@@ -5,9 +5,53 @@ require 'timeout'
 require 'json'
 require 'yaml'
 
+require './setup/helpers/abs_helper'
+include AbsHelper
+
 BASE_ABS_URI = 'https://cinext-abs.delivery.puppetlabs.net/api/v2/'
 
 task :default => :performance
+
+# temporary alternate versions of the performace tasks that use awsdirect
+
+# TODO: replace original version and remove '_awsdirect'
+desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
+rototiller_task :performance_awsdirect do
+  if ENV['PUPPET_GATLING_REPORTS_ONLY'] == 'true' && (!ENV['PUPPET_GATLING_REPORTS_TARGET'] || ENV['PUPPET_GATLING_REPORTS_TARGET'] == '')
+    abort 'A valid result folder (i.e. PerfTestLarge-1524848074511) must be specified for PUPPET_GATLING_REPORTS_TARGET if PUPPET_GATLING_REPORTS_ONLY=true'
+  end
+
+  Rake::Task["performance_provision_with_abs_awsdirect"].execute unless ENV['ABS_RESOURCE_HOSTS'] ||
+      (ENV['BEAKER_HOSTS'] &&
+          ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' &&
+          ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg')
+  Rake::Task["performance_without_provision"].execute
+  Rake::Task["performance_deprovision_with_abs_awsdirect"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' ||
+      ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0)&&
+          ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
+end
+
+# TODO: replace original version and remove '_awsdirect'
+desc 'Provision systems for the performance task with ABS - included in the performance task'
+rototiller_task :performance_provision_with_abs_awsdirect do |t|
+  raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
+      ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
+  t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
+  t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
+  t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
+
+  abs_resource_hosts = abs_get_resource_hosts
+  raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
+end
+
+# TODO: replace original version and remove '_awsdirect'
+desc 'Task to deprovision systems that were provisioned with ABS - included in the performance task following the rules of BEAKER_PRESERVE_HOSTS env var.'
+rototiller_task :performance_deprovision_with_abs_awsdirect do
+  abs_resource_hosts = return_abs_resource_hosts
+  raise 'Failed to deprovision ABS hosts' unless abs_resource_hosts
+end
+
+#######
 
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
 rototiller_task :performance do
@@ -25,60 +69,61 @@ rototiller_task :performance do
           ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
 end
 
-def get_abs_token_from_fog_file
-  home = ENV['HOME']
-  fog_path = "#{home}/.fog"
-  token = nil
-
-  if File.exist?(fog_path)
-    fog = YAML.load(File.read(fog_path))
-    token = fog[:default][:abs_token]
-  else
-    puts ".fog file not found in home directory: #{fog_path}"
-  end
-
-  if !token
-    puts "ABS token not found in .fog file at #{fog_path}"
-  end
-  token
-end
-
-def get_abs_token
-  ENV['ABS_TOKEN'] ? token = ENV['ABS_TOKEN'] : token = get_abs_token_from_fog_file
-  if !token
-    abort "An ABS token must be set in either the ABS_TOKEN environment variable or the abs_token parameter in the .fog file"
-  end
-  token
-end
-
-def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])
-  req = Net::HTTP::Post.new(uri, {'Content-Type' => 'application/json', 'X-Auth-Token' => get_abs_token})
-  req.body = body
-  http = Net::HTTP.new(uri.host, uri.port)
-  http.use_ssl = true
-
-  puts "sending request body: #{body}"
-  puts "to uri: #{uri}"
-
-  res = nil
-  Timeout::timeout(timeout) do
-    while res.nil? || invalid_response_bodies.include?(res.body) || !valid_response_codes.include?(res.code)
-      begin
-        res = http.request(req)
-      rescue => ex
-        puts ex
-        puts ex.backtrace
-      end
-      if res.nil? || invalid_response_bodies.include?(res.body)
-        puts "#{Time.now} - Retrying ABS request..."
-        sleep(time_increment)
-      else
-        break
-      end
-    end
-  end
-  res
-end
+# TODO: remove; these have been extracted to abs_helper
+# def get_abs_token_from_fog_file
+#   home = ENV['HOME']
+#   fog_path = "#{home}/.fog"
+#   token = nil
+#
+#   if File.exist?(fog_path)
+#     fog = YAML.load(File.read(fog_path))
+#     token = fog[:default][:abs_token]
+#   else
+#     puts ".fog file not found in home directory: #{fog_path}"
+#   end
+#
+#   if !token
+#     puts "ABS token not found in .fog file at #{fog_path}"
+#   end
+#   token
+# end
+#
+# def get_abs_token
+#   ENV['ABS_TOKEN'] ? token = ENV['ABS_TOKEN'] : token = get_abs_token_from_fog_file
+#   if !token
+#     abort "An ABS token must be set in either the ABS_TOKEN environment variable or the abs_token parameter in the .fog file"
+#   end
+#   token
+# end
+#
+# def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])
+#   req = Net::HTTP::Post.new(uri, {'Content-Type' => 'application/json', 'X-Auth-Token' => get_abs_token})
+#   req.body = body
+#   http = Net::HTTP.new(uri.host, uri.port)
+#   http.use_ssl = true
+#
+#   puts "sending request body: #{body}"
+#   puts "to uri: #{uri}"
+#
+#   res = nil
+#   Timeout::timeout(timeout) do
+#     while res.nil? || invalid_response_bodies.include?(res.body) || !valid_response_codes.include?(res.code)
+#       begin
+#         res = http.request(req)
+#       rescue => ex
+#         puts ex
+#         puts ex.backtrace
+#       end
+#       if res.nil? || invalid_response_bodies.include?(res.body)
+#         puts "#{Time.now} - Retrying ABS request..."
+#         sleep(time_increment)
+#       else
+#         break
+#       end
+#     end
+#   end
+#   res
+# end
 
 desc 'Provision systems for the performance task with ABS - included in the performance task'
 rototiller_task :performance_provision_with_abs do |t|
@@ -119,6 +164,7 @@ rototiller_task :performance_deprovision_with_abs do
   retry_abs_request(uri, req_body, 30, 5)
 end
 
+desc 'Run Performance tests using previously provisioned hosts'
 rototiller_task :performance_against_already_provisioned do
   ENV['BEAKER_HOSTS'] ||= "log/latest/hosts_preserved.yml"
   ENV['ABS_RESOURCE_HOSTS'] = File.open("last_abs_resource_hosts.log").readlines[0] if File.exist? "last_abs_resource_hosts.log"

--- a/rakefile
+++ b/rakefile
@@ -1,9 +1,6 @@
 require 'rototiller'
 require 'rspec/core/rake_task'
 require 'net/http'
-require 'timeout'
-require 'json'
-require 'yaml'
 
 require './setup/helpers/abs_helper'
 include AbsHelper

--- a/rakefile
+++ b/rakefile
@@ -30,16 +30,16 @@ rototiller_task :performance_provision_with_abs do |t|
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
 
-  abs_resource_hosts = abs_get_resource_hosts(abs_get_a2a_hosts)
+  abs_resource_hosts = get_abs_resource_hosts(get_a2a_hosts)
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end
 
 desc 'Task to de-provision systems that were provisioned with ABS - included in the performance task following the rules of BEAKER_PRESERVE_HOSTS env var.'
 rototiller_task :performance_deprovision_with_abs do
-  abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? abs_get_last_abs_resource_hosts : ENV['ABS_RESOURCE_HOSTS']
+  abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? get_last_abs_resource_hosts : ENV['ABS_RESOURCE_HOSTS']
   raise 'This task requires an array of hostnames to be specified via the ABS_RESOURCE_HOSTS environment variable or the last_abs_resource_hosts.log file' unless abs_resource_hosts
 
-  returned_hosts = abs_return_resource_hosts(abs_resource_hosts)
+  returned_hosts = return_abs_resource_hosts(abs_resource_hosts)
   raise 'Failed to de-provision ABS hosts' unless returned_hosts == abs_resource_hosts
 end
 

--- a/rakefile
+++ b/rakefile
@@ -5,8 +5,6 @@ require 'net/http'
 require './setup/helpers/abs_helper'
 include AbsHelper
 
-BASE_ABS_URI = 'https://cinext-abs.delivery.puppetlabs.net/api/v2/'
-
 task :default => :performance
 
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
@@ -33,7 +31,7 @@ rototiller_task :performance_provision_with_abs do |t|
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
 
-  abs_resource_hosts = abs_get_resource_hosts
+  abs_resource_hosts = abs_get_resource_hosts(abs_get_a2a_hosts)
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end
 
@@ -42,8 +40,8 @@ rototiller_task :performance_deprovision_with_abs do
   abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? abs_get_last_abs_resource_hosts : ENV['ABS_RESOURCE_HOSTS']
   raise 'This task requires an array of hostnames to be specified via the ABS_RESOURCE_HOSTS environment variable or the last_abs_resource_hosts.log file' unless abs_resource_hosts
 
-  abs_returned_hosts = abs_return_resource_hosts(abs_resource_hosts)
-  raise 'Failed to de-provision ABS hosts' unless abs_returned_hosts
+  returned_hosts = abs_return_resource_hosts(abs_resource_hosts)
+  raise 'Failed to de-provision ABS hosts' unless returned_hosts == abs_resource_hosts
 end
 
 desc 'Run Performance tests using previously provisioned hosts'

--- a/rakefile
+++ b/rakefile
@@ -12,47 +12,6 @@ BASE_ABS_URI = 'https://cinext-abs.delivery.puppetlabs.net/api/v2/'
 
 task :default => :performance
 
-# temporary alternate versions of the performace tasks that use awsdirect
-
-# TODO: replace original version and remove '_awsdirect'
-desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
-rototiller_task :performance_awsdirect do
-  if ENV['PUPPET_GATLING_REPORTS_ONLY'] == 'true' && (!ENV['PUPPET_GATLING_REPORTS_TARGET'] || ENV['PUPPET_GATLING_REPORTS_TARGET'] == '')
-    abort 'A valid result folder (i.e. PerfTestLarge-1524848074511) must be specified for PUPPET_GATLING_REPORTS_TARGET if PUPPET_GATLING_REPORTS_ONLY=true'
-  end
-
-  Rake::Task["performance_provision_with_abs_awsdirect"].execute unless ENV['ABS_RESOURCE_HOSTS'] ||
-      (ENV['BEAKER_HOSTS'] &&
-          ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' &&
-          ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg')
-  Rake::Task["performance_without_provision"].execute
-  Rake::Task["performance_deprovision_with_abs_awsdirect"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' ||
-      ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0)&&
-          ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
-end
-
-# TODO: replace original version and remove '_awsdirect'
-desc 'Provision systems for the performance task with ABS - included in the performance task'
-rototiller_task :performance_provision_with_abs_awsdirect do |t|
-  raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
-      ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
-  t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
-  t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
-  t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
-
-  abs_resource_hosts = abs_get_resource_hosts
-  raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
-end
-
-# TODO: replace original version and remove '_awsdirect'
-desc 'Task to deprovision systems that were provisioned with ABS - included in the performance task following the rules of BEAKER_PRESERVE_HOSTS env var.'
-rototiller_task :performance_deprovision_with_abs_awsdirect do
-  abs_resource_hosts = abs_return_resource_hosts
-  raise 'Failed to deprovision ABS hosts' unless abs_resource_hosts
-end
-
-#######
-
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
 rototiller_task :performance do
   if ENV['PUPPET_GATLING_REPORTS_ONLY'] == 'true' && (!ENV['PUPPET_GATLING_REPORTS_TARGET'] || ENV['PUPPET_GATLING_REPORTS_TARGET'] == '')
@@ -69,99 +28,25 @@ rototiller_task :performance do
           ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
 end
 
-# TODO: remove; these have been extracted to abs_helper
-# def get_abs_token_from_fog_file
-#   home = ENV['HOME']
-#   fog_path = "#{home}/.fog"
-#   token = nil
-#
-#   if File.exist?(fog_path)
-#     fog = YAML.load(File.read(fog_path))
-#     token = fog[:default][:abs_token]
-#   else
-#     puts ".fog file not found in home directory: #{fog_path}"
-#   end
-#
-#   if !token
-#     puts "ABS token not found in .fog file at #{fog_path}"
-#   end
-#   token
-# end
-#
-# def get_abs_token
-#   ENV['ABS_TOKEN'] ? token = ENV['ABS_TOKEN'] : token = get_abs_token_from_fog_file
-#   if !token
-#     abort "An ABS token must be set in either the ABS_TOKEN environment variable or the abs_token parameter in the .fog file"
-#   end
-#   token
-# end
-#
-# def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])
-#   req = Net::HTTP::Post.new(uri, {'Content-Type' => 'application/json', 'X-Auth-Token' => get_abs_token})
-#   req.body = body
-#   http = Net::HTTP.new(uri.host, uri.port)
-#   http.use_ssl = true
-#
-#   puts "sending request body: #{body}"
-#   puts "to uri: #{uri}"
-#
-#   res = nil
-#   Timeout::timeout(timeout) do
-#     while res.nil? || invalid_response_bodies.include?(res.body) || !valid_response_codes.include?(res.code)
-#       begin
-#         res = http.request(req)
-#       rescue => ex
-#         puts ex
-#         puts ex.backtrace
-#       end
-#       if res.nil? || invalid_response_bodies.include?(res.body)
-#         puts "#{Time.now} - Retrying ABS request..."
-#         sleep(time_increment)
-#       else
-#         break
-#       end
-#     end
-#   end
-#   res
-# end
-
 desc 'Provision systems for the performance task with ABS - included in the performance task'
 rototiller_task :performance_provision_with_abs do |t|
   raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
       ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
   t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
-
   t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
-  # Creating a random job id, since this is required by ABS and needs to be unique. In CI, this task will not be executed.
-  ENV['ABS_JOB_ID'] = rand(100000..999999).to_s unless ENV['ABS_JOB_ID']
-  uri = URI("#{BASE_ABS_URI}request")
 
-  # Allows us to switch between AWS and VMPooler by selecting different ABS os's.
-  # centos-7-x86-64-west is an AWS image, centos-7-x86_64 is vmpooler
-  req_body = {'resources': {"#{ENV['ABS_OS']}": 2},'job': { 'id': "#{ENV['ABS_JOB_ID']}", 'tags': {'user': "#{ENV['USER']}"}}}.to_json
-
-  # Wait up to 20 minutes for a response from ABS with provisioned hosts
-  res = retry_abs_request(uri, req_body, 1200, 10, ['', nil])
-
-  ENV['ABS_RESOURCE_HOSTS'] = res.body
-  puts "ABS_RESOURCE_HOSTS=#{ENV['ABS_RESOURCE_HOSTS']}"
-  open('last_abs_resource_hosts.log', 'w') { |f|
-    f.puts res.body
-    f.puts ENV['ABS_JOB_ID']
-  }
+  abs_resource_hosts = abs_get_resource_hosts
+  raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end
 
-desc 'Task to deprovision systems that were provisioned with ABS - included in the performance task following the rules of BEAKER_PRESERVE_HOSTS env var.'
+desc 'Task to de-provision systems that were provisioned with ABS - included in the performance task following the rules of BEAKER_PRESERVE_HOSTS env var.'
 rototiller_task :performance_deprovision_with_abs do
-  abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? File.open("last_abs_resource_hosts.log").readlines[0] : ENV['ABS_RESOURCE_HOSTS']
-  abs_job_id = ENV['ABS_JOB_ID'].nil? ? File.open("last_abs_resource_hosts.log").readlines[1] : ENV['ABS_JOB_ID']
-  raise 'performance_deprovision_with_abs task requires values for env variables: ABS_RESOURCE_HOSTS and ABS_JOB_ID' unless abs_resource_hosts && abs_job_id
-  uri = URI("#{BASE_ABS_URI}return")
-  req_body = {'job_id': abs_job_id, 'hosts': JSON.parse(abs_resource_hosts)}.to_json
+  abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? abs_get_last_abs_resource_hosts : ENV['ABS_RESOURCE_HOSTS']
+  raise 'This task requires an array of hostnames to be specified via the ABS_RESOURCE_HOSTS environment variable or the last_abs_resource_hosts.log file' unless abs_resource_hosts
 
-  # Wait up to 30 seconds for a non error response from ABS when de-provisioning
-  retry_abs_request(uri, req_body, 30, 5)
+  abs_returned_hosts = abs_return_resource_hosts(abs_resource_hosts)
+  raise 'Failed to de-provision ABS hosts' unless abs_returned_hosts
 end
 
 desc 'Run Performance tests using previously provisioned hosts'

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -1,0 +1,284 @@
+require 'net/http'
+require 'timeout'
+require 'json'
+require 'yaml'
+
+module AbsHelper
+
+  # TODO: replace when ready
+  #ABS_BASE_URL = 'https://cinext-abs.delivery.puppetlabs.net/api/v2'
+  ABS_BASE_URL = 'https://cinext-abs-test.delivery.puppetlabs.net/api/v2'
+
+  ABS_AWS_PLATFORM = 'el-7-x86_64'
+  ABS_AWS_IMAGE_ID = 'ami-1b17242b'
+  ABS_AWS_SIZE = 'c4.2xlarge'
+  ABS_AWS_MOM_SIZE = 'c4.2xlarge'
+  ABS_AWS_METRICS_SIZE = 'c4.2xlarge'
+  ABS_AWS_REGION = 'us-west-2'
+
+  ABS_BEAKER_TYPE = 'centos-7-x86-64-west'
+  ABS_BEAKER_ENGINE = 'aws'
+
+  # TODO: replace when ready
+  # ABS_AWS_REAP_TIME = '86400'
+  ABS_AWS_REAP_TIME = '1200'
+
+  def abs_get_base_url
+    ENV['ABS_BASE_URL'] = ABS_BASE_URL unless ENV['ABS_BASE_URL']
+    ENV['ABS_BASE_URL']
+  end
+
+  def abs_get_aws_platform
+    ENV['ABS_AWS_PLATFORM'] = ABS_AWS_PLATFORM unless ENV['ABS_AWS_PLATFORM']
+    ENV['ABS_AWS_PLATFORM']
+  end
+
+  def abs_get_aws_image_id
+    ENV['ABS_AWS_IMAGE_ID'] = ABS_AWS_IMAGE_ID unless ENV['ABS_AWS_IMAGE_ID']
+    ENV['ABS_AWS_IMAGE_ID']
+  end
+
+  def abs_get_aws_size
+    ENV['ABS_AWS_SIZE'] = ABS_AWS_SIZE unless ENV['ABS_AWS_SIZE']
+    ENV['ABS_AWS_SIZE']
+  end
+
+  def abs_get_aws_region
+    ENV['ABS_AWS_REGION'] = ABS_AWS_REGION unless ENV['ABS_AWS_REGION']
+    ENV['ABS_AWS_REGION']
+  end
+
+  def abs_get_aws_reap_time
+    ENV['ABS_AWS_REAP_TIME'] = ABS_AWS_REAP_TIME unless ENV['ABS_AWS_REAP_TIME']
+    ENV['ABS_AWS_REAP_TIME']
+  end
+
+  def abs_get_aws_mom_size
+    ENV['ABS_AWS_MOM_SIZE'] = ABS_AWS_MOM_SIZE unless ENV['ABS_AWS_MOM_SIZE']
+    ENV['ABS_AWS_MOM_SIZE']
+  end
+
+  def abs_get_aws_metrics_size
+    ENV['ABS_AWS_METRICS_SIZE'] = ABS_AWS_METRICS_SIZE unless ENV['ABS_AWS_METRICS_SIZE']
+    ENV['ABS_AWS_METRICS_SIZE']
+  end
+
+  def abs_get_aws_tags(role)
+    # TODO: handle more tags
+    {'role': role,
+     'pe_version': ENV['BEAKER_PE_VER']}
+  end
+
+  def abs_get_awsdirect_request_body(role, size = abs_get_aws_size)
+    {'platform': abs_get_aws_platform,
+     'image_id': abs_get_aws_image_id,
+     'size': size,
+     'region': abs_get_aws_region,
+     'reap_time': abs_get_aws_reap_time,
+     'tags': abs_get_aws_tags(role)}.to_json
+  end
+
+  def get_abs_awsdirectreturn_request_body(hostname)
+    {"hostname": hostname}
+  end
+
+  def abs_get_token_from_fog_file
+    home = ENV['HOME']
+    fog_path = "#{home}/.fog"
+    token = nil
+
+    if File.exist?(fog_path)
+      fog = YAML.load(File.read(fog_path))
+      token = fog[:default][:abs_token]
+    else
+      puts ".fog file not found in home directory: #{fog_path}"
+    end
+
+    if !token
+      puts "ABS token not found in .fog file at #{fog_path}"
+    end
+    token
+  end
+
+  def abs_get_token
+    ENV['ABS_TOKEN'] ? token = ENV['ABS_TOKEN'] : token = abs_get_token_from_fog_file
+    if token.nil?
+      puts 'An ABS token must be set in either the ABS_TOKEN environment variable or the abs_token parameter in the .fog file'
+    end
+    token
+  end
+
+  # TODO: remove once we switch to awsdirect
+  def retry_abs_request(uri, body, timeout, time_increment, invalid_response_bodies = [], valid_response_codes = [202, 200])
+    req = Net::HTTP::Post.new(uri, {'Content-Type' => 'application/json', 'X-Auth-Token' => abs_get_token})
+    req.body = body
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+
+    puts "sending request body: #{body}"
+    puts "to uri: #{uri}"
+
+    res = nil
+    Timeout::timeout(timeout) do
+      while res.nil? || invalid_response_bodies.include?(res.body) || !valid_response_codes.include?(res.code)
+        begin
+          res = http.request(req)
+        rescue => ex
+          puts ex
+          puts ex.backtrace
+        end
+        if res.nil? || invalid_response_bodies.include?(res.body)
+          puts "#{Time.now} - Retrying ABS request..."
+          sleep(time_increment)
+        else
+          break
+        end
+      end
+    end
+    res
+  end
+
+  def abs_get_request_post(uri)
+    Net::HTTP::Post.new(uri, {'Content-Type' => 'application/json', 'X-Auth-Token' => abs_get_token})
+  end
+
+  def abs_request_awsdirect(uri, body)
+    req = abs_get_request_post(uri)
+    req.body = body
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.read_timeout = 120
+
+    puts 'sending request body:'
+    puts body
+    puts "to uri: #{uri}"
+    puts
+
+    res = http.request(req)
+
+    puts "response: #{res.body}" unless res.nil?
+
+    res
+  end
+
+  def abs_is_valid_response?(res)
+    # TODO: other criteria?
+    invalid_response_bodies = ['', nil]
+    valid_response_codes = ['200']
+    is_valid_response = false
+
+    if res.nil? || !valid_response_codes.include?(res.code) || invalid_response_bodies.include?(res.body)
+      puts 'Invalid ABS response: '
+      puts "code: #{res.code}" unless res.nil?
+      puts "body: #{res.body}" unless res.nil?
+    else
+      is_valid_response = true
+    end
+    is_valid_response
+  end
+
+  def abs_get_a2a_hosts
+    # TODO: A2A_HOSTS environment variable?
+    {'mom': abs_get_aws_mom_size, 'metrics': abs_get_aws_metrics_size}
+  end
+
+  def abs_reformat_resource_host(response_body)
+    reformatted_json = nil
+
+    begin
+      json = JSON.parse(response_body)
+      hostname = json['hostname']
+      type = json['type']
+
+      new_response_body = {
+          'hostname': hostname,
+          'type':     ABS_BEAKER_TYPE,
+          'engine':   ABS_BEAKER_ENGINE}
+
+      reformatted_json = new_response_body.to_json
+    rescue
+      puts 'JSON::ParserError encountered'
+    end
+
+    reformatted_json
+  end
+
+  def abs_get_resource_hosts
+    # Allows us to switch between AWS and VMPooler by selecting different ABS os's
+    # centos-7-x86-64-west is an AWS image, centos-7-x86_64 is vmpooler
+    uri = URI("#{ABS_BASE_URL}/awsdirect")
+    responses = []
+    abs_resource_hosts = nil
+    invalid_response = false
+
+    hosts = abs_get_a2a_hosts
+
+    hosts.each do |role, size|
+
+      request_body = abs_get_awsdirect_request_body(role, size)
+      response = abs_request_awsdirect(uri, request_body)
+
+      # if any invalid responses are encountered stop and return any provisioned hosts
+      if !abs_is_valid_response?(response)
+        invalid_response = true
+        puts "Unable to provision host for role: #{role}"
+
+        puts 'Returning any provisioned hosts'
+        if !responses.empty?
+          ENV['ABS_RESOURCE_HOSTS'] = responses.to_json
+          return_abs_resource_hosts
+        end
+
+        # stop requesting hosts
+        break
+
+      else
+        # reformat to satisfy beaker
+        responses << JSON.parse(abs_reformat_resource_host(response.body))
+      end
+
+    end
+
+    if responses.empty?
+      puts 'No ABS hosts were provisioned'
+      puts ''
+    elsif !invalid_response
+      abs_resource_hosts = responses.to_json
+      ENV['ABS_RESOURCE_HOSTS'] = abs_resource_hosts
+      puts "ABS_RESOURCE_HOSTS=#{ENV['ABS_RESOURCE_HOSTS']}"
+
+      # TODO: extract
+      open('last_abs_resource_hosts.log', 'w') { |f|
+        f.puts abs_resource_hosts
+      }
+    end
+    abs_resource_hosts
+  end
+
+  def abs_get_last_abs_resource_hosts
+    last_abs_resource_hosts = File.open("last_abs_resource_hosts.log").readlines[0]
+    last_abs_resource_hosts
+  end
+
+  def return_abs_resource_hosts
+    uri = URI("#{abs_get_base_url}/awsdirectreturn")
+    abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? abs_get_last_abs_resource_hosts : ENV['ABS_RESOURCE_HOSTS']
+
+    puts "ABS hosts: #{abs_resource_hosts}"
+
+    if !abs_resource_hosts
+      puts 'De-provisioning via return_abs_resource_hosts requires an array of hostnames to be specified via the ABS_RESOURCE_HOSTS environment variable or the last_abs_resource_hosts.log file'
+    else
+      hosts = JSON.parse(abs_resource_hosts)
+      hosts.each do |host|
+        hostname = host['hostname']
+
+        puts "Returning host: #{hostname}"
+        body = get_abs_awsdirectreturn_request_body(hostname)
+        abs_request_awsdirect(uri, body)
+      end
+    end
+    abs_resource_hosts
+  end
+
+end

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -564,15 +564,21 @@ module AbsHelper
       begin
         # verify that Beaker will be able to start using the host
         ssh = Net::SSH.start(host, user, keys: key_file)
-        result = ssh.exec("rpm -q curl")
+        result = ssh.exec!("rpm -q curl")
         ssh.close
 
         if result
           puts result
+          raise "Error: root account is not yet configured" if result.to_s.include?("centos")
+
           break
+
+        else
+          raise "Unknown error"
         end
+
       rescue => err
-        puts "Attempted connection to #{host} failed with #{err}"
+        puts "Attempted connection to #{host} failed with '#{err}'"
         backoff_sleep(tries)
 
       end

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -5,10 +5,7 @@ require 'yaml'
 
 module AbsHelper
 
-  # TODO: replace when ready
-  #ABS_BASE_URL = 'https://cinext-abs.delivery.puppetlabs.net/api/v2'
-  ABS_BASE_URL = 'https://cinext-abs-test.delivery.puppetlabs.net/api/v2'
-
+  ABS_BASE_URL = 'https://cinext-abs.delivery.puppetlabs.net/api/v2'
   ABS_AWS_PLATFORM = 'el-7-x86_64'
   ABS_AWS_IMAGE_ID = 'ami-1b17242b'
   ABS_AWS_SIZE = 'c4.2xlarge'
@@ -21,9 +18,8 @@ module AbsHelper
   ABS_BEAKER_TYPE = 'centos-7-x86-64-west'
   ABS_BEAKER_ENGINE = 'aws'
 
-  # TODO: replace when ready
-  # ABS_AWS_REAP_TIME = '86400'
-  ABS_AWS_REAP_TIME = '1200'
+  # TODO: is this the value we want to use?
+  ABS_AWS_REAP_TIME = '86400'
 
   def abs_initialize
 

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -156,7 +156,7 @@ module AbsHelper
 
       reformatted_json = new_response_body.to_json
     rescue
-      puts 'JSON::ParserError encountered'
+      puts "JSON::ParserError encountered parsing the response body: #{response_body}"
     end
 
     reformatted_json

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -1,204 +1,142 @@
-require 'net/http'
-require 'timeout'
-require 'json'
-require 'yaml'
+require "net/http"
+require "net/ssh"
+require "timeout"
+require "json"
+require "yaml"
 
+# Provides functionality to provision and deprovision hosts via ABS
 module AbsHelper
+  ABS_BASE_URL = "https://cinext-abs.delivery.puppetlabs.net/api/v2".freeze
+  AWS_PLATFORM = "centos-7-x86_64".freeze
+  AWS_IMAGE_ID = "ami-a042f4d8".freeze
+  AWS_SIZE = "c4.2xlarge".freeze
+  AWS_VOLUME_SIZE = "80".freeze
+  AWS_REGION = "us-west-2".freeze
 
-  ABS_BASE_URL = 'https://cinext-abs.delivery.puppetlabs.net/api/v2'
-  ABS_AWS_PLATFORM = 'el-7-x86_64'
-  ABS_AWS_IMAGE_ID = 'ami-1b17242b'
-  ABS_AWS_SIZE = 'c4.2xlarge'
-  ABS_AWS_MOM_SIZE = 'c4.2xlarge'
-  ABS_AWS_METRICS_SIZE = 'c4.2xlarge'
-  ABS_AWS_REGION = 'us-west-2'
-
-  # Allows us to switch between AWS and VMPooler by selecting different ABS os's
+  # Allows us to switch between AWS and VMPooler by selecting a different ABS OS
   # centos-7-x86-64-west is an AWS image, centos-7-x86_64 is vmpooler
-  ABS_BEAKER_TYPE = 'centos-7-x86-64-west'
-  ABS_BEAKER_ENGINE = 'aws'
+  ABS_BEAKER_TYPE = "centos-7-x86-64-west".freeze
+  ABS_BEAKER_ENGINE = "aws".freeze
 
   # TODO: is this the value we want to use?
-  ABS_AWS_REAP_TIME = '86400'
+  AWS_REAP_TIME = "86400".freeze
 
+  # TODO: update mom and metrics config
+  MOM_SIZE = AWS_SIZE.freeze
+  MOM_VOLUME_SIZE = AWS_VOLUME_SIZE.freeze
+  METRICS_SIZE = AWS_SIZE.freeze
+  METRICS_VOLUME_SIZE = AWS_VOLUME_SIZE.freeze
+
+  # Checks whether the user has a valid token and if so initializes the instance variables
+  #
+  # @author Bill Claytor
+  #
+  # @return [true,false] Based on whether the user has a valid token
+  #
+  # @example
+  #   success = abs_initialize
+  #
   def abs_initialize
-
     # only proceed if the user has a token
     user_has_token = false
-    if abs_get_token
+    if get_abs_token
       user_has_token = true
-      @abs_base_url = ENV['ABS_BASE_URL'] ? ENV['ABS_BASE_URL'] : ABS_BASE_URL
-      @abs_aws_platform = ENV['ABS_AWS_PLATFORM'] ? ENV['ABS_AWS_PLATFORM'] : ABS_AWS_PLATFORM
-      @abs_aws_image_id = ENV['ABS_AWS_IMAGE_ID'] ? ENV['ABS_AWS_IMAGE_ID'] : ABS_AWS_IMAGE_ID
-      @abs_aws_size = ENV['ABS_AWS_SIZE'] ? ENV['ABS_AWS_SIZE'] : ABS_AWS_SIZE
-      @abs_aws_region = ENV['ABS_AWS_REGION'] ? ENV['ABS_AWS_REGION'] : ABS_AWS_REGION
-      @abs_aws_reap_time = ENV['ABS_AWS_REAP_TIME'] ? ENV['ABS_AWS_REAP_TIME'] : ABS_AWS_REAP_TIME
-      @abs_aws_mom_size = ENV['ABS_AWS_MOM_SIZE'] ? ENV['ABS_AWS_MOM_SIZE'] : ABS_AWS_MOM_SIZE
-      @abs_aws_metrics_size = ENV['ABS_AWS_METRICS_SIZE'] ? ENV['ABS_AWS_METRICS_SIZE'] : ABS_AWS_METRICS_SIZE
-      @abs_beaker_pe_version = ENV['BEAKER_PE_VER'] ? ENV['BEAKER_PE_VER'] : nil
+
+      # TODO: preface all ABS environment variables with ABS?
+      @abs_base_url = ENV["ABS_BASE_URL"] ? ENV["ABS_BASE_URL"] : ABS_BASE_URL
+      @aws_platform = ENV["ABS_AWS_PLATFORM"] ? ENV["ABS_AWS_PLATFORM"] : AWS_PLATFORM
+      @aws_image_id = ENV["ABS_AWS_IMAGE_ID"] ? ENV["ABS_AWS_IMAGE_ID"] : AWS_IMAGE_ID
+      @aws_size = ENV["ABS_AWS_SIZE"] ? ENV["ABS_AWS_SIZE"] : AWS_SIZE
+      @aws_volume_size = ENV["ABS_AWS_VOLUME_SIZE"] ? ENV["ABS_AWS_VOLUME_SIZE"] : AWS_VOLUME_SIZE
+      @aws_region = ENV["ABS_AWS_REGION"] ? ENV["ABS_AWS_REGION"] : AWS_REGION
+      @aws_reap_time = ENV["ABS_AWS_REAP_TIME"] ? ENV["ABS_AWS_REAP_TIME"] : AWS_REAP_TIME
+      @mom_size = ENV["ABS_AWS_MOM_SIZE"] ? ENV["ABS_AWS_MOM_SIZE"] : MOM_SIZE
+      @mom_volume_size = ENV["ABS_AWS_MOM_VOLUME_SIZE"] ? ENV["ABS_AWS_MOM_VOLUME_SIZE"] : MOM_VOLUME_SIZE
+      @metrics_size = ENV["ABS_AWS_METRICS_SIZE"] ? ENV["ABS_AWS_METRICS_SIZE"] : METRICS_SIZE
+      @metrics_volume_size = ENV["ABS_METRICS_VOLUME_SIZE"] ? ENV["ABS_METRICS_VOLUME_SIZE"] : METRICS_VOLUME_SIZE
+      @abs_beaker_pe_version = ENV["BEAKER_PE_VER"] ? ENV["BEAKER_PE_VER"] : nil
     end
     user_has_token
   end
 
-  def abs_get_aws_tags(role)
-    # TODO: handle more tags
-    tags = {'role': role}
-    if @abs_beaker_pe_version
-      tags.merge!('pe_version': @abs_beaker_pe_version)
-    end
-    tags
-  end
-
-  def abs_get_awsdirect_request_body(role, size = @abs_aws_size)
-    {'platform': @abs_aws_platform,
-     'image_id': @abs_aws_image_id,
-     'size': size,
-     'region': @abs_aws_region,
-     'reap_time': @abs_aws_reap_time,
-     'tags': abs_get_aws_tags(role)}.to_json
-  end
-
-  def abs_get_awsdirectreturn_request_body(hostname)
-    {"hostname": hostname}.to_json
-  end
-
-  def abs_get_token_from_fog_file
-    home = ENV['HOME']
-    fog_path = "#{home}/.fog"
-    token = nil
-
-    if File.exist?(fog_path)
-      fog = YAML.load(File.read(fog_path))
-      token = fog[:default][:abs_token]
-      if !token
-        puts "ABS token not found in .fog file at #{fog_path}"
-      end
-    else
-      puts ".fog file not found in home directory: #{fog_path}"
-    end
-    token
-  end
-
-  def abs_get_token
-    ENV['ABS_TOKEN'] ? token = ENV['ABS_TOKEN'] : token = abs_get_token_from_fog_file
-    if token.nil?
-      puts 'An ABS token must be set in either the ABS_TOKEN environment variable or the abs_token parameter in the .fog file'
-    end
-    ENV['ABS_TOKEN'] = token
-    token
-  end
-
-  def abs_get_request_post(uri)
-    req = nil
-    abs_token = abs_get_token
-    if abs_token
-      req =  Net::HTTP::Post.new(uri, {'Content-Type' => 'application/json', 'X-Auth-Token' => abs_token})
-    else
-      puts 'Unable to prepare a valid ABS request without a valid token'
-    end
-    req
-  end
-
-  # TODO: rename?
-  def abs_request_awsdirect(uri, body)
-    res = nil
-    req = abs_get_request_post(uri)
-
-    if req
-      req.body = body
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.read_timeout = 120
-
-      puts
-      puts 'sending request body:'
-      puts body
-      puts "to uri: #{uri}"
-      puts
-
-      res = http.request(req)
-      puts "response code: #{res.code}" unless res.nil?
-      puts "response body: #{res.body}" unless res.nil?
-      puts
-    else
-      puts 'Unable to complete the specified ABS request'
-    end
-
-    res
-  end
-
-  def abs_is_valid_response?(res, valid_response_codes = ['200'], invalid_response_bodies = ['', nil])
-    # TODO: other criteria?
-    is_valid_response = false
-
-    if res.nil? || !valid_response_codes.include?(res.code) || invalid_response_bodies.include?(res.body)
-      puts 'Invalid ABS response: '
-      puts "code: #{res.code}" unless res.nil?
-      puts "body: #{res.body}" unless res.nil?
-    else
-      is_valid_response = true
-    end
-    is_valid_response
-  end
-
-  def abs_get_a2a_hosts
+  # Initializes AbsHelper and returns the hosts for an ApplesToApples run
+  #
+  # @author Bill Claytor
+  #
+  # @return [Hash] The ApplesToApples hosts (mom and metrics)
+  #
+  # @example
+  #   hosts = abs_get_a2a_hosts
+  #
+  def get_a2a_hosts
     abs_initialize
-    {'mom': @abs_aws_mom_size, 'metrics': @abs_aws_metrics_size}
+    mom =
+      { 'role': "mom",
+        'size': @mom_size,
+        'volume_size': @mom_volume_size }
+
+    metrics =
+      { 'role': "metrics",
+        'size': @metrics_size,
+        'volume_size': @metrics_volume_size }
+
+    hosts = [mom, metrics]
+
+    return hosts
   end
 
-  def abs_reformat_resource_host(response_body)
-    reformatted_json = nil
-
-    begin
-      host = JSON.parse(response_body)
-      hostname = host['hostname']
-
-      new_response_body = {
-          'hostname': hostname,
-          'type':     ABS_BEAKER_TYPE,
-          'engine':   ABS_BEAKER_ENGINE}
-
-      reformatted_json = new_response_body.to_json
-    rescue
-      puts "JSON::ParserError encountered parsing the response body: #{response_body}"
-    end
-
-    reformatted_json
-  end
-
-  def abs_update_last_abs_resource_hosts(abs_resource_hosts)
-    File.write('last_abs_resource_hosts.log', abs_resource_hosts)
-  end
-
+  # Attempts to provision the specified hosts via ABS
+  #
   # hosts will likely come from abs_get_a2a_hosts:
-  #  {'mom': @abs_aws_mom_size, 'metrics': @abs_aws_metrics_size}
+  #  {"mom": @abs_aws_mom_size, "metrics": @abs_aws_metrics_size}
   #
   # otherwise specify hosts in the following format
-  #  {'role1': 'size1', 'role2': 'size2', ... }
-  def abs_get_resource_hosts(hosts_to_request)
-    responses = []
+  #  {"role1": "size1", "role2": "size2", ... }
+  #
+  # @author Bill Claytor
+  #
+  # @param [Array] hosts_to_request The hosts to request via ABS
+  #
+  # @return [JSON, nil] The hosts that were provisioned via ABS, otherwise nil
+  #
+  # @example
+  #   abs_get_resource_hosts = abs_get_resource_hosts(hosts_to_request)
+  #
+  def get_abs_resource_hosts(hosts_to_request)
+    hosts = []
     abs_resource_hosts = nil
     invalid_response = false
+
+    puts
+    puts "Attempting to provision ABS hosts: #{hosts_to_request}"
+    puts
 
     # ensure the user has a token before proceeding
     if abs_initialize
       uri = URI("#{@abs_base_url}/awsdirect")
-      hosts_to_request.each do |role, size|
-        request_body = abs_get_awsdirect_request_body(role, size)
-        response = abs_request_awsdirect(uri, request_body)
+      hosts_to_request.each do |host_to_request|
+        puts "host_to_request: #{host_to_request}"
+
+        role = host_to_request[:role]
+        size = host_to_request[:size]
+        volume_size = host_to_request[:volume_size]
+
+        request_body = get_awsdirect_request_body(role, size, volume_size)
+        response = perform_awsdirect_request(uri, request_body)
 
         # if any invalid responses are encountered stop and return any provisioned hosts
         # TODO: extract managing the responses and test separately
-        if !abs_is_valid_response?(response)
+        if !valid_abs_response?(response)
           invalid_response = true
           puts "Unable to provision host for role: #{role}"
+          puts
 
-          if responses.empty?
-            puts 'No ABS hosts were provisioned'
-            puts ''
+          if hosts.empty?
+            puts "No ABS hosts were provisioned"
+            puts
           else
-            puts 'Returning any provisioned hosts'
-            abs_return_resource_hosts(responses.to_json)
+            puts "Returning any provisioned hosts"
+            return_abs_resource_hosts(hosts.to_json)
           end
 
           # stop requesting hosts
@@ -206,58 +144,105 @@ module AbsHelper
 
         else
           # reformat to satisfy beaker
-          responses << JSON.parse(abs_reformat_resource_host(response.body))
+          hosts << JSON.parse(reformat_abs_resource_host(response.body))
         end
-
       end
 
-      if !responses.empty? && !invalid_response
-        abs_resource_hosts = responses.to_json
-        ENV['ABS_RESOURCE_HOSTS'] = abs_resource_hosts
+      if !hosts.empty? && !invalid_response
+        abs_resource_hosts = hosts.to_json
+        ENV["ABS_RESOURCE_HOSTS"] = abs_resource_hosts
         puts "ABS_RESOURCE_HOSTS=#{ENV['ABS_RESOURCE_HOSTS']}"
 
-        # write to 'last_abs_resource_hosts.log' (used when returning hosts)
-        abs_update_last_abs_resource_hosts(abs_resource_hosts)
-
+        # write to "last_abs_resource_hosts.log" (used when returning hosts)
+        update_last_abs_resource_hosts(abs_resource_hosts)
       end
 
     else
-      puts 'Unable to proceed without a valid ABS token'
-      puts ''
+      puts "Unable to proceed without a valid ABS token"
+      puts
     end
 
-    abs_resource_hosts
+    # only return the hosts if they're successfully verified
+    success = verify_abs_hosts(hosts) unless abs_resource_hosts.nil?
+    verified_hosts = success ? abs_resource_hosts : nil
+
+    if verified_hosts
+      puts
+      puts "ABS hosts have been successfully provisioned"
+      puts "Pausing to ensure successful configuration"
+
+      # TODO: remove?
+      sleep 30
+    end
+
+    return verified_hosts
   end
 
-  def is_valid_abs_resource_hosts?(abs_resource_hosts)
-    is_valid = false
+  # Returns the specified ABS hosts via ABS
+  #
+  # @author Bill Claytor
+  #
+  # @param [JSON] abs_resource_hosts The hosts to de-provision
+  #
+  # @return [JSON] The hosts that were successfully returned
+  #
+  # @example
+  #   returned_hosts = abs_return_resource_hosts(abs_resource_hosts)
+  #
+  def return_abs_resource_hosts(abs_resource_hosts)
+    returned_hosts = nil
+    puts "ABS hosts specified for return: #{abs_resource_hosts}"
 
-    if abs_resource_hosts.nil?
-      puts 'A valid hosts array is required; nil was specified'
-      puts ''
-    else
+    is_valid = valid_abs_resource_hosts?(abs_resource_hosts)
+    unless is_valid
+      puts "De-provisioning via awsdirectreturn requires an array of hostnames to be specified"
+      puts "Specify hostnames via the ABS_RESOURCE_HOSTS environment variable"
+      puts "Or specify via the last_abs_resource_hosts.log file"
+      puts
+    end
 
-      begin
-        hosts = JSON.parse(abs_resource_hosts)
-        host = hosts[0]
-        hostname = host['hostname']
-        if !hostname.nil? && !hostname.empty?
-          is_valid = true
+    has_token = abs_initialize
+    unless has_token
+      puts "Unable to proceed without a valid ABS token"
+      puts
+    end
+
+    if is_valid && has_token
+      uri = URI("#{@abs_base_url}/awsdirectreturn")
+
+      # returned_hosts = []
+      hosts = JSON.parse(abs_resource_hosts)
+      hosts.each do |host|
+        hostname = host["hostname"]
+
+        puts "Returning host: #{hostname}"
+        body = get_awsdirectreturn_request_body(hostname)
+        res = perform_awsdirect_request(uri, body)
+
+        if valid_abs_response?(res)
+          puts "Successfully returned host: #{hostname}"
+          returned_hosts ? returned_hosts << host : returned_hosts = [host]
         else
-          puts "The specified resource host array is not valid: #{abs_resource_hosts}"
-          puts ''
+          puts "Failed to return host: #{hostname}"
         end
-      rescue
-        puts "JSON::ParserError encountered parsing the hosts array: #{abs_resource_hosts}"
       end
 
     end
 
-    is_valid
+    returned_hosts ? returned_hosts.to_json : returned_hosts
   end
 
-  def abs_get_last_abs_resource_hosts
-    file = 'last_abs_resource_hosts.log'
+  # Reads the ABS hosts from the last_abs_resource_hosts.log file
+  #
+  # @author Bill Claytor
+  #
+  # @return [JSON, nil] The hosts of the log file if successful, otherwise nil
+  #
+  # @example
+  #   abs_resource_hosts = abs_get_last_abs_resource_hosts
+  #
+  def get_last_abs_resource_hosts
+    file = "last_abs_resource_hosts.log"
     last_abs_resource_hosts = nil
     expected = '[{"hostname":'
 
@@ -275,48 +260,392 @@ module AbsHelper
     last_abs_resource_hosts
   end
 
-  def abs_return_resource_hosts(abs_resource_hosts)
-    returned_hosts = nil
-    puts "ABS hosts specified for return: #{abs_resource_hosts}"
+  # Creates the tags hash with the specified role
+  #
+  # @author Bill Claytor
+  #
+  # @param [string] role The role for the host being requested
+  #
+  # @return [Hash] The tags for the host being requested
+  #
+  # @example
+  #   tags = abs_get_aws_tags("metrics")
+  #
+  def get_aws_tags(role)
+    # TODO: handle more tags
+    tags = { "role": role }
+    tags[:pe_version] = @abs_beaker_pe_version if @abs_beaker_pe_version
+    tags
+  end
 
-    is_valid = is_valid_abs_resource_hosts?(abs_resource_hosts)
-    if !is_valid
-      puts 'De-provisioning via return_abs_resource_hosts requires an array of hostnames to be specified via the ABS_RESOURCE_HOSTS environment variable or the last_abs_resource_hosts.log file'
-      puts ''
+  # Creates the awsdirect request body for the specified role
+  #
+  # @author Bill Claytor
+  #
+  # @param [string] role The role for the host being requested
+  # @param [string] size The size for the host being requested
+  #
+  # @return [JSON] The JSON request body for the host being requested
+  #
+  # @example
+  #   req_body = abs_get_awsdirect_request_body("metrics", "c4.2xlarge", "80")
+  #
+  def get_awsdirect_request_body(role, size = @aws_size, volume_size = @aws_volume_size)
+    { "platform": @aws_platform,
+      "image_id": @aws_image_id,
+      "size": size,
+      "region": @aws_region,
+      "reap_time": @aws_reap_time,
+      "tags": get_aws_tags(role),
+      "volume_size": volume_size }.to_json
+  end
+
+  # Creates the awsdirectreturn request body for the specified host
+  #
+  # @author Bill Claytor
+  #
+  # @param [string] hostname The host being returned
+  #
+  # @return [JSON] The JSON request body for the host being returned
+  #
+  # @example
+  #   req_body = abs_get_awsdirectreturn_request_body("myhost")
+  #
+  def get_awsdirectreturn_request_body(hostname)
+    { "hostname": hostname }.to_json
+  end
+
+  # Attempts to retrieve the ABS token from the user's .fog file
+  #
+  # @author Bill Claytor
+  #
+  # @return [string, nil] The user's token or nil if not found
+  #
+  # @example
+  #   token = abs_get_token_from_fog_file
+  #
+  # rubocop:disable Security/YAMLLoad
+  def get_abs_token_from_fog_file
+    home = ENV["HOME"]
+    fog_path = "#{home}/.fog"
+    token = nil
+
+    if File.exist?(fog_path)
+      file = File.read(fog_path)
+
+      begin
+        # TODO: safe_load?
+        fog = YAML.load(file)
+      rescue
+        # TODO: raise?
+        puts "YAML error encountered parsing .fog file"
+      end
+
+      token = fog[:default][:abs_token]
+      puts "ABS token not found in .fog file at #{fog_path}" unless token
+    else
+      puts ".fog file not found in home directory: #{fog_path}"
+    end
+    token
+  end
+
+  # rubocop:enable Security/YAMLLoad
+
+  # Attempts to retrieve the ABS token from the ABS_TOKEN environment variable
+  # or the user's .fog file
+  #
+  # Sets the ABS_TOKEN environment variable to the token if provided via the .fog file
+  #
+  # @author Bill Claytor
+  #
+  # @return [string, nil] The user's token or nil if not found
+  #
+  # @example
+  #   token = def abs_get_token
+  #
+  def get_abs_token
+    token = ENV["ABS_TOKEN"] ? ENV["ABS_TOKEN"] : get_abs_token_from_fog_file
+    if token.nil?
+      puts "An ABS token must be set in either the ABS_TOKEN environment variable"
+      + " or the abs_token parameter in the .fog file"
+    end
+    ENV["ABS_TOKEN"] = token
+    token
+  end
+
+  # Creates the request to be sent based on the specified URI
+  #
+  # @author Bill Claytor
+  #
+  # @param [URI] uri The URI where the request should be sent
+  #
+  # @return [Net::HTTP::Post, nil] The request or nil if unsuccessful
+  #
+  # @example
+  #   request = abs_get_request_post(uri)
+  #
+  def get_abs_post_request(uri)
+    req = nil
+    abs_token = get_abs_token
+    if abs_token
+      req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json",
+                                     "X-Auth-Token" => abs_token)
+    else
+      puts "Unable to prepare a valid ABS request without a valid token"
+    end
+    req
+  end
+
+  # Prepares and submits the awsdirect request with the specified URI and body
+  #
+  # @author Bill Claytor
+  #
+  # @param [URI] uri The URI where the request should be sent
+  # @param [JSON] body The request body
+  #
+  # @return [Net::HTTPResponse, nil] The HTTP response or nil if unsuccessful
+  #
+  # @example
+  #   response = abs_request_awsdirect(uri, body)
+  #
+  def perform_awsdirect_request(uri, body)
+    res = nil
+    req = get_abs_post_request(uri)
+
+    if req
+      req.body = body
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.read_timeout = 120
+
+      puts "sending request body:"
+      puts body
+      puts "to uri: #{uri}"
+      puts
+
+      res = http.request(req)
+      puts "response code: #{res.code}" unless res.nil?
+      puts "response body: #{res.body}" unless res.nil?
+      puts
+    else
+      puts "Unable to complete the specified ABS request"
     end
 
-    has_token = abs_initialize
-    if !has_token
-      puts 'Unable to proceed without a valid ABS token'
-      puts ''
+    res
+  end
+
+  # Determines whether the ABS response is valid
+  #
+  # @author Bill Claytor
+  #
+  # @param [Net::HTTPResponse] res The HTTP response to evaluate
+  # @param [Array] valid_response_codes The list of valid response codes
+  # @param [Array] invalid_response_bodies The list of invalid response bodies
+  #
+  # @return [true,false] Based on whether the response is valid
+  #
+  # @example
+  #   valid = abs_valid_response?(res, ["200"], ["", nil])
+  #
+  def valid_abs_response?(res, valid_response_codes = ["200"],
+                          invalid_response_bodies = ["", nil])
+    # TODO: other criteria?
+    is_valid_response = false
+
+    if res.nil? || !valid_response_codes.include?(res.code) ||
+       invalid_response_bodies.include?(res.body)
+      puts "Invalid ABS response: "
+      puts "code: #{res.code}" unless res.nil?
+      puts "body: #{res.body}" unless res.nil?
+      puts
+    else
+      is_valid_response = true
+    end
+    is_valid_response
+  end
+
+  # Creates a Beaker-formatted version of the response body
+  # for the provisioned host
+  #
+  # Beaker requires hosts to be specified in this format
+  #
+  # @author Bill Claytor
+  #
+  # @param [Hash] response_body The response body for the provisioned host
+  #
+  # @return [Hash] The updated host
+  #
+  # @example
+  #   host = abs_reformat_resource_host(response_body)
+  #
+  def reformat_abs_resource_host(response_body)
+    reformatted_json = nil
+
+    begin
+      host = JSON.parse(response_body)
+      hostname = host["hostname"]
+
+      new_response_body = {
+        'hostname': hostname,
+        'type':     ABS_BEAKER_TYPE,
+        'engine':   ABS_BEAKER_ENGINE
+      }
+
+      reformatted_json = new_response_body.to_json
+    rescue
+      # TODO: raise?
+      puts "JSON::ParserError encountered parsing response body: #{response_body}"
     end
 
-    if is_valid && has_token
-      uri = URI("#{@abs_base_url}/awsdirectreturn")
+    reformatted_json
+  end
 
-      # returned_hosts = []
-      hosts = JSON.parse(abs_resource_hosts)
-      hosts.each do |host|
-        hostname = host['hostname']
+  # Writes the current ABS resource hosts to the log file
+  # last_abs_resource_hosts.log
+  #
+  # @author Bill Claytor
+  #
+  # @param [JSON] abs_resource_hosts The current ABS resource hosts
+  #
+  # @return [void]
+  #
+  # @example
+  #   abs_update_last_abs_resource_hosts(abs_resource_hosts)
+  #
+  def update_last_abs_resource_hosts(abs_resource_hosts)
+    File.write("last_abs_resource_hosts.log", abs_resource_hosts)
+  end
 
-        puts "Returning host: #{hostname}"
-        body = abs_get_awsdirectreturn_request_body(hostname)
-        res = abs_request_awsdirect(uri, body)
+  # Calculates and waits a back-off period based on the number of tries
+  # Logs each backupoff time and retry value to the console
+  #
+  # This is duplicated code from beaker-aws:
+  # https://github.com/puppetlabs/beaker-aws/blob/master/lib/beaker/hypervisor/aws_sdk.rb#L682-L695
+  #
+  # @param tries [Number] number of tries to calculate back-off period
+  #
+  # @return [void]
+  #
+  # @example
+  #   abs_backoff_sleep(tries)
+  #
+  def backoff_sleep(tries)
+    # Exponential with some randomization
+    sleep_time = 2**tries
+    puts "Sleeping for #{sleep_time} seconds after attempt #{tries}..."
+    sleep sleep_time
+    nil
+  end
 
-        if abs_is_valid_response?(res)
-          puts "Successfully returned host: #{hostname}"
-          returned_hosts ? returned_hosts << host : returned_hosts = [host]
-        else
-          puts "Failed to return host: #{hostname}"
+  # Verifies that the specified host can be accessed via ssh as the root user
+  #
+  # @author Bill Claytor
+  #
+  # @param [string] host The host to verify
+  #
+  # @return [true, false] Based on successful verification of the specified host
+  #
+  # @example
+  #   success = abs_verify_host(host)
+  #
+  def verify_abs_host(host)
+    result = nil
+    user = "root"
+    key_file = "~/.ssh/abs-aws-ec2.rsa"
+
+    puts "Verifying #{host}"
+    puts
+
+    # TODO: 8 tries?
+    for tries in 1..8
+
+      puts "Attempt #{tries} for #{host}"
+
+      begin
+        # verify that Beaker will be able to start using the host
+        ssh = Net::SSH.start(host, user, keys: key_file)
+        result = ssh.exec("rpm -q curl")
+        ssh.close
+
+        if result
+          puts result
+          break
         end
+      rescue => err
+        puts "Attempted connection to #{host} failed with #{err}"
+        backoff_sleep(tries)
 
       end
 
     end
 
-    returned_hosts ? returned_hosts.to_json : returned_hosts
-
+    puts "Failed to verify host #{host}" unless result
+    success = result ? true : false
+    return success
   end
 
+  # Verifies that the specified hosts can be accessed via ssh as the root user
+  #
+  # @author Bill Claytor
+  #
+  # @param [Array] hosts The hosts to verify
+  #
+  # @return [true, false] Based on successful verification of the specified hosts
+  #
+  # @example
+  #   success = abs_verify_hosts(host)
+  #
+  def verify_abs_hosts(hosts)
+    success = false
+    puts "Verifying ABS hosts: #{hosts}"
+    hosts.each do |host|
+      puts
+      puts "Current host: #{host}"
 
+      success = verify_abs_host(host["hostname"])
+      break unless success
+    end
+
+    puts "Unable to verify the provisioned hosts" unless success
+    return success
+  end
+
+  # Determines whether the specified hosts list is valid
+  #
+  # @author Bill Claytor
+  #
+  # @param [JSON] abs_resource_hosts The hosts to validate
+  #
+  # @return [true, false] Based on the validity of the specified hosts
+  #
+  # @example
+  #   valid = abs_valid_resource_hosts?(abs_resource_hosts)
+  #
+  def valid_abs_resource_hosts?(abs_resource_hosts)
+    is_valid = false
+
+    if abs_resource_hosts.nil?
+      puts "A valid hosts array is required; nil was specified"
+      puts
+    else
+
+      begin
+        hosts = JSON.parse(abs_resource_hosts)
+        host = hosts[0]
+        hostname = host["hostname"]
+        if !hostname.nil? && !hostname.empty?
+          is_valid = true
+        else
+          puts "The specified resource host array is not valid: #{abs_resource_hosts}"
+          puts
+        end
+      rescue
+        # TODO: raise?
+        puts "JSON::ParserError encountered parsing the hosts array: #{abs_resource_hosts}"
+      end
+
+    end
+
+    is_valid
+  end
 end

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -78,7 +78,7 @@ module AbsHelper
      'tags': abs_get_aws_tags(role)}.to_json
   end
 
-  def get_abs_awsdirectreturn_request_body(hostname)
+  def abs_get_awsdirectreturn_request_body(hostname)
     {"hostname": hostname}
   end
 
@@ -226,7 +226,7 @@ module AbsHelper
         puts 'Returning any provisioned hosts'
         if !responses.empty?
           ENV['ABS_RESOURCE_HOSTS'] = responses.to_json
-          return_abs_resource_hosts
+          abs_return_resource_hosts
         end
 
         # stop requesting hosts
@@ -260,7 +260,7 @@ module AbsHelper
     last_abs_resource_hosts
   end
 
-  def return_abs_resource_hosts
+  def abs_return_resource_hosts
     uri = URI("#{abs_get_base_url}/awsdirectreturn")
     abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? abs_get_last_abs_resource_hosts : ENV['ABS_RESOURCE_HOSTS']
 
@@ -274,7 +274,7 @@ module AbsHelper
         hostname = host['hostname']
 
         puts "Returning host: #{hostname}"
-        body = get_abs_awsdirectreturn_request_body(hostname)
+        body = abs_get_awsdirectreturn_request_body(hostname)
         abs_request_awsdirect(uri, body)
       end
     end

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -16,6 +16,8 @@ module AbsHelper
   ABS_AWS_METRICS_SIZE = 'c4.2xlarge'
   ABS_AWS_REGION = 'us-west-2'
 
+  # Allows us to switch between AWS and VMPooler by selecting different ABS os's
+  # centos-7-x86-64-west is an AWS image, centos-7-x86_64 is vmpooler
   ABS_BEAKER_TYPE = 'centos-7-x86-64-west'
   ABS_BEAKER_ENGINE = 'aws'
 
@@ -23,44 +25,15 @@ module AbsHelper
   # ABS_AWS_REAP_TIME = '86400'
   ABS_AWS_REAP_TIME = '1200'
 
-  def abs_get_base_url
-    ENV['ABS_BASE_URL'] = ABS_BASE_URL unless ENV['ABS_BASE_URL']
-    ENV['ABS_BASE_URL']
-  end
-
-  def abs_get_aws_platform
-    ENV['ABS_AWS_PLATFORM'] = ABS_AWS_PLATFORM unless ENV['ABS_AWS_PLATFORM']
-    ENV['ABS_AWS_PLATFORM']
-  end
-
-  def abs_get_aws_image_id
-    ENV['ABS_AWS_IMAGE_ID'] = ABS_AWS_IMAGE_ID unless ENV['ABS_AWS_IMAGE_ID']
-    ENV['ABS_AWS_IMAGE_ID']
-  end
-
-  def abs_get_aws_size
-    ENV['ABS_AWS_SIZE'] = ABS_AWS_SIZE unless ENV['ABS_AWS_SIZE']
-    ENV['ABS_AWS_SIZE']
-  end
-
-  def abs_get_aws_region
-    ENV['ABS_AWS_REGION'] = ABS_AWS_REGION unless ENV['ABS_AWS_REGION']
-    ENV['ABS_AWS_REGION']
-  end
-
-  def abs_get_aws_reap_time
-    ENV['ABS_AWS_REAP_TIME'] = ABS_AWS_REAP_TIME unless ENV['ABS_AWS_REAP_TIME']
-    ENV['ABS_AWS_REAP_TIME']
-  end
-
-  def abs_get_aws_mom_size
-    ENV['ABS_AWS_MOM_SIZE'] = ABS_AWS_MOM_SIZE unless ENV['ABS_AWS_MOM_SIZE']
-    ENV['ABS_AWS_MOM_SIZE']
-  end
-
-  def abs_get_aws_metrics_size
-    ENV['ABS_AWS_METRICS_SIZE'] = ABS_AWS_METRICS_SIZE unless ENV['ABS_AWS_METRICS_SIZE']
-    ENV['ABS_AWS_METRICS_SIZE']
+  def abs_initialize
+    @abs_base_url = ENV['ABS_BASE_URL'] ? ENV['ABS_BASE_URL'] : ABS_BASE_URL
+    @abs_aws_platform = ENV['ABS_AWS_PLATFORM'] ? ENV['ABS_AWS_PLATFORM'] : ABS_AWS_PLATFORM
+    @abs_aws_image_id = ENV['ABS_AWS_IMAGE_ID'] ? ENV['ABS_AWS_IMAGE_ID'] : ABS_AWS_IMAGE_ID
+    @abs_aws_size = ENV['ABS_AWS_SIZE'] ? ENV['ABS_AWS_SIZE'] : ABS_AWS_SIZE
+    @abs_aws_region = ENV['ABS_AWS_REGION'] ? ENV['ABS_AWS_REGION'] : ABS_AWS_REGION
+    @abs_aws_reap_time = ENV['ABS_AWS_REAP_TIME'] ? ENV['ABS_AWS_REAP_TIME'] : ABS_AWS_REAP_TIME
+    @abs_aws_mom_size = ENV['ABS_AWS_MOM_SIZE'] ? ENV['ABS_AWS_MOM_SIZE'] : ABS_AWS_MOM_SIZE
+    @abs_aws_metrics_size = ENV['ABS_AWS_METRICS_SIZE'] ? ENV['ABS_AWS_METRICS_SIZE'] : ABS_AWS_METRICS_SIZE
   end
 
   def abs_get_aws_tags(role)
@@ -69,12 +42,12 @@ module AbsHelper
      'pe_version': ENV['BEAKER_PE_VER']}
   end
 
-  def abs_get_awsdirect_request_body(role, size = abs_get_aws_size)
-    {'platform': abs_get_aws_platform,
-     'image_id': abs_get_aws_image_id,
+  def abs_get_awsdirect_request_body(role, size = @abs_aws_size)
+    {'platform': @abs_aws_platform,
+     'image_id': @abs_aws_image_id,
      'size': size,
-     'region': abs_get_aws_region,
-     'reap_time': abs_get_aws_reap_time,
+     'region': @abs_aws_region,
+     'reap_time': @abs_aws_reap_time,
      'tags': abs_get_aws_tags(role)}.to_json
   end
 
@@ -179,7 +152,7 @@ module AbsHelper
 
   def abs_get_a2a_hosts
     # TODO: A2A_HOSTS environment variable?
-    {'mom': abs_get_aws_mom_size, 'metrics': abs_get_aws_metrics_size}
+    {'mom': @abs_aws_mom_size, 'metrics': @abs_aws_metrics_size}
   end
 
   def abs_reformat_resource_host(response_body)
@@ -204,9 +177,9 @@ module AbsHelper
   end
 
   def abs_get_resource_hosts
-    # Allows us to switch between AWS and VMPooler by selecting different ABS os's
-    # centos-7-x86-64-west is an AWS image, centos-7-x86_64 is vmpooler
-    uri = URI("#{ABS_BASE_URL}/awsdirect")
+    abs_initialize
+
+    uri = URI("#{@abs_base_url}/awsdirect")
     responses = []
     abs_resource_hosts = nil
     invalid_response = false
@@ -261,7 +234,7 @@ module AbsHelper
   end
 
   def abs_return_resource_hosts
-    uri = URI("#{abs_get_base_url}/awsdirectreturn")
+    uri = URI("#{@abs_base_url}/awsdirectreturn")
     abs_resource_hosts = ENV['ABS_RESOURCE_HOSTS'].nil? ? abs_get_last_abs_resource_hosts : ENV['ABS_RESOURCE_HOSTS']
 
     puts "ABS hosts: #{abs_resource_hosts}"

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -550,6 +550,7 @@ module AbsHelper
   #
   def verify_abs_host(host)
     result = nil
+    success = false
     user = "root"
     key_file = "~/.ssh/abs-aws-ec2.rsa"
 
@@ -568,9 +569,9 @@ module AbsHelper
         ssh.close
 
         if result
-          puts result
+          puts "Result: #{result}"
           raise "Error: root account is not yet configured" if result.to_s.include?("centos")
-
+          success = true
           break
 
         else
@@ -585,8 +586,7 @@ module AbsHelper
 
     end
 
-    puts "Failed to verify host #{host}" unless result
-    success = result ? true : false
+    puts "Failed to verify host #{host}" unless success
     return success
   end
 

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -531,7 +531,7 @@ describe AbsHelperClass do
     context 'when an invalid response_body is provided' do
 
       it 'reports the error and returns nil' do
-        expect(subject).to receive(:puts).with('JSON::ParserError encountered')
+        expect(subject).to receive(:puts).with("JSON::ParserError encountered parsing the response body: #{TEST_INVALID_RESPONSE_BODY}")
         expect(subject.abs_reformat_resource_host(TEST_INVALID_RESPONSE_BODY)).to eq(nil)
       end
 

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -11,27 +11,65 @@ describe AbsHelperClass do
   let(:test_http_request) { Class.new }
   let(:test_http_response) { Class.new }
 
+  let(:test_abs_base_url) { Class.new }
+  let(:test_abs_platform) { Class.new }
+  let(:test_abs_aws_image_id) { Class.new }
+  let(:test_abs_aws_size) { Class.new }
+  let(:test_abs_aws_mom_size) { Class.new }
+  let(:test_abs_aws_metrics_size) { Class.new }
+  let(:test_abs_aws_region) { Class.new }
+  let(:test_abs_aws_reap_time) { Class.new }
+
   TEST_ABS_TOKEN = 'test_abs_token_zzz'
-  TEST_BASE_URL = 'https://testing.puppet.net/v2'
-  TEST_AWSDIRECT_URL = "#{TEST_BASE_URL}/awsdirect"
+  TEST_ABS_BASE_URL = 'https://testing.puppet.net/v2'
+  TEST_ABS_AWS_PLATFORM = 'test-amazon-6-x86_64'
+  TEST_ABS_AWS_IMAGE_ID = 'test-ami-a07379d9'
+  TEST_ABS_AWS_SIZE = 'test.c3.large'
+  TEST_ABS_AWS_REGION = 'test-us-west-2'
+  TEST_ABS_AWS_REAP_TIME = '12345'
+  TEST_ABS_AWS_MOM_SIZE = TEST_ABS_AWS_SIZE
+  TEST_ABS_AWS_METRICS_SIZE = TEST_ABS_AWS_SIZE
+
+  TEST_AWSDIRECT_URL = "#{TEST_ABS_BASE_URL}/awsdirect"
   TEST_AWSDIRECT_URI = URI(TEST_AWSDIRECT_URL)
-  TEST_AWSDIRECTRETURN_URL = "#{TEST_BASE_URL}/awsdirectreturn"
+  TEST_AWSDIRECTRETURN_URL = "#{TEST_ABS_BASE_URL}/awsdirectreturn"
   TEST_AWSDIRECTRETURN_URI = URI(TEST_AWSDIRECTRETURN_URL)
 
   TEST_HOSTNAME = 'testing.puppet.net'
   TEST_ABS_TYPE = 'el-7-x86_64'
   TEST_BEAKER_TYPE = 'centos-7-x86-64-west'
   TEST_ENGINE = 'aws'
+  TEST_BEAKER_PE_VERSION = '2018.1.0-rc17'
 
   TEST_AWSDIRECT_REQUEST_BODY =
-    { 'platform': 'amazon-6-x86_64',
-      'image_id': 'ami-a07379d9',
-      'size': 'c3.large',
-      'region': 'us-west-2',
-      'reap_time': 10800,
+    { 'platform': TEST_ABS_AWS_PLATFORM,
+      'image_id': TEST_ABS_AWS_IMAGE_ID,
+      'size': TEST_ABS_AWS_SIZE,
+      'region': TEST_ABS_AWS_REGION,
+      'reap_time': TEST_ABS_AWS_REAP_TIME,
       'tags':
           {'field1': 'value1', 'field2': 'value2'}
     }.to_json
+
+  TEST_AWSDIRECT_MOM_REQUEST_BODY =
+      { 'platform': TEST_ABS_AWS_PLATFORM,
+        'image_id': TEST_ABS_AWS_IMAGE_ID,
+        'size': TEST_ABS_AWS_MOM_SIZE,
+        'region': TEST_ABS_AWS_REGION,
+        'reap_time': TEST_ABS_AWS_REAP_TIME,
+        'tags':
+            {'role': 'mom', 'pe_version': 'value2'}
+      }.to_json
+
+  TEST_AWSDIRECT_METRICS_REQUEST_BODY =
+      { 'platform': TEST_ABS_AWS_PLATFORM,
+        'image_id': TEST_ABS_AWS_IMAGE_ID,
+        'size': TEST_ABS_AWS_METRICS_SIZE,
+        'region': TEST_ABS_AWS_REGION,
+        'reap_time': TEST_ABS_AWS_REAP_TIME,
+        'tags':
+            {'field1': 'value1', 'pe_version': 'value2'}
+      }.to_json
 
   TEST_AWSDIRECT_RESPONSE_BODY =
     { 'hostname': TEST_HOSTNAME,
@@ -57,7 +95,82 @@ describe AbsHelperClass do
         'type': TEST_BEAKER_TYPE,
         'engine': TEST_ENGINE}].to_json
 
-  TEST_A2A_HOSTS = {'mom': 'c4.2xlarge', 'metrics': 'c4.2xlarge'}
+  TEST_A2A_HOSTS = {'mom': TEST_ABS_AWS_MOM_SIZE, 'metrics': TEST_ABS_AWS_METRICS_SIZE}
+
+  before {
+    ENV['BEAKER_PE_VER'] = TEST_BEAKER_PE_VERSION
+    subject.instance_variable_set(:@abs_base_url, TEST_ABS_BASE_URL)
+  }
+
+  describe '#abs_initialize' do
+
+    context 'when environment variables are specified' do
+
+      it 'sets the properties to the specified values' do
+
+        ENV['ABS_BASE_URL'] = TEST_ABS_BASE_URL
+        ENV['ABS_AWS_PLATFORM'] = TEST_ABS_AWS_PLATFORM
+        ENV['ABS_AWS_IMAGE_ID'] = TEST_ABS_AWS_IMAGE_ID
+        ENV['ABS_AWS_SIZE'] = TEST_ABS_AWS_SIZE
+        ENV['ABS_AWS_REGION'] = TEST_ABS_AWS_REGION
+        ENV['ABS_AWS_REAP_TIME'] = TEST_ABS_AWS_REAP_TIME
+        ENV['ABS_AWS_MOM_SIZE'] = TEST_ABS_AWS_MOM_SIZE
+        ENV['ABS_AWS_METRICS_SIZE'] = TEST_ABS_AWS_METRICS_SIZE
+
+        subject.abs_initialize
+        expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
+        expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
+        expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
+        expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
+        expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
+        expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
+        expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
+        expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
+
+      end
+
+    end
+
+    context 'when environment variables are not specified' do
+
+      it 'sets the properties to the default values' do
+        pending 'resolve stubbed constant issue'
+
+        ENV['ABS_BASE_URL'] = nil
+        ENV['ABS_AWS_PLATFORM'] = nil
+        ENV['ABS_AWS_IMAGE_ID'] = nil
+        ENV['ABS_AWS_SIZE'] = nil
+        ENV['ABS_AWS_REGION'] = nil
+        ENV['ABS_AWS_REAP_TIME'] = nil
+        ENV['ABS_AWS_MOM_SIZE'] = nil
+        ENV['ABS_AWS_METRICS_SIZE'] = nil
+
+        stub_const('ABS_BASE_URL', TEST_ABS_BASE_URL)
+        stub_const('ABS_AWS_PLATFORM', TEST_ABS_AWS_PLATFORM)
+        stub_const('ABS_AWS_IMAGE_ID', TEST_ABS_AWS_IMAGE_ID)
+        stub_const('ABS_AWS_SIZE', TEST_ABS_AWS_SIZE)
+        stub_const('ABS_AWS_MOM_SIZE', TEST_ABS_AWS_MOM_SIZE)
+        stub_const('ABS_AWS_METRICS_SIZE', TEST_ABS_AWS_METRICS_SIZE)
+        stub_const('ABS_AWS_REGION', TEST_ABS_AWS_REGION)
+        stub_const('ABS_AWS_REAP_TIME', TEST_ABS_AWS_REAP_TIME)
+
+        # TODO: stubbed constants aren't used by the properties in the code under test
+        subject.abs_initialize
+
+        expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
+        expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
+        expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
+        expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
+        expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
+        expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
+        expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
+        expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
+
+      end
+
+    end
+
+  end
 
   describe '#abs_get_token_from_fog_file' do
 
@@ -80,13 +193,14 @@ describe AbsHelperClass do
 
       context 'when the .fog file does not contain the abs token' do
 
-        it 'returns nil' do
+        it 'reports the error and returns nil' do
           fog_file =
               ':default:
               :not_abs_token: xyz123'
 
           expect(File).to receive(:exist?).and_return(true)
           expect(File).to receive(:read).and_return(fog_file)
+          expect(subject).to receive(:puts).with(/ABS token not found/).at_least(:once)
 
           expect(subject.abs_get_token_from_fog_file).to eq(nil)
         end
@@ -99,11 +213,10 @@ describe AbsHelperClass do
 
       it 'reports the error and returns nil' do
         expect(File).to receive(:exist?).and_return(false)
-        expect(subject).to receive(:puts).at_least(:once)
+        expect(subject).to receive(:puts).with(/fog file not found/).at_least(:once)
 
         expect(subject.abs_get_token_from_fog_file).to eq(nil)
       end
-
 
     end
 
@@ -138,7 +251,7 @@ describe AbsHelperClass do
 
           ENV['ABS_TOKEN'] = nil
           expect(subject).to receive(:abs_get_token_from_fog_file).and_return(nil)
-          expect(subject).to receive(:puts)
+          expect(subject).to receive(:puts).with(/An ABS token must be set/)
           expect(subject.abs_get_token).to eq(nil)
         end
 
@@ -189,7 +302,9 @@ describe AbsHelperClass do
 
     context 'when the response is nil' do
 
-      it 'returns false' do
+      it 'reports the error and returns false' do
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/).at_least(:once)
         expect(subject.abs_is_valid_response?(nil)).to eq(false)
       end
 
@@ -197,10 +312,17 @@ describe AbsHelperClass do
 
     context 'when the response code is not valid' do
 
-      it 'returns false' do
+      # TODO: Verify the full error message including values?
+
+      it 'reports the error and returns false' do
         expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
         expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_INVALID_RESPONSE_CODE)
         expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/)
+        expect(subject).to receive(:puts).with(/code/)
+        expect(subject).to receive(:puts).with(/body/)
 
         expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
       end
@@ -209,10 +331,15 @@ describe AbsHelperClass do
 
     context 'when the response body is empty' do
 
-      it 'returns false' do
+      it 'reports the error and returns false' do
         expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
         expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
         expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_INVALID_RESPONSE_BODY)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/)
+        expect(subject).to receive(:puts).with(/code/)
+        expect(subject).to receive(:puts).with(/body/)
 
         expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
       end
@@ -221,10 +348,15 @@ describe AbsHelperClass do
 
     context 'when the response body is nil' do
 
-      it 'returns false' do
+      it 'reports the error and returns false' do
         expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
         expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
         expect(test_http_response).to receive(:body).at_least(:once).and_return(nil)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/)
+        expect(subject).to receive(:puts).with(/code/)
+        expect(subject).to receive(:puts).with(/body/)
 
         expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
       end
@@ -260,61 +392,65 @@ describe AbsHelperClass do
 
     context 'when a valid response is returned' do
 
-      it 'sets the environment variable, logs the hosts, and returns the response(s)' do
+      it 'sets the environment variable, logs the hosts, returns the response(s), reports no errors and does not return the hosts' do
         ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
-        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(test_http_response)
+        expect(subject).to receive(:abs_initialize).once
+        expect(subject).to receive(:abs_get_a2a_hosts).once.and_return(TEST_A2A_HOSTS)
+        allow(TEST_ABS_RESOURCE_HOSTS).to receive(:each)
 
-        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
-        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(subject).to receive(:abs_get_awsdirect_request_body).with(:mom, TEST_ABS_AWS_MOM_SIZE).once.and_return(TEST_AWSDIRECT_MOM_REQUEST_BODY)
+        expect(subject).to receive(:abs_get_awsdirect_request_body).with(:metrics, TEST_ABS_AWS_METRICS_SIZE).and_return(TEST_AWSDIRECT_METRICS_REQUEST_BODY)
+
+        expect(subject).to receive(:abs_request_awsdirect).once.with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_MOM_REQUEST_BODY).and_return(test_http_response)
+        expect(subject).to receive(:abs_request_awsdirect).once.with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_METRICS_REQUEST_BODY).and_return(test_http_response)
+
+        expect(subject).to receive(:abs_is_valid_response?).at_least(:once).with(test_http_response).and_return(true)
+
         expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+        expect(subject).to receive(:abs_reformat_resource_host).at_least(:once).with(TEST_AWSDIRECT_RESPONSE_BODY).and_return(TEST_REFORMATTED_RESPONSE_BODY)
+
+        expect(subject).not_to receive(:puts).with(/Returning any provisioned hosts/)
+        expect(subject).not_to receive(:puts).with(/Unable to provision host for role/)
+        expect(subject).not_to receive(:puts).with(/No ABS hosts were provisioned/)
+
+        expect(subject).not_to receive(:abs_return_resource_hosts)
 
         expect(subject.abs_get_resource_hosts).to eq(TEST_ABS_RESOURCE_HOSTS)
       end
 
     end
 
-    context 'when an invalid response code is returned' do
+    # TODO: verify error reporting or trust the tests for abs_is_valid_response?
+    context 'when an invalid response is returned' do
 
-      it 'reports the error and returns nil' do
-        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
-        test_expected_result = nil
+      context 'when this is the first request' do
 
-        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(test_http_response)
+        it 'does not attempt to return hosts, reports the error and returns nil' do
+          # TODO: set up and verify this being the first request
+          ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+          test_expected_result = nil
 
-        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
-        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_INVALID_RESPONSE_CODE)
-        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_INVALID_RESPONSE_BODY)
+          expect(subject).to receive(:abs_request_awsdirect).once.and_return(test_http_response)
+          expect(subject).to receive(:abs_is_valid_response?).once.with(test_http_response).and_return(false)
 
-        expect(subject.abs_get_resource_hosts).to eq(test_expected_result)
+          allow(subject).to receive(:puts)
+          expect(subject).not_to receive(:puts).with(/Returning any provisioned hosts/)
+          expect(subject).not_to receive(:abs_return_resource_hosts)
+
+          expect(subject).to receive(:puts).with(/Unable to provision host for role/)
+          expect(subject).to receive(:puts).with(/No ABS hosts were provisioned/)
+
+          expect(subject.abs_get_resource_hosts).to eq(test_expected_result)
+        end
+
       end
 
-    end
+      context 'when there have been previous successful requests' do
 
-    context 'when an invalid response body is returned' do
+        it 'attempts to return the previously provisioned hosts' do
+          skip
+        end
 
-      it 'reports the error and returns nil' do
-        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
-        test_expected_result = nil
-
-        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(test_http_response)
-
-        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
-        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
-        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_INVALID_RESPONSE_BODY)
-
-        expect(subject.abs_get_resource_hosts).to eq(test_expected_result)
-      end
-
-    end
-
-    context 'when the response is nil' do
-
-      it 'reports the error and returns nil' do
-        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
-        test_expected_result = nil
-
-        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(nil)
-        expect(subject.abs_get_resource_hosts).to eq(test_expected_result)
       end
 
     end
@@ -366,34 +502,17 @@ describe AbsHelperClass do
     test_uri = TEST_AWSDIRECTRETURN_URI
     test_body = TEST_AWSDIRECTRETURN_REQUEST_BODY
 
-    context 'when an array of hosts is specified via ABS_RESOURCE_HOSTS' do
-
-      it 'submits requests to return the hosts and returns the host array' do
-        ENV['ABS_RESOURCE_HOSTS'] = TEST_ABS_RESOURCE_HOSTS
-
-        expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
-
-        expect(subject).to receive(:abs_get_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
-        expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(nil)
-
-        expect(subject.abs_return_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
-      end
-
-    end
-
-    context 'when an array of hosts is specified via last_abs_resource_hosts.log' do
+    context 'when an array of hosts is specified' do
 
       it 'submits requests to returns the hosts and returns the host array' do
-        ENV['ABS_RESOURCE_HOSTS'] = nil
-
-        expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
-
-        expect(subject).to receive(:abs_get_last_abs_resource_hosts).at_least(:once).and_return(TEST_ABS_RESOURCE_HOSTS)
-
+        expect(subject).to receive(:abs_initialize)
         expect(subject).to receive(:abs_get_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
         expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(nil)
 
-        expect(subject.abs_return_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
+        allow(subject).to receive(:puts)
+        expect(subject).not_to receive(:puts).with(/De-provisioning via return_abs_resource_hosts requires an array of hostnames/)
+
+        expect(subject.abs_return_resource_hosts(TEST_ABS_RESOURCE_HOSTS)).to eq(TEST_ABS_RESOURCE_HOSTS)
       end
 
     end
@@ -402,13 +521,12 @@ describe AbsHelperClass do
 
       # TODO: improve
       it 'reports the error and returns nil' do
-        ENV['ABS_RESOURCE_HOSTS'] = nil
+        expect(subject).to receive(:abs_initialize)
 
-        expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/De-provisioning via return_abs_resource_hosts requires an array of hostnames/)
 
-        expect(subject).to receive(:abs_get_last_abs_resource_hosts).at_least(:once).and_return(nil)
-        expect(subject.abs_return_resource_hosts).to eq(nil)
-
+        expect(subject.abs_return_resource_hosts(nil)).to eq(nil)
       end
 
     end

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -77,6 +77,7 @@ describe AbsHelperClass do
 
   TEST_AWSDIRECTRETURN_REQUEST_BODY = {'hostname': TEST_HOSTNAME}.to_json
 
+  TEST_VALID_RESPONSE_BODY = 'OK'
   TEST_INVALID_RESPONSE_BODY = ''
   TEST_VALID_RESPONSE_CODE = '200'
   TEST_INVALID_RESPONSE_CODE = '777'
@@ -379,7 +380,7 @@ describe AbsHelperClass do
 
     context 'when a request is successfully prepared' do
 
-      it 'performs the request and returns the response' do
+      it 'performs the request, reports and returns the response' do
         expect(subject).to receive(:abs_get_request_post).and_return(test_http_request)
         allow(test_http_request).to receive(:body=)
 
@@ -390,7 +391,12 @@ describe AbsHelperClass do
         allow(test_net_http_instance).to receive(:read_timeout=)
         expect(test_net_http_instance).to receive(:request).with(test_http_request).and_return(test_http_response)
 
-        allow(test_http_response).to receive(:body)
+        expect(test_http_response).to receive(:code).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).and_return(TEST_VALID_RESPONSE_BODY)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).at_least(:once).with("response code: #{TEST_VALID_RESPONSE_CODE}")
+        expect(subject).to receive(:puts).at_least(:once).with("response body: #{TEST_VALID_RESPONSE_BODY}")
 
         expect(subject.abs_request_awsdirect(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_REQUEST_BODY)).to eq(test_http_response)
 

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -1,4 +1,4 @@
-require './setup/helpers/abs_helper'
+require "./setup/helpers/abs_helper"
 
 class AbsHelperClass
   include AbsHelper
@@ -11,649 +11,341 @@ describe AbsHelperClass do
   let(:test_http_request) { Class.new }
   let(:test_http_response) { Class.new }
 
-  TEST_ABS_TOKEN = 'test_abs_token_zzz'
-  TEST_ABS_BASE_URL = 'https://testing.puppet.net/v2'
-  TEST_ABS_AWS_PLATFORM = 'test-amazon-6-x86_64'
-  TEST_ABS_AWS_IMAGE_ID = 'test-ami-a07379d9'
-  TEST_ABS_AWS_SIZE = 'test.c3.large'
-  TEST_ABS_AWS_REGION = 'test-us-west-2'
-  TEST_ABS_AWS_REAP_TIME = '12345'
-  TEST_ABS_AWS_MOM_SIZE = TEST_ABS_AWS_SIZE
-  TEST_ABS_AWS_METRICS_SIZE = TEST_ABS_AWS_SIZE
+  TEST_ABS_TOKEN = "test_abs_token_zzz".freeze
+  TEST_ABS_BASE_URL = "https://testing.puppet.net/v2".freeze
+  TEST_PLATFORM = "test-amazon-6-x86_64".freeze
+  TEST_IMAGE_ID = "test-ami-a07379d9".freeze
+  TEST_SIZE = "test.c3.large".freeze
+  TEST_VOLUME_SIZE = "80".freeze
+  TEST_REGION = "test-us-west-2".freeze
+  TEST_REAP_TIME = "12345".freeze
 
-  TEST_AWSDIRECT_URL = "#{TEST_ABS_BASE_URL}/awsdirect"
-  TEST_AWSDIRECT_URI = URI(TEST_AWSDIRECT_URL)
-  TEST_AWSDIRECTRETURN_URL = "#{TEST_ABS_BASE_URL}/awsdirectreturn"
-  TEST_AWSDIRECTRETURN_URI = URI(TEST_AWSDIRECTRETURN_URL)
+  # TODO: update to use different values for mom and metrics
+  TEST_MOM_ROLE = "mom".freeze
+  TEST_MOM_SIZE = TEST_SIZE
+  TEST_MOM_VOLUME_SIZE = TEST_VOLUME_SIZE
+  TEST_METRICS_ROLE = "metrics".freeze
+  TEST_METRICS_SIZE = TEST_SIZE
+  TEST_METRICS_VOLUME_SIZE = TEST_VOLUME_SIZE
 
-  TEST_HOSTNAME = 'testing.puppet.net'
-  TEST_ABS_TYPE = 'el-7-x86_64'
-  TEST_BEAKER_TYPE = 'centos-7-x86-64-west'
-  TEST_ENGINE = 'aws'
-  TEST_BEAKER_PE_VERSION = '2018.1.0-rc17'
-  TEST_ROLE = 'test-role'
+  TEST_AWSDIRECT_URL = "#{TEST_ABS_BASE_URL}/awsdirect".freeze
+  TEST_AWSDIRECT_URI = URI(TEST_AWSDIRECT_URL).freeze
+  TEST_AWSDIRECTRETURN_URL = "#{TEST_ABS_BASE_URL}/awsdirectreturn".freeze
+  TEST_AWSDIRECTRETURN_URI = URI(TEST_AWSDIRECTRETURN_URL).freeze
 
-  TEST_EXPECTED_REQUEST_HEADERS = {'Content-Type' => 'application/json', 'X-Auth-Token' => TEST_ABS_TOKEN}
+  TEST_HOSTNAME = "testing.puppet.net".freeze
+  TEST_HOSTNAME_MOM = "mom.puppet.net".freeze
+  TEST_HOSTNAME_METRICS = "metrics.puppet.net".freeze
+
+  TEST_ABS_TYPE = "el-7-x86_64".freeze
+  TEST_BEAKER_TYPE = "centos-7-x86-64-west".freeze
+  TEST_ENGINE = "aws".freeze
+  TEST_BEAKER_PE_VERSION = "2018.1.0-rc17".freeze
+  TEST_ROLE = "test-role".freeze
+
+  TEST_EXPECTED_REQUEST_HEADERS = { "Content-Type" => "application/json",
+                                    "X-Auth-Token" => TEST_ABS_TOKEN }.freeze
 
   TEST_AWSDIRECT_REQUEST_BODY =
-  { 'platform': TEST_ABS_AWS_PLATFORM,
-    'image_id': TEST_ABS_AWS_IMAGE_ID,
-    'size': TEST_ABS_AWS_SIZE,
-    'region': TEST_ABS_AWS_REGION,
-    'reap_time': TEST_ABS_AWS_REAP_TIME,
-    'tags':
-        {'role': TEST_ROLE, 'pe_version': TEST_BEAKER_PE_VERSION}
-  }.to_json
+    { 'platform': TEST_PLATFORM,
+      'image_id': TEST_IMAGE_ID,
+      'size': TEST_SIZE,
+      'region': TEST_REGION,
+      'reap_time': TEST_REAP_TIME,
+      'tags':
+          { 'role': TEST_ROLE, 'pe_version': TEST_BEAKER_PE_VERSION },
+      'volume_size': TEST_VOLUME_SIZE }.to_json.freeze
 
   TEST_AWSDIRECT_MOM_REQUEST_BODY =
-      { 'platform': TEST_ABS_AWS_PLATFORM,
-        'image_id': TEST_ABS_AWS_IMAGE_ID,
-        'size': TEST_ABS_AWS_MOM_SIZE,
-        'region': TEST_ABS_AWS_REGION,
-        'reap_time': TEST_ABS_AWS_REAP_TIME,
-        'tags':
-            {'role': 'mom', 'pe_version': 'value2'}
-      }.to_json
+    { 'platform': TEST_PLATFORM,
+      'image_id': TEST_IMAGE_ID,
+      'size': TEST_MOM_SIZE,
+      'region': TEST_REGION,
+      'reap_time': TEST_REAP_TIME,
+      'tags':
+          { 'role': "mom", 'pe_version': "value2" },
+      'volume_size': TEST_VOLUME_SIZE }.to_json.freeze
 
   TEST_AWSDIRECT_METRICS_REQUEST_BODY =
-      { 'platform': TEST_ABS_AWS_PLATFORM,
-        'image_id': TEST_ABS_AWS_IMAGE_ID,
-        'size': TEST_ABS_AWS_METRICS_SIZE,
-        'region': TEST_ABS_AWS_REGION,
-        'reap_time': TEST_ABS_AWS_REAP_TIME,
-        'tags':
-            {'field1': 'value1', 'pe_version': 'value2'}
-      }.to_json
+    { 'platform': TEST_PLATFORM,
+      'image_id': TEST_IMAGE_ID,
+      'size': TEST_METRICS_SIZE,
+      'region': TEST_REGION,
+      'reap_time': TEST_REAP_TIME,
+      'tags':
+          { 'field1': "value1", 'pe_version': "value2" },
+      'volume_size': TEST_VOLUME_SIZE }.to_json.freeze
 
   TEST_AWSDIRECT_RESPONSE_BODY =
     { 'hostname': TEST_HOSTNAME,
-      'instance_id': 'i-0721e8f28c67a0axx',
-      'type': TEST_ABS_TYPE}.to_json
+      'instance_id': "i-0721e8f28c67a0axx",
+      'type': TEST_ABS_TYPE }.to_json.freeze
 
   TEST_REFORMATTED_RESPONSE_BODY =
-      { 'hostname': TEST_HOSTNAME,
-        'type': TEST_BEAKER_TYPE,
-        'engine': TEST_ENGINE}.to_json
+    { 'hostname': TEST_HOSTNAME,
+      'type': TEST_BEAKER_TYPE,
+      'engine': TEST_ENGINE }.to_json.freeze
 
-  TEST_AWSDIRECTRETURN_REQUEST_BODY = {'hostname': TEST_HOSTNAME}.to_json
+  TEST_AWSDIRECTRETURN_REQUEST_BODY = { 'hostname': TEST_HOSTNAME }.to_json.freeze
 
-  TEST_VALID_RESPONSE_BODY = 'OK'
-  TEST_INVALID_RESPONSE_BODY = ''
-  TEST_VALID_RESPONSE_CODE = '200'
-  TEST_INVALID_RESPONSE_CODE = '777'
+  TEST_VALID_RESPONSE_BODY = "OK".freeze
+  TEST_INVALID_RESPONSE_BODY = "".freeze
+  TEST_VALID_RESPONSE_CODE = "200".freeze
+  TEST_INVALID_RESPONSE_CODE = "777".freeze
 
-  TEST_ABS_RESOURCE_HOSTS_SINGLE = [
-      { 'hostname': TEST_HOSTNAME,
-        'type': TEST_BEAKER_TYPE,
-        'engine': TEST_ENGINE}].to_json
+  # TEST_A2A_HOSTS = { 'mom': TEST_ABS_AWS_MOM_SIZE, 'metrics': TEST_ABS_AWS_METRICS_SIZE }.freeze
 
-  TEST_ABS_RESOURCE_HOSTS = [
-      { 'hostname': TEST_HOSTNAME,
-        'type': TEST_BEAKER_TYPE,
-        'engine': TEST_ENGINE},
-      { 'hostname': TEST_HOSTNAME,
-        'type': TEST_BEAKER_TYPE,
-        'engine': TEST_ENGINE}].to_json
+  TEST_HOST = JSON.parse(TEST_REFORMATTED_RESPONSE_BODY).freeze
+
+  TEST_A2A_MOM =
+    { 'role': "mom",
+      'size': TEST_SIZE,
+      'volume_size': TEST_VOLUME_SIZE }.freeze
+
+  TEST_A2A_METRICS =
+    { 'role': "metrics",
+      'size': TEST_SIZE,
+      'volume_size': TEST_VOLUME_SIZE }.freeze
+
+  TEST_A2A_HOSTS = [TEST_A2A_MOM, TEST_A2A_METRICS].freeze
+
+  # TODO: update to use mom and metrics
+  TEST_ABS_HOSTS = [TEST_HOST, TEST_HOST].freeze
+
+  # the final result is converted back to json
+  TEST_ABS_RESOURCE_HOSTS_SINGLE = [TEST_HOST].to_json.freeze
+  TEST_ABS_RESOURCE_HOSTS = TEST_ABS_HOSTS.to_json
 
   TEST_INVALID_ABS_RESOURCE_HOSTS = [
-      { 'hostz': TEST_HOSTNAME,
-        'typez': TEST_BEAKER_TYPE,
-        'enginez': TEST_ENGINE},
-      { 'hostz': TEST_HOSTNAME,
-        'typez': TEST_BEAKER_TYPE,
-        'enginez': TEST_ENGINE}].to_json
+    { 'hostz': TEST_HOSTNAME,
+      'typez': TEST_BEAKER_TYPE,
+      'enginez': TEST_ENGINE },
+    { 'hostz': TEST_HOSTNAME,
+      'typez': TEST_BEAKER_TYPE,
+      'enginez': TEST_ENGINE }
+  ].to_json.freeze
 
-  TEST_A2A_HOSTS = {'mom': TEST_ABS_AWS_MOM_SIZE, 'metrics': TEST_ABS_AWS_METRICS_SIZE}
-
-  before {
-    ENV['BEAKER_PE_VER'] = TEST_BEAKER_PE_VERSION
+  before do
+    ENV["BEAKER_PE_VER"] = TEST_BEAKER_PE_VERSION
     subject.instance_variable_set(:@abs_base_url, TEST_ABS_BASE_URL)
     subject.instance_variable_set(:@abs_beaker_pe_version, TEST_BEAKER_PE_VERSION)
-  }
+  end
 
-  describe '#abs_initialize' do
+  describe "#abs_initialize" do
+    context "when the user has a token" do
+      context "when environment variables are specified" do
+        it "sets the properties to the specified values and returns true" do
+          ENV["ABS_TOKEN"] = TEST_ABS_TOKEN
 
-    context 'when the user has a token' do
+          ENV["ABS_BASE_URL"] = TEST_ABS_BASE_URL
+          ENV["ABS_AWS_PLATFORM"] = TEST_PLATFORM
+          ENV["ABS_AWS_IMAGE_ID"] = TEST_IMAGE_ID
+          ENV["ABS_AWS_SIZE"] = TEST_SIZE
+          ENV["ABS_AWS_VOLUME_SIZE"] = TEST_VOLUME_SIZE
+          ENV["ABS_AWS_REGION"] = TEST_REGION
+          ENV["ABS_AWS_REAP_TIME"] = TEST_REAP_TIME
+          ENV["ABS_AWS_MOM_SIZE"] = TEST_MOM_SIZE
+          ENV["ABS_AWS_METRICS_SIZE"] = TEST_METRICS_SIZE
+          ENV["BEAKER_PE_VER"] = TEST_BEAKER_PE_VERSION
 
-      context 'when environment variables are specified' do
-
-        it 'sets the properties to the specified values and returns true' do
-
-          ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
-
-          ENV['ABS_BASE_URL'] = TEST_ABS_BASE_URL
-          ENV['ABS_AWS_PLATFORM'] = TEST_ABS_AWS_PLATFORM
-          ENV['ABS_AWS_IMAGE_ID'] = TEST_ABS_AWS_IMAGE_ID
-          ENV['ABS_AWS_SIZE'] = TEST_ABS_AWS_SIZE
-          ENV['ABS_AWS_REGION'] = TEST_ABS_AWS_REGION
-          ENV['ABS_AWS_REAP_TIME'] = TEST_ABS_AWS_REAP_TIME
-          ENV['ABS_AWS_MOM_SIZE'] = TEST_ABS_AWS_MOM_SIZE
-          ENV['ABS_AWS_METRICS_SIZE'] = TEST_ABS_AWS_METRICS_SIZE
-          ENV['BEAKER_PE_VER'] = TEST_BEAKER_PE_VERSION
-
-          expect(subject).to receive(:abs_get_token).and_return(TEST_ABS_TOKEN)
+          expect(subject).to receive(:get_abs_token).and_return(TEST_ABS_TOKEN)
           expect(subject.abs_initialize).to eq(true)
 
-          expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
-          expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
-          expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
-          expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
-          expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
-          expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
-          expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
-          expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
-          expect(subject.instance_variable_get(:@abs_beaker_pe_version)). to eq(TEST_BEAKER_PE_VERSION)
-
+          expect(subject.instance_variable_get(:@abs_base_url)).to eq(TEST_ABS_BASE_URL)
+          expect(subject.instance_variable_get(:@aws_platform)).to eq(TEST_PLATFORM)
+          expect(subject.instance_variable_get(:@aws_image_id)).to eq(TEST_IMAGE_ID)
+          expect(subject.instance_variable_get(:@aws_size)).to eq(TEST_SIZE)
+          expect(subject.instance_variable_get(:@aws_volume_size)).to eq(TEST_VOLUME_SIZE)
+          expect(subject.instance_variable_get(:@aws_region)).to eq(TEST_REGION)
+          expect(subject.instance_variable_get(:@aws_reap_time)).to eq(TEST_REAP_TIME)
+          expect(subject.instance_variable_get(:@mom_size)).to eq(TEST_MOM_SIZE)
+          expect(subject.instance_variable_get(:@metrics_size))
+            .to eq(TEST_METRICS_SIZE)
+          expect(subject.instance_variable_get(:@abs_beaker_pe_version))
+            .to eq(TEST_BEAKER_PE_VERSION)
         end
-
       end
 
-      context 'when environment variables are not specified' do
+      context "when environment variables are not specified" do
+        it "sets the properties to the default values and returns true" do
+          pending "resolve stubbed constant issue"
 
-        it 'sets the properties to the default values and returns true' do
-          pending 'resolve stubbed constant issue'
+          ENV["ABS_BASE_URL"] = nil
+          ENV["ABS_AWS_PLATFORM"] = nil
+          ENV["ABS_AWS_IMAGE_ID"] = nil
+          ENV["ABS_AWS_SIZE"] = nil
+          ENV["ABS_AWS_VOLUME_SIZE"] = nil
+          ENV["ABS_AWS_REGION"] = nil
+          ENV["ABS_AWS_REAP_TIME"] = nil
+          ENV["ABS_AWS_MOM_SIZE"] = nil
+          ENV["ABS_AWS_METRICS_SIZE"] = nil
 
-          ENV['ABS_BASE_URL'] = nil
-          ENV['ABS_AWS_PLATFORM'] = nil
-          ENV['ABS_AWS_IMAGE_ID'] = nil
-          ENV['ABS_AWS_SIZE'] = nil
-          ENV['ABS_AWS_REGION'] = nil
-          ENV['ABS_AWS_REAP_TIME'] = nil
-          ENV['ABS_AWS_MOM_SIZE'] = nil
-          ENV['ABS_AWS_METRICS_SIZE'] = nil
-
-          stub_const('ABS_BASE_URL', TEST_ABS_BASE_URL)
-          stub_const('ABS_AWS_PLATFORM', TEST_ABS_AWS_PLATFORM)
-          stub_const('ABS_AWS_IMAGE_ID', TEST_ABS_AWS_IMAGE_ID)
-          stub_const('ABS_AWS_SIZE', TEST_ABS_AWS_SIZE)
-          stub_const('ABS_AWS_MOM_SIZE', TEST_ABS_AWS_MOM_SIZE)
-          stub_const('ABS_AWS_METRICS_SIZE', TEST_ABS_AWS_METRICS_SIZE)
-          stub_const('ABS_AWS_REGION', TEST_ABS_AWS_REGION)
-          stub_const('ABS_AWS_REAP_TIME', TEST_ABS_AWS_REAP_TIME)
+          stub_const("ABS_BASE_URL", TEST_ABS_BASE_URL)
+          stub_const("ABS_AWS_PLATFORM", TEST_PLATFORM)
+          stub_const("ABS_AWS_IMAGE_ID", TEST_IMAGE_ID)
+          stub_const("ABS_AWS_SIZE", TEST_SIZE)
+          stub_const("ABS_AWS_VOLUME_SIZE", TEST_VOLUME_SIZE)
+          stub_const("ABS_AWS_MOM_SIZE", TEST_MOM_SIZE)
+          stub_const("ABS_AWS_METRICS_SIZE", TEST_METRICS_SIZE)
+          stub_const("ABS_AWS_REGION", TEST_REGION)
+          stub_const("ABS_AWS_REAP_TIME", TEST_REAP_TIME)
 
           # TODO: stubbed constants aren't used by the properties in the code under test
           # subject.abs_initialize
 
-          expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
-          expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
-          expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
-          expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
-          expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
-          expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
-          expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
-          expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
+          expect(subject.instance_variable_get(:@abs_base_url)).to eq(TEST_ABS_BASE_URL)
+          expect(subject.instance_variable_get(:@aws_platform)).to eq(TEST_PLATFORM)
+          expect(subject.instance_variable_get(:@aws_image_id)).to eq(TEST_IMAGE_ID)
+          expect(subject.instance_variable_get(:@aws_size)).to eq(TEST_SIZE)
+          expect(subject.instance_variable_get(:@aws_volume_size)).to eq(TEST_VOLUME_SIZE)
+          expect(subject.instance_variable_get(:@aws_region)).to eq(TEST_REGION)
+          expect(subject.instance_variable_get(:@aws_reap_time)).to eq(TEST_REAP_TIME)
+          expect(subject.instance_variable_get(:@mom_size)).to eq(TEST_MOM_SIZE)
+          expect(subject.instance_variable_get(:@metrics_size))
+            .to eq(TEST_METRICS_SIZE)
 
           subject.abs_initialize
         end
-
       end
-
     end
 
-    context 'when the user does not have a token' do
+    context "when the user does not have a token" do
+      it "returns false" do
+        ENV["ABS_TOKEN"] = nil
 
-      it 'returns false' do
-        ENV['ABS_TOKEN'] = nil
-
-        expect(subject).to receive(:abs_get_token).and_return(false)
+        expect(subject).to receive(:get_abs_token).and_return(false)
         expect(subject.abs_initialize).to eq(false)
       end
-
-    end
-
-  end
-
-  describe '#abs_get_aws_tags' do
-
-    context 'when a pe version is specified' do
-
-      it 'returns tags including the specified role and pe version' do
-        test_expected_tags = {'role': TEST_ROLE, 'pe_version': TEST_BEAKER_PE_VERSION}
-
-        subject.instance_variable_set(:@abs_beaker_pe_version, TEST_BEAKER_PE_VERSION)
-        expect(subject.abs_get_aws_tags(TEST_ROLE)). to eq(test_expected_tags)
-      end
-
-    end
-
-    context 'when a pe version is not specified' do
-
-      it 'returns tags that include only the specified role' do
-        test_expected_tags = {'role': TEST_ROLE}
-
-        subject.instance_variable_set(:@abs_beaker_pe_version, nil)
-        expect(subject.abs_get_aws_tags(TEST_ROLE)). to eq(test_expected_tags)
-      end
-
-    end
-
-  end
-
-  describe '#abs_get_awsdirect_request_body' do
-
-    before {
-      subject.instance_variable_set("@abs_aws_size", TEST_ABS_AWS_SIZE)
-      subject.instance_variable_set("@abs_aws_platform", TEST_ABS_AWS_PLATFORM)
-      subject.instance_variable_set("@abs_aws_image_id", TEST_ABS_AWS_IMAGE_ID)
-      subject.instance_variable_set("@abs_aws_region", TEST_ABS_AWS_REGION)
-      subject.instance_variable_set("@abs_aws_reap_time", TEST_ABS_AWS_REAP_TIME)
-    }
-
-    context 'when a role is specified' do
-
-      it 'uses the default size and returns the expected result' do
-        test_expected_request_body = TEST_AWSDIRECT_REQUEST_BODY
-        expect(subject.abs_get_awsdirect_request_body(TEST_ROLE)). to eq(test_expected_request_body)
-      end
-
-    end
-
-    context 'when a role and size are specified' do
-
-      it 'uses the specified size and returns the expected result' do
-        test_role = 'new-role'
-        test_size = 'new-size'
-
-        test_expected_request_body =
-            { 'platform': TEST_ABS_AWS_PLATFORM,
-              'image_id': TEST_ABS_AWS_IMAGE_ID,
-              'size': test_size,
-              'region': TEST_ABS_AWS_REGION,
-              'reap_time': TEST_ABS_AWS_REAP_TIME,
-              'tags':
-                  {'role': test_role, 'pe_version': TEST_BEAKER_PE_VERSION}
-            }.to_json
-
-        expect(subject.abs_get_awsdirect_request_body(test_role, test_size)). to eq(test_expected_request_body)
-      end
-
-    end
-
-  end
-
-  describe '#abs_get_awsdirectreturn_request_body' do
-
-    context 'when a hostname is specified' do
-
-      it 'returns the expected result' do
-        test_expected_body = {'hostname': TEST_HOSTNAME}.to_json
-        expect(subject.abs_get_awsdirectreturn_request_body(TEST_HOSTNAME)). to eq(test_expected_body)
-      end
-
     end
   end
 
-  describe '#abs_get_token_from_fog_file' do
-
-    context 'when the .fog file exists' do
-
-      context 'when the .fog file contains the abs token' do
-
-        it 'returns the token' do
-          fog_file =
-              ":default:
-              :abs_token: #{TEST_ABS_TOKEN}"
-
-          expect(File).to receive(:exist?).and_return(true)
-          expect(File).to receive(:read).and_return(fog_file)
-
-          expect(subject.abs_get_token_from_fog_file).to eq(TEST_ABS_TOKEN)
-        end
-
-      end
-
-      context 'when the .fog file does not contain the abs token' do
-
-        it 'reports the error and returns nil' do
-          fog_file =
-              ':default:
-              :not_abs_token: xyz123'
-
-          expect(File).to receive(:exist?).and_return(true)
-          expect(File).to receive(:read).and_return(fog_file)
-          expect(subject).to receive(:puts).with(/ABS token not found/).at_least(:once)
-
-          expect(subject.abs_get_token_from_fog_file).to eq(nil)
-        end
-
-      end
-
+  describe "#get_a2a_hosts" do
+    before do
+      subject.instance_variable_set("@mom_size", TEST_MOM_SIZE)
+      subject.instance_variable_set("@mom_volume_size", TEST_MOM_VOLUME_SIZE)
+      subject.instance_variable_set("@metrics_size", TEST_METRICS_SIZE)
+      subject.instance_variable_set("@metrics_volume_size", TEST_METRICS_VOLUME_SIZE)
     end
 
-    context 'when the .fog file does not exist' do
-
-      it 'reports the error and returns nil' do
-        expect(File).to receive(:exist?).and_return(false)
-        expect(subject).to receive(:puts).with(/fog file not found/).at_least(:once)
-
-        expect(subject.abs_get_token_from_fog_file).to eq(nil)
-      end
-
-    end
-
-  end
-
-  describe '#abs_get_token' do
-
-    context 'when a token is set as an environment variable' do
-
-      it 'returns the token' do
-        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
-        expect(subject.abs_get_token).to eq(TEST_ABS_TOKEN)
-      end
-
-    end
-
-    context 'when a token is not set as an environment variable' do
-
-      context 'when a token is set in the .fog file' do
-
-        it 'returns the token' do
-          ENV['ABS_TOKEN'] = nil
-          expect(subject).to receive(:abs_get_token_from_fog_file).and_return(TEST_ABS_TOKEN)
-          expect(subject.abs_get_token).to eq(TEST_ABS_TOKEN)
-        end
-
-      end
-
-      context 'when a token is not set in the .fog file' do
-
-        it 'reports the error and returns nil' do
-
-          ENV['ABS_TOKEN'] = nil
-          expect(subject).to receive(:abs_get_token_from_fog_file).and_return(nil)
-          expect(subject).to receive(:puts).with(/An ABS token must be set/)
-          expect(subject.abs_get_token).to eq(nil)
-        end
-
-      end
-
-    end
-
-  end
-
-  describe '#abs_get_request_post' do
-
-    context 'when an abs token is present' do
-
-      it 'returns the expected result' do
-        expect(subject).to receive(:abs_get_token).and_return(TEST_ABS_TOKEN)
-
-        stub_const('Net::HTTP::Post', test_net_http_post)
-        expect(test_net_http_post).to receive(:new).with(TEST_AWSDIRECT_URI, TEST_EXPECTED_REQUEST_HEADERS).and_return(test_http_request)
-
-        expect(subject.abs_get_request_post(TEST_AWSDIRECT_URI)).to eq(test_http_request)
-      end
-
-    end
-
-    context 'when an abs token is not present' do
-
-      it 'reports the error and returns nil' do
-        test_expected_message = 'Unable to prepare a valid ABS request without a valid token'
-        test_expected_result = nil
-
-        expect(subject).to receive(:abs_get_token).and_return(nil)
-        expect(subject).to receive(:puts).with(test_expected_message)
-
-        expect(subject.abs_get_request_post(TEST_AWSDIRECT_URI)).to eq(test_expected_result)
-      end
-
-    end
-
-  end
-
-  describe '#abs_request_awsdirect' do
-
-    context 'when a request is successfully prepared' do
-
-      it 'performs the request, reports and returns the response' do
-        expect(subject).to receive(:abs_get_request_post).and_return(test_http_request)
-        allow(test_http_request).to receive(:body=)
-
-        stub_const('Net::HTTP', test_net_http)
-        expect(test_net_http).to receive(:new).and_return(test_net_http_instance)
-
-        allow(test_net_http_instance).to receive(:use_ssl=)
-        allow(test_net_http_instance).to receive(:read_timeout=)
-        expect(test_net_http_instance).to receive(:request).with(test_http_request).and_return(test_http_response)
-
-        expect(test_http_response).to receive(:code).and_return(TEST_VALID_RESPONSE_CODE)
-        expect(test_http_response).to receive(:body).and_return(TEST_VALID_RESPONSE_BODY)
-
-        allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).at_least(:once).with("response code: #{TEST_VALID_RESPONSE_CODE}")
-        expect(subject).to receive(:puts).at_least(:once).with("response body: #{TEST_VALID_RESPONSE_BODY}")
-
-        expect(subject.abs_request_awsdirect(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_REQUEST_BODY)).to eq(test_http_response)
-
-      end
-
-    end
-
-    context 'when a request is not successfully prepared' do
-
-      it 'reports the error, does not attempt the request, and returns nil' do
-        test_expected_message = 'Unable to complete the specified ABS request'
-        test_expected_result = nil
-
-        expect(subject).to receive(:abs_get_request_post).and_return(nil)
-        expect(subject).to receive(:puts).with(test_expected_message)
-
-        expect(subject.abs_request_awsdirect(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_REQUEST_BODY)).to eq(test_expected_result)
-      end
-
-    end
-
-  end
-
-  describe '#abs_is_valid_response?' do
-
-    context 'when a valid response is provided' do
-
-      it 'returns true' do
-        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
-        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
-        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
-
-        expect(subject.abs_is_valid_response?(test_http_response)).to eq(true)
-      end
-
-    end
-
-    context 'when the response is nil' do
-
-      it 'reports the error and returns false' do
-        allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with(/Invalid ABS response/).at_least(:once)
-        expect(subject.abs_is_valid_response?(nil)).to eq(false)
-      end
-
-    end
-
-    context 'when the response code is not valid' do
-
-      # TODO: Verify the full error message including values?
-
-      it 'reports the error and returns false' do
-        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
-        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_INVALID_RESPONSE_CODE)
-        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
-
-        allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with(/Invalid ABS response/)
-        expect(subject).to receive(:puts).with(/code/)
-        expect(subject).to receive(:puts).with(/body/)
-
-        expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
-      end
-
-    end
-
-    context 'when the response body is empty' do
-
-      it 'reports the error and returns false' do
-        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
-        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
-        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_INVALID_RESPONSE_BODY)
-
-        allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with(/Invalid ABS response/)
-        expect(subject).to receive(:puts).with(/code/)
-        expect(subject).to receive(:puts).with(/body/)
-
-        expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
-      end
-
-    end
-
-    context 'when the response body is nil' do
-
-      it 'reports the error and returns false' do
-        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
-        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
-        expect(test_http_response).to receive(:body).at_least(:once).and_return(nil)
-
-        allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with(/Invalid ABS response/)
-        expect(subject).to receive(:puts).with(/code/)
-        expect(subject).to receive(:puts).with(/body/)
-
-        expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
-      end
-
-    end
-
-  end
-
-  describe '#abs_get_a2a_hosts' do
-
-    before {
-      subject.instance_variable_set("@abs_aws_mom_size", TEST_ABS_AWS_MOM_SIZE)
-      subject.instance_variable_set("@abs_aws_metrics_size", TEST_ABS_AWS_METRICS_SIZE)
-    }
-
-    context 'when called' do
-
-      it 'initializes the helper and returns the a2a hosts' do
+    context "when called" do
+      it "initializes the helper and returns the a2a hosts" do
         expect(subject).to receive(:abs_initialize)
-        expect(subject.abs_get_a2a_hosts).to eq(TEST_A2A_HOSTS)
-
+        expect(subject.get_a2a_hosts).to eq(TEST_A2A_HOSTS)
       end
-
-    end
-
-  end
-
-  describe '#abs_reformat_resource_host' do
-
-    context 'when a valid response_body is provided' do
-
-      it 'returns the expected reformatted response' do
-        expect(subject.abs_reformat_resource_host(TEST_AWSDIRECT_RESPONSE_BODY)).to eq(TEST_REFORMATTED_RESPONSE_BODY)
-      end
-
-    end
-
-    context 'when an invalid response_body is provided' do
-
-      it 'reports the error and returns nil' do
-        expect(subject).to receive(:puts).with("JSON::ParserError encountered parsing the response body: #{TEST_INVALID_RESPONSE_BODY}")
-        expect(subject.abs_reformat_resource_host(TEST_INVALID_RESPONSE_BODY)).to eq(nil)
-      end
-
-    end
-
-  end
-
-  describe '#abs_update_last_abs_resource_hosts' do
-
-    context 'when a host string is specified' do
-
-      it 'writes the string to the log file' do
-        skip
-      end
-
     end
   end
 
-  describe '#abs_get_resource_hosts' do
-
-    context 'when a valid token is present' do
-
-      context 'when a valid response is returned' do
-
-        it 'sets the environment variable, logs the hosts, returns the response(s), reports no errors and does not return the hosts' do
-          ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+  describe "#get_abs_resource_hosts" do
+    context "when a valid token is present" do
+      context "when a valid response is returned" do
+        it "sets the environment variable, logs the hosts, and returns the response(s)" do
+          ENV["ABS_TOKEN"] = TEST_ABS_TOKEN
           expect(subject).to receive(:abs_initialize).and_return(true)
           allow(TEST_ABS_RESOURCE_HOSTS).to receive(:each)
 
-          expect(subject).to receive(:abs_get_awsdirect_request_body).with(:mom, TEST_ABS_AWS_MOM_SIZE).once.and_return(TEST_AWSDIRECT_MOM_REQUEST_BODY)
-          expect(subject).to receive(:abs_get_awsdirect_request_body).with(:metrics, TEST_ABS_AWS_METRICS_SIZE).and_return(TEST_AWSDIRECT_METRICS_REQUEST_BODY)
+          expect(subject).to receive(:get_awsdirect_request_body)
+            .with(TEST_MOM_ROLE, TEST_MOM_SIZE, TEST_MOM_VOLUME_SIZE)
+            .and_return(TEST_AWSDIRECT_MOM_REQUEST_BODY)
 
-          expect(subject).to receive(:abs_request_awsdirect).once.with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_MOM_REQUEST_BODY).and_return(test_http_response)
-          expect(subject).to receive(:abs_request_awsdirect).once.with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_METRICS_REQUEST_BODY).and_return(test_http_response)
+          expect(subject).to receive(:get_awsdirect_request_body)
+            .with(TEST_METRICS_ROLE, TEST_METRICS_SIZE, TEST_METRICS_VOLUME_SIZE)
+            .and_return(TEST_AWSDIRECT_METRICS_REQUEST_BODY)
 
-          expect(subject).to receive(:abs_is_valid_response?).at_least(:once).with(test_http_response).and_return(true)
+          expect(subject).to receive(:perform_awsdirect_request)
+            .with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_MOM_REQUEST_BODY)
+            .and_return(test_http_response)
 
-          expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
-          expect(subject).to receive(:abs_reformat_resource_host).at_least(:once).with(TEST_AWSDIRECT_RESPONSE_BODY).and_return(TEST_REFORMATTED_RESPONSE_BODY)
+          expect(subject).to receive(:perform_awsdirect_request)
+            .with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_METRICS_REQUEST_BODY)
+            .and_return(test_http_response)
+
+          expect(subject).to receive(:valid_abs_response?).at_least(:once)
+            .with(test_http_response).and_return(true)
+
+          expect(test_http_response).to receive(:body)
+            .at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+
+          expect(subject).to receive(:reformat_abs_resource_host).at_least(:once)
+            .with(TEST_AWSDIRECT_RESPONSE_BODY).and_return(TEST_REFORMATTED_RESPONSE_BODY)
+
+          expect(subject).to receive(:update_last_abs_resource_hosts)
+                                 .with(TEST_ABS_RESOURCE_HOSTS)
+
+          expect(subject).to receive(:verify_abs_hosts)
+            .with(TEST_ABS_HOSTS).and_return(true)
 
           expect(subject).not_to receive(:puts).with(/Returning any provisioned hosts/)
           expect(subject).not_to receive(:puts).with(/Unable to provision host for role/)
           expect(subject).not_to receive(:puts).with(/No ABS hosts were provisioned/)
 
-          expect(subject).not_to receive(:abs_return_resource_hosts)
+          expect(subject).not_to receive(:return_abs_resource_hosts)
 
-          expect(subject.abs_get_resource_hosts(TEST_A2A_HOSTS)).to eq(TEST_ABS_RESOURCE_HOSTS)
+          expect(subject).to receive(:sleep)
+
+          expect(subject.get_abs_resource_hosts(TEST_A2A_HOSTS)).to eq(TEST_ABS_RESOURCE_HOSTS)
         end
-
       end
 
       # TODO: verify error reporting or trust the tests for abs_is_valid_response?
-      context 'when an invalid response is returned' do
-
-        context 'when this is the first request' do
-
-          it 'does not attempt to return hosts, reports the error and returns nil' do
+      context "when an invalid response is returned" do
+        context "when this is the first request" do
+          it "does not attempt to return hosts, reports the error and returns nil" do
             # TODO: set up and verify this being the first request
-            ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+            ENV["ABS_TOKEN"] = TEST_ABS_TOKEN
             test_expected_result = nil
 
-            expect(subject).to receive(:abs_request_awsdirect).once.and_return(test_http_response)
-            expect(subject).to receive(:abs_is_valid_response?).once.with(test_http_response).and_return(false)
+            expect(subject).to receive(:perform_awsdirect_request).and_return(test_http_response)
+            expect(subject).to receive(:valid_abs_response?).with(test_http_response)
+                                                            .and_return(false)
 
             allow(subject).to receive(:puts)
             expect(subject).not_to receive(:puts).with(/Returning any provisioned hosts/)
-            expect(subject).not_to receive(:abs_return_resource_hosts)
+            expect(subject).not_to receive(:return_abs_resource_hosts)
+
+            expect(subject).not_to receive(:update_last_abs_resource_hosts)
+            expect(subject).not_to receive(:verify_abs_hosts)
 
             expect(subject).to receive(:puts).with(/Unable to provision host for role/)
             expect(subject).to receive(:puts).with(/No ABS hosts were provisioned/)
 
-            expect(subject.abs_get_resource_hosts(TEST_A2A_HOSTS)).to eq(test_expected_result)
+            expect(subject.get_abs_resource_hosts(TEST_A2A_HOSTS)).to eq(test_expected_result)
           end
-
         end
 
-        context 'when there have been previous successful requests' do
-
-          it 'attempts to return the previously provisioned hosts' do
-            ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+        context "when there have been previous successful requests" do
+          it "attempts to return the previously provisioned hosts" do
+            ENV["ABS_TOKEN"] = TEST_ABS_TOKEN
             expect(subject).to receive(:abs_initialize).and_return(true)
             allow(TEST_ABS_RESOURCE_HOSTS).to receive(:each)
 
             # valid
-            expect(subject).to receive(:abs_get_awsdirect_request_body).with(:mom, TEST_ABS_AWS_MOM_SIZE).and_return(TEST_AWSDIRECT_MOM_REQUEST_BODY)
-            expect(subject).to receive(:abs_request_awsdirect).with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_MOM_REQUEST_BODY).and_return(test_http_response)
-            expect(subject).to receive(:abs_is_valid_response?).with(test_http_response).and_return(true)
+            expect(subject).to receive(:get_awsdirect_request_body)
+              .with(TEST_MOM_ROLE, TEST_MOM_SIZE, TEST_MOM_VOLUME_SIZE)
+              .and_return(TEST_AWSDIRECT_MOM_REQUEST_BODY)
+
+            expect(subject).to receive(:perform_awsdirect_request)
+              .with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_MOM_REQUEST_BODY)
+              .and_return(test_http_response)
+
+            expect(subject).to receive(:valid_abs_response?)
+              .with(test_http_response).and_return(true)
 
             expect(test_http_response).to receive(:body).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
-            expect(subject).to receive(:abs_reformat_resource_host).with(TEST_AWSDIRECT_RESPONSE_BODY).and_return(TEST_REFORMATTED_RESPONSE_BODY)
+
+            expect(subject).to receive(:reformat_abs_resource_host)
+              .with(TEST_AWSDIRECT_RESPONSE_BODY)
+              .and_return(TEST_REFORMATTED_RESPONSE_BODY)
 
             # invalid
-            expect(subject).to receive(:abs_get_awsdirect_request_body).with(:metrics, TEST_ABS_AWS_METRICS_SIZE).and_return(TEST_AWSDIRECT_METRICS_REQUEST_BODY)
-            expect(subject).to receive(:abs_request_awsdirect).with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_METRICS_REQUEST_BODY).and_return(nil)
-            expect(subject).to receive(:abs_is_valid_response?).with(nil).and_return(false)
+            expect(subject).to receive(:get_awsdirect_request_body)
+              .with(TEST_METRICS_ROLE, TEST_METRICS_SIZE, TEST_METRICS_VOLUME_SIZE)
+              .and_return(TEST_AWSDIRECT_METRICS_REQUEST_BODY)
+
+            expect(subject).to receive(:perform_awsdirect_request)
+              .with(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_METRICS_REQUEST_BODY)
+              .and_return(nil)
+
+            expect(subject).to receive(:valid_abs_response?).with(nil).and_return(false)
 
             allow(subject).to receive(:puts)
             expect(subject).to receive(:puts).with(/Returning any provisioned hosts/)
@@ -661,95 +353,138 @@ describe AbsHelperClass do
 
             expect(subject).not_to receive(:puts).with(/No ABS hosts were provisioned/)
 
-            expect(subject).to receive(:abs_return_resource_hosts).with(TEST_ABS_RESOURCE_HOSTS_SINGLE).and_return(TEST_ABS_RESOURCE_HOSTS_SINGLE)
-            expect(subject.abs_get_resource_hosts(TEST_A2A_HOSTS)).to eq(nil)
+            expect(subject).not_to receive(:update_last_abs_resource_hosts)
+            expect(subject).not_to receive(:verify_abs_hosts)
+
+            expect(subject).to receive(:return_abs_resource_hosts)
+              .with(TEST_ABS_RESOURCE_HOSTS_SINGLE)
+              .and_return(TEST_ABS_RESOURCE_HOSTS_SINGLE)
+
+            expect(subject.get_abs_resource_hosts(TEST_A2A_HOSTS)).to eq(nil)
           end
-
         end
-
       end
-
     end
 
-    context 'when a valid token is not present' do
-
-      it 'does not make the request, reports the error and returns nil' do
-        ENV['ABS_TOKEN'] = 'not_a_token'
+    context "when a valid token is not present" do
+      it "does not make the request, reports the error and returns nil" do
+        ENV["ABS_TOKEN"] = "not_a_token"
         expect(subject).to receive(:abs_initialize).and_return(false)
 
         expect(subject).to receive(:puts).with(/Unable to proceed without a valid ABS token/)
 
         expect(TEST_ABS_RESOURCE_HOSTS).not_to receive(:each)
-        expect(subject).not_to receive(:abs_get_awsdirect_request_body)
-        expect(subject).not_to receive(:abs_request_awsdirect)
+        expect(subject).not_to receive(:get_awsdirect_request_body)
+        expect(subject).not_to receive(:perform_awsdirect_request)
         expect(subject).not_to receive(:puts).with(/Returning any provisioned hosts/)
         expect(subject).not_to receive(:puts).with(/Unable to provision host for role/)
         expect(subject).not_to receive(:puts).with(/No ABS hosts were provisioned/)
-        expect(subject).not_to receive(:abs_return_resource_hosts)
+        expect(subject).not_to receive(:return_abs_resource_hosts)
+        expect(subject).not_to receive(:update_last_abs_resource_hosts)
+        expect(subject).not_to receive(:verify_abs_hosts)
 
-        expect(subject.abs_get_resource_hosts(TEST_A2A_HOSTS)).to eq(nil)
-
+        expect(subject.get_abs_resource_hosts(TEST_A2A_HOSTS)).to eq(nil)
       end
-
     end
-
   end
 
-  describe '#is_valid_abs_resource_hosts' do
+  describe "#return_abs_resource_hosts" do
+    test_uri = TEST_AWSDIRECTRETURN_URI
+    test_body = TEST_AWSDIRECTRETURN_REQUEST_BODY
 
-    context 'when a valid resource host array is specified' do
+    context "when a valid token is present and array of hosts is specified" do
+      context "when the responses are valid" do
+        it "submits requests to return the hosts and returns the expected host array" do
+          expect(subject).to receive(:abs_initialize).and_return(true)
+          expect(subject).to receive(:valid_abs_resource_hosts?)
+            .with(TEST_ABS_RESOURCE_HOSTS).and_return(true)
 
-      it 'returns true' do
-        expect(subject.is_valid_abs_resource_hosts?(TEST_ABS_RESOURCE_HOSTS)).to eq(true)
+          expect(subject).to receive(:get_awsdirectreturn_request_body)
+            .with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
+          expect(subject).to receive(:perform_awsdirect_request)
+            .with(test_uri, test_body).at_least(:once).and_return(test_http_response)
+          expect(subject).to receive(:valid_abs_response?)
+            .with(test_http_response).at_least(:once).and_return(true)
+
+          allow(subject).to receive(:puts)
+          expect(subject).not_to receive(:puts).with(/De-provisioning/)
+
+          expect(subject.return_abs_resource_hosts(TEST_ABS_RESOURCE_HOSTS))
+            .to eq(TEST_ABS_RESOURCE_HOSTS)
+        end
       end
 
+      context "when the responses are not valid" do
+        it "submits requests to return the hosts, reports the errors, returns nil" do
+          expect(subject).to receive(:abs_initialize).and_return(true)
+          expect(subject).to receive(:valid_abs_resource_hosts?)
+            .with(TEST_ABS_RESOURCE_HOSTS).and_return(true)
+
+          expect(subject).to receive(:get_awsdirectreturn_request_body)
+            .with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
+          expect(subject).to receive(:perform_awsdirect_request)
+            .with(test_uri, test_body).at_least(:once).and_return(test_http_response)
+
+          expect(subject).to receive(:valid_abs_response?)
+            .with(test_http_response).at_least(:once).and_return(false)
+
+          allow(subject).to receive(:puts)
+          expect(subject).to receive(:puts).with(/Failed to return host/)
+
+          expect(subject.return_abs_resource_hosts(TEST_ABS_RESOURCE_HOSTS)).to eq(nil)
+        end
+      end
+
+      context "when a mix of valid and invalid responses are returned" do
+        it "submits requests to return the hosts, reports the errors, returns the hosts" do
+          skip
+        end
+      end
     end
 
-    context 'when an invalid resource host array is specified' do
+    context "when an array of hosts is not specified" do
+      # TODO: improve
+      it "reports the error and returns nil" do
+        expect(subject).to receive(:abs_initialize).and_return(true)
+        expect(subject).to receive(:valid_abs_resource_hosts?).with(nil).and_return(false)
 
-      it 'reports the error and returns false' do
         allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with("The specified resource host array is not valid: #{TEST_INVALID_ABS_RESOURCE_HOSTS}")
+        expect(subject).to receive(:puts)
+          .with(/De-provisioning via awsdirectreturn requires an array of hostnames/)
 
-        expect(subject.is_valid_abs_resource_hosts?(TEST_INVALID_ABS_RESOURCE_HOSTS)).to eq(false)
+        expect(subject.return_abs_resource_hosts(nil)).to eq(nil)
       end
-
     end
 
-    context 'when an nil is specified' do
+    context "when a valid token is not present" do
+      it "does not make the request, reports the error and returns nil" do
+        expect(subject).to receive(:abs_initialize).and_return(false)
+        expect(subject).to receive(:valid_abs_resource_hosts?).and_return(true)
 
-      it 'reports the error and returns false' do
         allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with('A valid hosts array is required; nil was specified')
+        expect(subject).to receive(:puts).with("Unable to proceed without a valid ABS token")
 
-        expect(subject.is_valid_abs_resource_hosts?(nil)).to eq(false)
+        expect(subject.return_abs_resource_hosts(nil)).to eq(nil)
       end
-
     end
-
   end
 
-  describe '#abs_get_last_abs_resource_hosts' do
-
-    context 'when the file exists' do
-
-      context 'when the file contains a valid list of hosts' do
-
-        it 'returns the hosts' do
+  describe "#get_last_abs_resource_hosts" do
+    context "when the file exists" do
+      context "when the file contains a valid list of hosts" do
+        it "returns the hosts" do
           expect(File).to receive(:exist?).and_return(true)
           expect(File).to receive(:read).and_return(TEST_ABS_RESOURCE_HOSTS)
           expect(TEST_ABS_RESOURCE_HOSTS).to receive(:start_with?).and_return(true)
 
           expect(subject).to_not receive(:puts)
 
-          expect(subject.abs_get_last_abs_resource_hosts).to eq(TEST_ABS_RESOURCE_HOSTS)
+          expect(subject.get_last_abs_resource_hosts).to eq(TEST_ABS_RESOURCE_HOSTS)
         end
-
       end
 
-      context 'when the file does not contain a valid list of hosts' do
-
-        it 'reports the error and returns nil' do
+      context "when the file does not contain a valid list of hosts" do
+        it "reports the error and returns nil" do
           expect(File).to receive(:exist?).and_return(true)
           expect(File).to receive(:read).and_return(TEST_ABS_RESOURCE_HOSTS)
           expect(TEST_ABS_RESOURCE_HOSTS).to receive(:start_with?).and_return(false)
@@ -757,15 +492,13 @@ describe AbsHelperClass do
           allow(subject).to receive(:puts)
           expect(subject).to receive(:puts).with(/Invalid last ABS resource hosts file/)
 
-          expect(subject.abs_get_last_abs_resource_hosts).to eq(nil)
+          expect(subject.get_last_abs_resource_hosts).to eq(nil)
         end
-
       end
 
-      context 'when the file is empty' do
-
-        it 'reports the error and returns nil' do
-          test_file = ''
+      context "when the file is empty" do
+        it "reports the error and returns nil" do
+          test_file = ""
 
           expect(File).to receive(:exist?).and_return(true)
           expect(File).to receive(:read).and_return(test_file)
@@ -774,113 +507,482 @@ describe AbsHelperClass do
           allow(subject).to receive(:puts)
           expect(subject).to receive(:puts).with(/Invalid last ABS resource hosts file/)
 
-          expect(subject.abs_get_last_abs_resource_hosts).to eq(nil)
+          expect(subject.get_last_abs_resource_hosts).to eq(nil)
         end
-
       end
-
     end
 
-    context 'when the file does not exist' do
-
-      it 'reports the error and returns nil' do
+    context "when the file does not exist" do
+      it "reports the error and returns nil" do
         expect(File).to receive(:exist?).and_return(false)
         expect(File).not_to receive(:read)
 
         allow(subject).to receive(:puts)
         expect(subject).to receive(:puts).with(/Last ABS resource hosts file not found/)
 
-        expect(subject.abs_get_last_abs_resource_hosts).to eq(nil)
+        expect(subject.get_last_abs_resource_hosts).to eq(nil)
       end
-
     end
-
   end
 
-  describe '#abs_return_resource_hosts' do
+  describe "#get_aws_tags" do
+    context "when a pe version is specified" do
+      it "returns tags including the specified role and pe version" do
+        test_expected_tags = { 'role': TEST_ROLE, 'pe_version': TEST_BEAKER_PE_VERSION }
 
-    test_uri = TEST_AWSDIRECTRETURN_URI
-    test_body = TEST_AWSDIRECTRETURN_REQUEST_BODY
-
-    context 'when a valid token is present and array of hosts is specified' do
-
-      context 'when the responses are valid' do
-
-        it 'submits requests to return the hosts and returns the expected host array' do
-          expect(subject).to receive(:abs_initialize).and_return(true)
-          expect(subject).to receive(:is_valid_abs_resource_hosts?).with(TEST_ABS_RESOURCE_HOSTS).and_return(true)
-
-          expect(subject).to receive(:abs_get_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
-          expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(test_http_response)
-          expect(subject).to receive(:abs_is_valid_response?).at_least(:once).with(test_http_response).and_return(true)
-
-          allow(subject).to receive(:puts)
-          expect(subject).not_to receive(:puts).with(/De-provisioning via return_abs_resource_hosts requires an array of hostnames/)
-
-          expect(subject.abs_return_resource_hosts(TEST_ABS_RESOURCE_HOSTS)).to eq(TEST_ABS_RESOURCE_HOSTS)
-        end
-
+        subject.instance_variable_set(:@abs_beaker_pe_version, TEST_BEAKER_PE_VERSION)
+        expect(subject.get_aws_tags(TEST_ROLE)).to eq(test_expected_tags)
       end
-
-      context 'when the responses are not valid' do
-
-        it 'submits requests to return the hosts, reports the errors, returns nil' do
-          expect(subject).to receive(:abs_initialize).and_return(true)
-          expect(subject).to receive(:is_valid_abs_resource_hosts?).with(TEST_ABS_RESOURCE_HOSTS).and_return(true)
-
-          expect(subject).to receive(:abs_get_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
-          expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(test_http_response)
-
-          expect(subject).to receive(:abs_is_valid_response?).at_least(:once).with(test_http_response).and_return(false)
-
-          allow(subject).to receive(:puts)
-          expect(subject).to receive(:puts).with(/Failed to return host/)
-
-          expect(subject.abs_return_resource_hosts(TEST_ABS_RESOURCE_HOSTS)).to eq(nil)
-        end
-
-      end
-
-      context 'when a mix of valid and invalid responses are returned' do
-
-        it 'submits requests to return the hosts, reports the errors, returns the successfully returned hosts' do
-          skip
-        end
-
-      end
-
     end
 
-    context 'when an array of hosts is not specified' do
+    context "when a pe version is not specified" do
+      it "returns tags that include only the specified role" do
+        test_expected_tags = { 'role': TEST_ROLE }
 
-      # TODO: improve
-      it 'reports the error and returns nil' do
-        expect(subject).to receive(:abs_initialize).and_return(true)
-        expect(subject).to receive(:is_valid_abs_resource_hosts?).with(nil).and_return(false)
-
-        allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with(/De-provisioning via return_abs_resource_hosts requires an array of hostnames/)
-
-        expect(subject.abs_return_resource_hosts(nil)).to eq(nil)
+        subject.instance_variable_set(:@abs_beaker_pe_version, nil)
+        expect(subject.get_aws_tags(TEST_ROLE)).to eq(test_expected_tags)
       end
-
     end
-
-    context 'when a valid token is not present' do
-
-      it 'does not make the request, reports the error and returns nil' do
-        expect(subject).to receive(:abs_initialize).and_return(false)
-        expect(subject).to receive(:is_valid_abs_resource_hosts?).and_return(true)
-
-        allow(subject).to receive(:puts)
-        expect(subject).to receive(:puts).with('Unable to proceed without a valid ABS token')
-
-        expect(subject.abs_return_resource_hosts(nil)).to eq(nil)
-
-      end
-
-    end
-
   end
 
+  describe "#get_awsdirect_request_body" do
+    before do
+      subject.instance_variable_set("@aws_size", TEST_SIZE)
+      subject.instance_variable_set("@aws_volume_size", TEST_VOLUME_SIZE)
+      subject.instance_variable_set("@aws_platform", TEST_PLATFORM)
+      subject.instance_variable_set("@aws_image_id", TEST_IMAGE_ID)
+      subject.instance_variable_set("@aws_region", TEST_REGION)
+      subject.instance_variable_set("@aws_reap_time", TEST_REAP_TIME)
+    end
+
+    context "when a role is specified" do
+      it "uses the default size and returns the expected result" do
+        test_expected_request_body = TEST_AWSDIRECT_REQUEST_BODY
+        expect(subject.get_awsdirect_request_body(TEST_ROLE)).to eq(test_expected_request_body)
+      end
+    end
+
+    context "when a role, size, and volume_size are specified" do
+      it "uses the specified size and returns the expected result" do
+        test_role = "new-role"
+        test_size = "new-size"
+        test_volume_size = "new-volume-size"
+
+        test_expected_request_body =
+          { 'platform': TEST_PLATFORM,
+            'image_id': TEST_IMAGE_ID,
+            'size': test_size,
+            'region': TEST_REGION,
+            'reap_time': TEST_REAP_TIME,
+            'tags':
+                { 'role': test_role, 'pe_version': TEST_BEAKER_PE_VERSION },
+            'volume_size': test_volume_size }.to_json
+
+        expect(subject.get_awsdirect_request_body(test_role, test_size, test_volume_size))
+          .to eq(test_expected_request_body)
+      end
+    end
+  end
+
+  describe "#get_awsdirectreturn_request_body" do
+    context "when a hostname is specified" do
+      it "returns the expected result" do
+        test_expected_body = { 'hostname': TEST_HOSTNAME }.to_json
+        expect(subject.get_awsdirectreturn_request_body(TEST_HOSTNAME))
+          .to eq(test_expected_body)
+      end
+    end
+  end
+
+  describe "#get_abs_token_from_fog_file" do
+    context "when the .fog file exists" do
+      context "when the .fog file contains the abs token" do
+        it "returns the token" do
+          fog_file =
+            ":default:
+            :abs_token: #{TEST_ABS_TOKEN}"
+
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(fog_file)
+
+          expect(subject.get_abs_token_from_fog_file).to eq(TEST_ABS_TOKEN)
+        end
+      end
+
+      context "when the .fog file does not contain the abs token" do
+        it "reports the error and returns nil" do
+          fog_file =
+            ":default:
+            :not_abs_token: xyz123"
+
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(fog_file)
+          expect(subject).to receive(:puts).with(/ABS token not found/).at_least(:once)
+
+          expect(subject.get_abs_token_from_fog_file).to eq(nil)
+        end
+      end
+    end
+
+    context "when the .fog file does not exist" do
+      it "reports the error and returns nil" do
+        expect(File).to receive(:exist?).and_return(false)
+        expect(subject).to receive(:puts).with(/fog file not found/).at_least(:once)
+
+        expect(subject.get_abs_token_from_fog_file).to eq(nil)
+      end
+    end
+  end
+
+  describe "#get_abs_token" do
+    context "when a token is set as an environment variable" do
+      it "returns the token" do
+        ENV["ABS_TOKEN"] = TEST_ABS_TOKEN
+        expect(subject.get_abs_token).to eq(TEST_ABS_TOKEN)
+      end
+    end
+
+    context "when a token is not set as an environment variable" do
+      context "when a token is set in the .fog file" do
+        it "returns the token" do
+          ENV["ABS_TOKEN"] = nil
+          expect(subject).to receive(:get_abs_token_from_fog_file).and_return(TEST_ABS_TOKEN)
+          expect(subject.get_abs_token).to eq(TEST_ABS_TOKEN)
+        end
+      end
+
+      context "when a token is not set in the .fog file" do
+        it "reports the error and returns nil" do
+          ENV["ABS_TOKEN"] = nil
+          expect(subject).to receive(:get_abs_token_from_fog_file).and_return(nil)
+          expect(subject).to receive(:puts).with(/An ABS token must be set/)
+          expect(subject.get_abs_token).to eq(nil)
+        end
+      end
+    end
+  end
+
+  describe "#get_abs_post_request" do
+    context "when an abs token is present" do
+      it "returns the expected result" do
+        expect(subject).to receive(:get_abs_token).and_return(TEST_ABS_TOKEN)
+
+        stub_const("Net::HTTP::Post", test_net_http_post)
+        expect(test_net_http_post).to receive(:new)
+          .with(TEST_AWSDIRECT_URI, TEST_EXPECTED_REQUEST_HEADERS).and_return(test_http_request)
+
+        expect(subject.get_abs_post_request(TEST_AWSDIRECT_URI)).to eq(test_http_request)
+      end
+    end
+
+    context "when an abs token is not present" do
+      it "reports the error and returns nil" do
+        test_expected_message = "Unable to prepare a valid ABS request without a valid token"
+        test_expected_result = nil
+
+        expect(subject).to receive(:get_abs_token).and_return(nil)
+        expect(subject).to receive(:puts).with(test_expected_message)
+
+        expect(subject.get_abs_post_request(TEST_AWSDIRECT_URI)).to eq(test_expected_result)
+      end
+    end
+  end
+
+  describe "#perform_awsdirect_request" do
+    context "when a request is successfully prepared" do
+      it "performs the request, reports and returns the response" do
+        expect(subject).to receive(:get_abs_post_request).and_return(test_http_request)
+        allow(test_http_request).to receive(:body=)
+
+        stub_const("Net::HTTP", test_net_http)
+        expect(test_net_http).to receive(:new).and_return(test_net_http_instance)
+
+        allow(test_net_http_instance).to receive(:use_ssl=)
+        allow(test_net_http_instance).to receive(:read_timeout=)
+        expect(test_net_http_instance).to receive(:request).with(test_http_request)
+                                                           .and_return(test_http_response)
+
+        expect(test_http_response).to receive(:code).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).and_return(TEST_VALID_RESPONSE_BODY)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).at_least(:once)
+                                         .with("response code: #{TEST_VALID_RESPONSE_CODE}")
+        expect(subject).to receive(:puts).at_least(:once)
+                                         .with("response body: #{TEST_VALID_RESPONSE_BODY}")
+
+        expect(subject.perform_awsdirect_request(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_REQUEST_BODY))
+          .to eq(test_http_response)
+      end
+    end
+
+    context "when a request is not successfully prepared" do
+      it "reports the error, does not attempt the request, and returns nil" do
+        test_expected_message = "Unable to complete the specified ABS request"
+        test_expected_result = nil
+
+        expect(subject).to receive(:get_abs_post_request).and_return(nil)
+        expect(subject).to receive(:puts).with(test_expected_message)
+
+        expect(subject.perform_awsdirect_request(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_REQUEST_BODY))
+          .to eq(test_expected_result)
+      end
+    end
+  end
+
+  describe "#valid_abs_response??" do
+    context "when a valid response is provided" do
+      it "returns true" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once)
+                                                    .and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once)
+                                                    .and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+
+        expect(subject.valid_abs_response?(test_http_response)).to eq(true)
+      end
+    end
+
+    context "when the response is nil" do
+      it "reports the error and returns false" do
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/).at_least(:once)
+        expect(subject.valid_abs_response?(nil)).to eq(false)
+      end
+    end
+
+    context "when the response code is not valid" do
+      # TODO: Verify the full error message including values?
+
+      it "reports the error and returns false" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once)
+                                                    .and_return(TEST_INVALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once)
+                                                    .and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/)
+        expect(subject).to receive(:puts).with(/code/)
+        expect(subject).to receive(:puts).with(/body/)
+
+        expect(subject.valid_abs_response?(test_http_response)).to eq(false)
+      end
+    end
+
+    context "when the response body is empty" do
+      it "reports the error and returns false" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once)
+                                                    .and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once)
+                                                    .and_return(TEST_INVALID_RESPONSE_BODY)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/)
+        expect(subject).to receive(:puts).with(/code/)
+        expect(subject).to receive(:puts).with(/body/)
+
+        expect(subject.valid_abs_response?(test_http_response)).to eq(false)
+      end
+    end
+
+    context "when the response body is nil" do
+      it "reports the error and returns false" do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once)
+                                                    .and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(nil)
+
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(/Invalid ABS response/)
+        expect(subject).to receive(:puts).with(/code/)
+        expect(subject).to receive(:puts).with(/body/)
+
+        expect(subject.valid_abs_response?(test_http_response)).to eq(false)
+      end
+    end
+  end
+
+  describe "#reformat_abs_resource_host" do
+    context "when a valid response_body is provided" do
+      it "returns the expected reformatted response" do
+        expect(subject.reformat_abs_resource_host(TEST_AWSDIRECT_RESPONSE_BODY))
+          .to eq(TEST_REFORMATTED_RESPONSE_BODY)
+      end
+    end
+
+    context "when an invalid response_body is provided" do
+      it "reports the error and returns nil" do
+        body = TEST_INVALID_RESPONSE_BODY
+        message = "JSON::ParserError encountered parsing response body: #{body}"
+        expect(subject).to receive(:puts).with(message)
+        expect(subject.reformat_abs_resource_host(body)).to eq(nil)
+      end
+    end
+  end
+
+  # TODO: implement
+  describe "#update_last_abs_resource_hosts" do
+    context "when a host string is specified" do
+      it "writes the string to the log file" do
+        skip
+      end
+    end
+  end
+
+  describe "#backoff_sleep" do
+    context "when called with a positive number of tries" do
+      it "sleeps for a multiple of the number of tries" do
+        skip
+      end
+    end
+  end
+
+  describe "#verify_abs_host" do
+    let(:test_ssh) { Class.new }
+
+    context "when the specified number of tries has not been exceeded" do
+      context "when the result is successful" do
+        it "breaks and returns true" do
+          tries = 1
+
+          allow(subject).to receive(:puts)
+          expect(subject).to receive(:puts).with("Verifying #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt #{tries} for #{TEST_HOSTNAME}")
+
+          stub_const("Net::SSH", test_ssh)
+          test_ssh_session = double
+          test_ssh_result = double
+
+          expect(test_ssh).to receive(:start).and_return(test_ssh_session)
+          expect(test_ssh_session).to receive(:exec).and_return(test_ssh_result)
+
+          expect(subject).to receive(:puts).with(test_ssh_result)
+
+          expect(subject).not_to receive(:backoff_sleep)
+
+          expect(test_ssh_session).to receive(:close)
+
+          expect(subject.verify_abs_host(TEST_HOSTNAME)).to eq(true)
+        end
+      end
+
+      context "when the result is not successful" do
+        it "reports the failure and sleeps" do
+          stub_const("Net::SSH", test_ssh)
+          test_ssh_session = double
+          test_ssh_result = double
+
+          allow(subject).to receive(:puts)
+          expect(subject).to receive(:puts).with("Verifying #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 1 for #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 2 for #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 3 for #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 4 for #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 5 for #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 6 for #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 7 for #{TEST_HOSTNAME}")
+          expect(subject).to receive(:puts).with("Attempt 8 for #{TEST_HOSTNAME}")
+
+          expect(test_ssh).to receive(:start)
+            .exactly(8).times.and_return(test_ssh_session)
+
+          expect(test_ssh_session).to receive(:exec)
+            .exactly(7).times.and_raise(RuntimeError)
+
+          expect(test_ssh_session).to receive(:exec).and_return(test_ssh_result)
+
+          expect(subject).to receive(:backoff_sleep).exactly(7).times
+
+          expect(test_ssh_session).to receive(:close).exactly(1).times
+
+          expect(subject).to receive(:puts).with(test_ssh_result)
+
+          expect(subject.verify_abs_host(TEST_HOSTNAME)).to eq(true)
+        end
+      end
+    end
+
+    context "when the specified number of tries has been exceeded" do
+      it "reports the failure and returns false" do
+        allow(subject).to receive(:puts)
+
+        stub_const("Net::SSH", test_ssh)
+        test_ssh_session = double
+
+        expect(test_ssh).to receive(:start)
+          .exactly(8).times.and_return(test_ssh_session)
+
+        expect(test_ssh_session).to receive(:exec)
+          .exactly(8).times.and_raise(RuntimeError)
+
+        expect(subject).to receive(:backoff_sleep).exactly(8).times
+
+        expect(test_ssh_session).not_to receive(:close)
+
+        expect(subject).to receive(:puts).with("Failed to verify host #{TEST_HOSTNAME}")
+
+        expect(subject.verify_abs_host(TEST_HOSTNAME)).to eq(false)
+      end
+    end
+  end
+
+  describe "#verify_abs_hosts" do
+    context "when no hosts fail verification" do
+      it "checks all hosts and returns true" do
+        # TODO: test messages?
+        allow(subject).to receive(:puts)
+
+        # TODO: update to mom and metrics
+        expect(subject).to receive(:verify_abs_host)
+          .with(TEST_HOSTNAME).twice.and_return(true)
+
+        expect(subject.verify_abs_hosts(TEST_ABS_HOSTS)).to eq(true)
+      end
+    end
+
+    context "when a host fails verification" do
+      it "stops verifying hosts, reports the error, and returns false" do
+        error = "Unable to verify the provisioned hosts"
+        allow(subject).to receive(:puts)
+
+        # TODO: update to mom and metrics
+        expect(subject).to receive(:verify_abs_host)
+          .with(TEST_HOSTNAME).once.and_return(false)
+
+        expect(subject).to receive(:puts).with(error)
+
+        expect(subject.verify_abs_hosts(TEST_ABS_HOSTS)).to eq(false)
+      end
+    end
+  end
+
+  describe "#valid_abs_resource_hosts?" do
+    context "when a valid resource host array is specified" do
+      it "returns true" do
+        expect(subject.valid_abs_resource_hosts?(TEST_ABS_RESOURCE_HOSTS)).to eq(true)
+      end
+    end
+
+    context "when an invalid resource host array is specified" do
+      it "reports the error and returns false" do
+        hosts = TEST_INVALID_ABS_RESOURCE_HOSTS
+        message = "The specified resource host array is not valid: #{hosts}"
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with(message)
+
+        expect(subject.valid_abs_resource_hosts?(hosts)).to eq(false)
+      end
+    end
+
+    context "when an nil is specified" do
+      it "reports the error and returns false" do
+        allow(subject).to receive(:puts)
+        expect(subject).to receive(:puts).with("A valid hosts array is required; nil was specified")
+
+        expect(subject.valid_abs_resource_hosts?(nil)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -361,7 +361,7 @@ describe AbsHelperClass do
 
   end
 
-  describe '#return_abs_resource_hosts' do
+  describe '#abs_return_resource_hosts' do
 
     test_uri = TEST_AWSDIRECTRETURN_URI
     test_body = TEST_AWSDIRECTRETURN_REQUEST_BODY
@@ -373,10 +373,10 @@ describe AbsHelperClass do
 
         expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
 
-        expect(subject).to receive(:get_abs_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
+        expect(subject).to receive(:abs_get_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
         expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(nil)
 
-        expect(subject.return_abs_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
+        expect(subject.abs_return_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
       end
 
     end
@@ -390,10 +390,10 @@ describe AbsHelperClass do
 
         expect(subject).to receive(:abs_get_last_abs_resource_hosts).at_least(:once).and_return(TEST_ABS_RESOURCE_HOSTS)
 
-        expect(subject).to receive(:get_abs_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
+        expect(subject).to receive(:abs_get_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
         expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(nil)
 
-        expect(subject.return_abs_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
+        expect(subject.abs_return_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
       end
 
     end
@@ -407,7 +407,7 @@ describe AbsHelperClass do
         expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
 
         expect(subject).to receive(:abs_get_last_abs_resource_hosts).at_least(:once).and_return(nil)
-        expect(subject.return_abs_resource_hosts).to eq(nil)
+        expect(subject.abs_return_resource_hosts).to eq(nil)
 
       end
 

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -113,71 +113,90 @@ describe AbsHelperClass do
 
   describe '#abs_initialize' do
 
-    context 'when environment variables are specified' do
+    context 'when the user has a token' do
 
-      it 'sets the properties to the specified values' do
+      context 'when environment variables are specified' do
 
-        ENV['ABS_BASE_URL'] = TEST_ABS_BASE_URL
-        ENV['ABS_AWS_PLATFORM'] = TEST_ABS_AWS_PLATFORM
-        ENV['ABS_AWS_IMAGE_ID'] = TEST_ABS_AWS_IMAGE_ID
-        ENV['ABS_AWS_SIZE'] = TEST_ABS_AWS_SIZE
-        ENV['ABS_AWS_REGION'] = TEST_ABS_AWS_REGION
-        ENV['ABS_AWS_REAP_TIME'] = TEST_ABS_AWS_REAP_TIME
-        ENV['ABS_AWS_MOM_SIZE'] = TEST_ABS_AWS_MOM_SIZE
-        ENV['ABS_AWS_METRICS_SIZE'] = TEST_ABS_AWS_METRICS_SIZE
-        ENV['BEAKER_PE_VER'] = TEST_BEAKER_PE_VERSION
+        it 'sets the properties to the specified values and returns true' do
 
-        subject.abs_initialize
-        expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
-        expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
-        expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
-        expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
-        expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
-        expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
-        expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
-        expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
-        expect(subject.instance_variable_get(:@abs_beaker_pe_version)). to eq(TEST_BEAKER_PE_VERSION)
+          ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+
+          ENV['ABS_BASE_URL'] = TEST_ABS_BASE_URL
+          ENV['ABS_AWS_PLATFORM'] = TEST_ABS_AWS_PLATFORM
+          ENV['ABS_AWS_IMAGE_ID'] = TEST_ABS_AWS_IMAGE_ID
+          ENV['ABS_AWS_SIZE'] = TEST_ABS_AWS_SIZE
+          ENV['ABS_AWS_REGION'] = TEST_ABS_AWS_REGION
+          ENV['ABS_AWS_REAP_TIME'] = TEST_ABS_AWS_REAP_TIME
+          ENV['ABS_AWS_MOM_SIZE'] = TEST_ABS_AWS_MOM_SIZE
+          ENV['ABS_AWS_METRICS_SIZE'] = TEST_ABS_AWS_METRICS_SIZE
+          ENV['BEAKER_PE_VER'] = TEST_BEAKER_PE_VERSION
+
+          expect(subject).to receive(:abs_get_token).and_return(TEST_ABS_TOKEN)
+          expect(subject.abs_initialize).to eq(true)
+
+          expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
+          expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
+          expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
+          expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
+          expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
+          expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
+          expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
+          expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
+          expect(subject.instance_variable_get(:@abs_beaker_pe_version)). to eq(TEST_BEAKER_PE_VERSION)
+
+        end
+
+      end
+
+      context 'when environment variables are not specified' do
+
+        it 'sets the properties to the default values and returns true' do
+          pending 'resolve stubbed constant issue'
+
+          ENV['ABS_BASE_URL'] = nil
+          ENV['ABS_AWS_PLATFORM'] = nil
+          ENV['ABS_AWS_IMAGE_ID'] = nil
+          ENV['ABS_AWS_SIZE'] = nil
+          ENV['ABS_AWS_REGION'] = nil
+          ENV['ABS_AWS_REAP_TIME'] = nil
+          ENV['ABS_AWS_MOM_SIZE'] = nil
+          ENV['ABS_AWS_METRICS_SIZE'] = nil
+
+          stub_const('ABS_BASE_URL', TEST_ABS_BASE_URL)
+          stub_const('ABS_AWS_PLATFORM', TEST_ABS_AWS_PLATFORM)
+          stub_const('ABS_AWS_IMAGE_ID', TEST_ABS_AWS_IMAGE_ID)
+          stub_const('ABS_AWS_SIZE', TEST_ABS_AWS_SIZE)
+          stub_const('ABS_AWS_MOM_SIZE', TEST_ABS_AWS_MOM_SIZE)
+          stub_const('ABS_AWS_METRICS_SIZE', TEST_ABS_AWS_METRICS_SIZE)
+          stub_const('ABS_AWS_REGION', TEST_ABS_AWS_REGION)
+          stub_const('ABS_AWS_REAP_TIME', TEST_ABS_AWS_REAP_TIME)
+
+          # TODO: stubbed constants aren't used by the properties in the code under test
+          # subject.abs_initialize
+
+          expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
+          expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
+          expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
+          expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
+          expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
+          expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
+          expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
+          expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
+
+          subject.abs_initialize
+        end
 
       end
 
     end
 
-    context 'when environment variables are not specified' do
+    context 'when the user does not have a token' do
 
-      it 'sets the properties to the default values' do
-        pending 'resolve stubbed constant issue'
+      it 'returns false' do
+        ENV['ABS_TOKEN'] = nil
 
-        ENV['ABS_BASE_URL'] = nil
-        ENV['ABS_AWS_PLATFORM'] = nil
-        ENV['ABS_AWS_IMAGE_ID'] = nil
-        ENV['ABS_AWS_SIZE'] = nil
-        ENV['ABS_AWS_REGION'] = nil
-        ENV['ABS_AWS_REAP_TIME'] = nil
-        ENV['ABS_AWS_MOM_SIZE'] = nil
-        ENV['ABS_AWS_METRICS_SIZE'] = nil
-
-        stub_const('ABS_BASE_URL', TEST_ABS_BASE_URL)
-        stub_const('ABS_AWS_PLATFORM', TEST_ABS_AWS_PLATFORM)
-        stub_const('ABS_AWS_IMAGE_ID', TEST_ABS_AWS_IMAGE_ID)
-        stub_const('ABS_AWS_SIZE', TEST_ABS_AWS_SIZE)
-        stub_const('ABS_AWS_MOM_SIZE', TEST_ABS_AWS_MOM_SIZE)
-        stub_const('ABS_AWS_METRICS_SIZE', TEST_ABS_AWS_METRICS_SIZE)
-        stub_const('ABS_AWS_REGION', TEST_ABS_AWS_REGION)
-        stub_const('ABS_AWS_REAP_TIME', TEST_ABS_AWS_REAP_TIME)
-
-        # TODO: stubbed constants aren't used by the properties in the code under test
-        # subject.abs_initialize
-
-        expect(subject.instance_variable_get(:@abs_base_url)). to eq(TEST_ABS_BASE_URL)
-        expect(subject.instance_variable_get(:@abs_aws_platform)). to eq(TEST_ABS_AWS_PLATFORM)
-        expect(subject.instance_variable_get(:@abs_aws_image_id)). to eq(TEST_ABS_AWS_IMAGE_ID)
-        expect(subject.instance_variable_get(:@abs_aws_size)). to eq(TEST_ABS_AWS_SIZE)
-        expect(subject.instance_variable_get(:@abs_aws_region)). to eq(TEST_ABS_AWS_REGION)
-        expect(subject.instance_variable_get(:@abs_aws_reap_time)). to eq(TEST_ABS_AWS_REAP_TIME)
-        expect(subject.instance_variable_get(:@abs_aws_mom_size)). to eq(TEST_ABS_AWS_MOM_SIZE)
-        expect(subject.instance_variable_get(:@abs_aws_metrics_size)). to eq(TEST_ABS_AWS_METRICS_SIZE)
-
-        subject.abs_initialize
+        expect(subject).to receive(:abs_get_token).and_return(false)
+        expect(subject.abs_initialize).to eq(false)
       end
 
     end
@@ -709,7 +728,6 @@ describe AbsHelperClass do
     end
 
   end
-
 
   describe '#abs_get_last_abs_resource_hosts' do
 

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -1,0 +1,418 @@
+require './setup/helpers/abs_helper'
+
+class AbsHelperClass
+  include AbsHelper
+end
+
+describe AbsHelperClass do
+  let(:test_net_http) { Class.new }
+  let(:test_net_http_instance) { Class.new }
+  let(:test_net_http_post) { Class.new }
+  let(:test_http_request) { Class.new }
+  let(:test_http_response) { Class.new }
+
+  TEST_ABS_TOKEN = 'test_abs_token_zzz'
+  TEST_BASE_URL = 'https://testing.puppet.net/v2'
+  TEST_AWSDIRECT_URL = "#{TEST_BASE_URL}/awsdirect"
+  TEST_AWSDIRECT_URI = URI(TEST_AWSDIRECT_URL)
+  TEST_AWSDIRECTRETURN_URL = "#{TEST_BASE_URL}/awsdirectreturn"
+  TEST_AWSDIRECTRETURN_URI = URI(TEST_AWSDIRECTRETURN_URL)
+
+  TEST_HOSTNAME = 'testing.puppet.net'
+  TEST_ABS_TYPE = 'el-7-x86_64'
+  TEST_BEAKER_TYPE = 'centos-7-x86-64-west'
+  TEST_ENGINE = 'aws'
+
+  TEST_AWSDIRECT_REQUEST_BODY =
+    { 'platform': 'amazon-6-x86_64',
+      'image_id': 'ami-a07379d9',
+      'size': 'c3.large',
+      'region': 'us-west-2',
+      'reap_time': 10800,
+      'tags':
+          {'field1': 'value1', 'field2': 'value2'}
+    }.to_json
+
+  TEST_AWSDIRECT_RESPONSE_BODY =
+    { 'hostname': TEST_HOSTNAME,
+      'instance_id': 'i-0721e8f28c67a0axx',
+      'type': TEST_ABS_TYPE}.to_json
+
+  TEST_REFORMATTED_RESPONSE_BODY =
+      { 'hostname': TEST_HOSTNAME,
+        'type': TEST_BEAKER_TYPE,
+        'engine': TEST_ENGINE}.to_json
+
+  TEST_AWSDIRECTRETURN_REQUEST_BODY = {'hostname': TEST_HOSTNAME}.to_json
+
+  TEST_INVALID_RESPONSE_BODY = ''
+  TEST_VALID_RESPONSE_CODE = '200'
+  TEST_INVALID_RESPONSE_CODE = '777'
+
+  TEST_ABS_RESOURCE_HOSTS = [
+      { 'hostname': TEST_HOSTNAME,
+        'type': TEST_BEAKER_TYPE,
+        'engine': TEST_ENGINE},
+      { 'hostname': TEST_HOSTNAME,
+        'type': TEST_BEAKER_TYPE,
+        'engine': TEST_ENGINE}].to_json
+
+  TEST_A2A_HOSTS = {'mom': 'c4.2xlarge', 'metrics': 'c4.2xlarge'}
+
+  describe '#abs_get_token_from_fog_file' do
+
+    context 'when the .fog file exists' do
+
+      context 'when the .fog file contains the abs token' do
+
+        it 'returns the token' do
+          fog_file =
+              ":default:
+              :abs_token: #{TEST_ABS_TOKEN}"
+
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(fog_file)
+
+          expect(subject.abs_get_token_from_fog_file).to eq(TEST_ABS_TOKEN)
+        end
+
+      end
+
+      context 'when the .fog file does not contain the abs token' do
+
+        it 'returns nil' do
+          fog_file =
+              ':default:
+              :not_abs_token: xyz123'
+
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:read).and_return(fog_file)
+
+          expect(subject.abs_get_token_from_fog_file).to eq(nil)
+        end
+
+      end
+
+    end
+
+    context 'when the .fog file does not exist' do
+
+      it 'reports the error and returns nil' do
+        expect(File).to receive(:exist?).and_return(false)
+        expect(subject).to receive(:puts).at_least(:once)
+
+        expect(subject.abs_get_token_from_fog_file).to eq(nil)
+      end
+
+
+    end
+
+  end
+
+  describe '#abs_get_token' do
+
+    context 'when a token is set as an environment variable' do
+
+      it 'returns the token' do
+        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+        expect(subject.abs_get_token).to eq(TEST_ABS_TOKEN)
+      end
+
+    end
+
+    context 'when a token is not set as an environment variable' do
+
+      context 'when a token is set in the .fog file' do
+
+        it 'returns the token' do
+          ENV['ABS_TOKEN'] = nil
+          expect(subject).to receive(:abs_get_token_from_fog_file).and_return(TEST_ABS_TOKEN)
+          expect(subject.abs_get_token).to eq(TEST_ABS_TOKEN)
+        end
+
+      end
+
+      context 'when a token is not set in the .fog file' do
+
+        it 'reports the error and returns nil' do
+
+          ENV['ABS_TOKEN'] = nil
+          expect(subject).to receive(:abs_get_token_from_fog_file).and_return(nil)
+          expect(subject).to receive(:puts)
+          expect(subject.abs_get_token).to eq(nil)
+        end
+
+      end
+
+    end
+
+  end
+
+  describe '#abs_request_awsdirect' do
+
+    context 'when a valid uri and body are specified' do
+
+      it 'returns the response' do
+        expect(subject).to receive(:abs_get_request_post).and_return(test_http_request)
+        allow(test_http_request).to receive(:body=)
+
+        stub_const('Net::HTTP', test_net_http)
+        allow(test_net_http).to receive(:new).and_return(test_net_http_instance)
+
+        allow(test_net_http_instance).to receive(:use_ssl=)
+        allow(test_net_http_instance).to receive(:read_timeout=)
+        expect(test_net_http_instance).to receive(:request).with(test_http_request).and_return(test_http_response)
+
+        allow(test_http_response).to receive(:body)
+
+        expect(subject.abs_request_awsdirect(TEST_AWSDIRECT_URI, TEST_AWSDIRECT_REQUEST_BODY)).to eq(test_http_response)
+
+      end
+
+    end
+
+  end
+
+  describe '#abs_is_valid_response?' do
+
+    context 'when a valid response is provided' do
+
+      it 'returns true' do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+
+        expect(subject.abs_is_valid_response?(test_http_response)).to eq(true)
+      end
+
+    end
+
+    context 'when the response is nil' do
+
+      it 'returns false' do
+        expect(subject.abs_is_valid_response?(nil)).to eq(false)
+      end
+
+    end
+
+    context 'when the response code is not valid' do
+
+      it 'returns false' do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_INVALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+
+        expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
+      end
+
+    end
+
+    context 'when the response body is empty' do
+
+      it 'returns false' do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_INVALID_RESPONSE_BODY)
+
+        expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
+      end
+
+    end
+
+    context 'when the response body is nil' do
+
+      it 'returns false' do
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(nil)
+
+        expect(subject.abs_is_valid_response?(test_http_response)).to eq(false)
+      end
+
+    end
+
+
+  end
+
+  describe '#abs_reformat_resource_host' do
+
+    context 'when a valid response_body is provided' do
+
+      it 'returns the expected reformatted response' do
+        expect(subject.abs_reformat_resource_host(TEST_AWSDIRECT_RESPONSE_BODY)).to eq(TEST_REFORMATTED_RESPONSE_BODY)
+      end
+
+    end
+
+    context 'when an invalid response_body is provided' do
+
+      it 'reports the error and returns nil' do
+        expect(subject).to receive(:puts).with('JSON::ParserError encountered')
+        expect(subject.abs_reformat_resource_host(TEST_INVALID_RESPONSE_BODY)).to eq(nil)
+
+      end
+
+    end
+
+  end
+
+  describe '#abs_get_resource_hosts' do
+
+    context 'when a valid response is returned' do
+
+      it 'sets the environment variable, logs the hosts, and returns the response(s)' do
+        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(test_http_response)
+
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_AWSDIRECT_RESPONSE_BODY)
+
+        expect(subject.abs_get_resource_hosts).to eq(TEST_ABS_RESOURCE_HOSTS)
+      end
+
+    end
+
+    context 'when an invalid response code is returned' do
+
+      it 'reports the error and returns nil' do
+        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+        test_expected_result = nil
+
+        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(test_http_response)
+
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_INVALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_INVALID_RESPONSE_BODY)
+
+        expect(subject.abs_get_resource_hosts).to eq(test_expected_result)
+      end
+
+    end
+
+    context 'when an invalid response body is returned' do
+
+      it 'reports the error and returns nil' do
+        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+        test_expected_result = nil
+
+        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(test_http_response)
+
+        expect(test_http_response).to receive(:nil?).at_least(:once).and_return(false)
+        expect(test_http_response).to receive(:code).at_least(:once).and_return(TEST_VALID_RESPONSE_CODE)
+        expect(test_http_response).to receive(:body).at_least(:once).and_return(TEST_INVALID_RESPONSE_BODY)
+
+        expect(subject.abs_get_resource_hosts).to eq(test_expected_result)
+      end
+
+    end
+
+    context 'when the response is nil' do
+
+      it 'reports the error and returns nil' do
+        ENV['ABS_TOKEN'] = TEST_ABS_TOKEN
+        test_expected_result = nil
+
+        expect(subject).to receive(:abs_request_awsdirect).at_least(:once).and_return(nil)
+        expect(subject.abs_get_resource_hosts).to eq(test_expected_result)
+      end
+
+    end
+
+  end
+
+  describe '#abs_get_last_abs_resource_hosts' do
+
+    context 'when the file exists' do
+
+      context 'when the file contains a valid list of hosts' do
+
+        it 'returns the hosts' do
+          skip
+        end
+
+      end
+
+      context 'when the file does not contain a valid list of hosts' do
+
+        it 'reports the error and returns nil' do
+          skip
+        end
+
+      end
+
+      context 'when the file is empty' do
+
+        it 'reports the error and returns nil' do
+          skip
+        end
+
+      end
+
+    end
+
+    context 'when the file does not exist' do
+
+      it 'reports the error and returns nil' do
+        skip
+      end
+
+    end
+
+  end
+
+  describe '#return_abs_resource_hosts' do
+
+    test_uri = TEST_AWSDIRECTRETURN_URI
+    test_body = TEST_AWSDIRECTRETURN_REQUEST_BODY
+
+    context 'when an array of hosts is specified via ABS_RESOURCE_HOSTS' do
+
+      it 'submits requests to return the hosts and returns the host array' do
+        ENV['ABS_RESOURCE_HOSTS'] = TEST_ABS_RESOURCE_HOSTS
+
+        expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
+
+        expect(subject).to receive(:get_abs_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
+        expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(nil)
+
+        expect(subject.return_abs_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
+      end
+
+    end
+
+    context 'when an array of hosts is specified via last_abs_resource_hosts.log' do
+
+      it 'submits requests to returns the hosts and returns the host array' do
+        ENV['ABS_RESOURCE_HOSTS'] = nil
+
+        expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
+
+        expect(subject).to receive(:abs_get_last_abs_resource_hosts).at_least(:once).and_return(TEST_ABS_RESOURCE_HOSTS)
+
+        expect(subject).to receive(:get_abs_awsdirectreturn_request_body).with(TEST_HOSTNAME).at_least(:once).and_return(test_body)
+        expect(subject).to receive(:abs_request_awsdirect).with(test_uri, test_body).at_least(:once).and_return(nil)
+
+        expect(subject.return_abs_resource_hosts).to include(TEST_ABS_RESOURCE_HOSTS)
+      end
+
+    end
+
+    context 'when an array of hosts is not specified' do
+
+      # TODO: improve
+      it 'reports the error and returns nil' do
+        ENV['ABS_RESOURCE_HOSTS'] = nil
+
+        expect(subject).to receive(:abs_get_base_url).at_least(:once).and_return(TEST_BASE_URL)
+
+        expect(subject).to receive(:abs_get_last_abs_resource_hosts).at_least(:once).and_return(nil)
+        expect(subject.return_abs_resource_hosts).to eq(nil)
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
ABS has been updated with the new endpoints /awsdirect and /awsdirectreturn to provide a direct response for AWS host requests:
https://github.com/puppetlabs/always-be-scheduling#apiv2awsdirect

This update adds an abs_helper module to extract and encapsulate the ABS-related code used by the performance rake tasks so that it can be tested via RSpec. A corresponding abs_helper_spec file has been added with examples for critical functionality.

The performance rake tasks (`performance`, `performance_provision_with_abs`, `performance_deprovision_with_abs`) have been updated to use the new endpoints via the abs_helper module. Obsolete code and dependencies have been removed.

Requests to the prod endpoint (https://cinext-abs.delivery.puppetlabs.net/api/v2/awsdirect) currently return a 504 Gateway Timeout error as the updated ABS code hasn't been deployed there yet. The test endpoint (https://cinext-abs-test.delivery.puppetlabs.net/api/v2/awsdirect) responds as specified in the README linked above without actually provisioning the hosts. 

The test endpoint is currently specified in abs_helper via the ABS_BASE_URL constant to facilitate testing and review. Performance runs will fail as Beaker will not be able to connect to the non-existent hosts. However, the `performance_provision_with_abs` and `performance_deprovision_with_abs` tasks can be run independently to test the abs_helper updates:
* Running the `performance_provision_with_abs` task will request two hosts (mom and metrics) from the /awsdirect endpoint and populate the 'last_abs_resource_hosts.log' file with the returned hosts. 

* Running the `performance_deprovision_with_abs` task (with no ABS_RESOURCE_HOSTS environment variable) will return the hosts captured in the 'last_abs_resource_hosts.log' file.

Once the prod endpoint is ready I'll update abs_helper to use it and perform a final round of testing with a full performance run.