### PR TITLE
(maint) Update aws template name

### DIFF
--- a/config/beaker_hosts/pe-perf-test.cfg
+++ b/config/beaker_hosts/pe-perf-test.cfg
@@ -1,4 +1,4 @@
-default_vmname: &default_vmname centos-7-x86-64-west
+default_vmname: &default_vmname centos-7-x86_64
 default_platform: &default_platform el-7-x86_64
 default_snapshot: &default_snapshot pe
 


### PR DESCRIPTION
This changed somewhere and that template no longer exists, this is causing CI failures, changing to a template that works.