### PR TITLE
(SLV-249) Update to support puppet 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,12 @@
 source ENV['GEM_SOURCE'] || 'https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
 
-gem 'beaker', :git => 'https://github.com/puppetlabs/beaker.git', :branch => 'fix/master/BKR-487_preserved_hosts_yml_fix'
+gem 'beaker', '~>4.0'
 gem 'beaker-benchmark', '~>0.0'
-gem 'beaker-pe', '~>1.4'
-gem 'beaker-pe-large-environments', '~>0.2'
-gem 'scooter', '~>4.0'
+gem 'beaker-pe', '~>2.0'
+gem 'beaker-aws'
+gem 'beaker-abs', '~>0.1'
+gem 'beaker-pe-large-environments', '~>0.3'
+gem 'scooter', '~>4.3'
 gem 'rototiller', '~>1.0'
 gem 'rspec', '~>3.0'
 

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -3,6 +3,7 @@ require 'tmpdir'
 require 'yaml'
 require 'beaker'
 require 'net/http'
+require 'beaker-pe' #PE-25240 will make this not needed
 
 module PerfHelper
   BASE_URL = 'http://builds.puppetlabs.lan'
@@ -529,18 +530,6 @@ authorization: {
     end
     step 'install scala build tool (sbt)' do
       on metric, 'rpm -ivh http://dl.bintray.com/sbt/rpm/sbt-0.13.7.rpm'
-    end
-    step 'install rvm, bundler' do
-      begin
-        on metric, 'gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3'
-      rescue
-        # Execute alternative gpg command
-        on metric, 'command curl -sSL https://rvm.io/mpapis.asc | gpg2 --import -'
-      end
-
-      on metric, 'curl -sSL https://get.rvm.io | bash -s stable'
-      on metric, 'rvm install 2.4.2'
-      on metric, 'gem install bundler'
     end
     step 'create key for metrics to talk to primary master' do
       on metric, 'yes | ssh-keygen -q -t rsa -b 4096 -f /root/.ssh/id_rsa -N "" -C "gatling"'


### PR DESCRIPTION
rvm interfers with puppet agent on metrics node, so stopped setting it up as we don't need it.
Updated gemfile for dependencies that support the lost cli commands in puppet 6.
like puppet cert.  had to require beaker-pe because beaker-pe-large-environments doesn't currently handle it's dependencies correctly.