### PR TITLE
(SLV-189) Disable max response time assertion

### DIFF
--- a/tests/ApplesToApples.rb
+++ b/tests/ApplesToApples.rb
@@ -18,7 +18,8 @@ perf_setup('ApplesToApples.json','PerfTestLarge', gatlingassertions)
 atop_result, gatling_result = perf_result
 
 step 'max response' do
-  assert_later(gatling_result.max_response_time_agent <= 20000, "Max response time per agent run was: #{gatling_result.max_response_time_agent}, expected <= 20000")
+  # Temporarily disabling this step until SLV-208 is complete
+  # assert_later(gatling_result.max_response_time_agent <= 20000, "Max response time per agent run was: #{gatling_result.max_response_time_agent}, expected <= 20000")
 end
 
 step 'request count' do


### PR DESCRIPTION
This update temporarily disables the max response time assertion until SLV-208 is complete