### PR TITLE
(SLV-235) redo recordings for puppet 6

### DIFF
--- a/proxy-recorder/launch-gatling-proxy.sh
+++ b/proxy-recorder/launch-gatling-proxy.sh
@@ -1,36 +1,9 @@
 #!/usr/bin/env bash
 
-echo "
-
-So you'd like to capture a puppet agent run, eh?
-
-First thing we're going to do is to check the state of your git working
-tree, because this script is going to make some commits containing
-the output of your recording.  If you have a dirty work tree, you can clean
-it up now if you like.  Otherwise, after you press ENTER and we do the check,
-the script will fail.
-PRESS ENTER"
-read
-
-git diff-index --quiet HEAD --
-RESULT=$?
-echo "RESULT IS: ${RESULT}"
-
-if [ $RESULT -ne 0 ]
-then
-  echo "
-ERROR!  Your git working tree appears to be dirty.  Please commit or stash your
-changes, and then run this script again.  Exiting.
-"
-  exit 1
-fi
 
 set -e
 
 echo "
-
-Great, your git working tree appears to be clean.  Let's move on to capturing
-the recording.
 
 Here are some assumptions that this program makes.  Please make sure that
 they are accurate.
@@ -50,45 +23,10 @@ All that sound correct?  If so, press enter to continue.
 PRESS ENTER"
 read
 
-echo "
-The first thing that we need to set up an SSL cert for the gatling proxy.
-To do this, we're going to need some of the .pem files from the PE master.
-I'll snag them for you via scp.
-
-Please enter the hostname or IP of the PE master machine: "
-read -e PE_MASTER
-
-echo "Copying files from $PE_MASTER."
-
-rm -rf ./target/tmp/ssl
-mkdir -p ./target/tmp/ssl
-HOST_CERTNAME=`ssh root@${PE_MASTER} "puppet master --configprint certname"`
-HOST_CERT=`ssh root@${PE_MASTER} "puppet master --configprint hostcert"`
-HOST_KEY=`ssh root@${PE_MASTER} "puppet master --configprint hostprivkey"`
-
-scp root@${PE_MASTER}:${HOST_CERT} ./target/tmp/ssl/hostcert.pem
-scp root@${PE_MASTER}:${HOST_KEY} ./target/tmp/ssl/hostkey.pem
-
-echo "Copied files.  Generating keystore file for gatling."
-cat ./target/tmp/ssl/hostcert.pem ./target/tmp/ssl/hostkey.pem > ./target/tmp/ssl/keystore.pem
-echo "puppet" | openssl pkcs12 -export \
-                        -in ./target/tmp/ssl/keystore.pem \
-                        -out ./target/tmp/ssl/keystore.p12 \
-                        -name ${HOST_CERTNAME} \
-                        -passout fd:0
-keytool -importkeystore \
-        -destkeystore ./target/tmp/ssl/gatling-proxy-keystore.jks \
-        -srckeystore ./target/tmp/ssl/keystore.p12 \
-        -srcstoretype PKCS12 \
-        -alias ${HOST_CERTNAME} \
-        -deststorepass "puppet" \
-        -srcstorepass "puppet"
-
-echo "Keystore successfully generated."
 
 echo "
-Sweet!  Things are going swimmingly.  Now we're ready to launch the gatling
-proxy.  When you press enter, we'll launch it as a background process, and
+Sweet!  Now we're ready to launch the gatling proxy.
+When you press enter, we'll launch it as a background process, and
 print out some more instructions here.  If you can arrange the windows so
 that you can see both this script and the proxy, that'll help.
 
@@ -201,18 +139,11 @@ fi
 echo "Moving report body file to correct directory."
 mv ${REPORT_BODY} ${REPORT_FINAL_PATH}
 
-echo "Preparing for git commit of raw output from gatling recorder."
-git add ${REPORT_FINAL_PATH}
-git add ${SIMULATION_FILE}
-
-git commit -m "(MAINT) Raw output of gatling recorder for ${SIMULATION_NAME}"
-
 echo "
 
 OK.  Found the required output files from the recorder and moved them to the
-appropriate locations.  Performed a 'git commit' to capture the raw recording
-output.  Now we'll run our post-processing script that converts the recording
-for use with gatling-puppet-load-test, and then commit that to git as well.
+appropriate locations.  Now we'll run our post-processing script that converts the recording
+for use with gatling-puppet-load-test.
 PRESS ENTER"
 read
 
@@ -220,13 +151,7 @@ read
 mv ${REPORT_FINAL_PATH}.new ${REPORT_FINAL_PATH}
 mv ${SIMULATION_FILE}.new ${SIMULATION_FILE}
 
-git add ${REPORT_FINAL_PATH}
-git add ${SIMULATION_FILE}
-git add ../simulation-runner/config/nodes/${SIMULATION_NAME}.json
-
-git commit -m "(MAINT) Processed gatling recording for ${SIMULATION_NAME}"
-
 echo "
-Done!  The recording has been modified successfully and committed to git.
+Done!  The recording has been modified successfully.
 "
 

--- a/rakefile
+++ b/rakefile
@@ -43,6 +43,15 @@ rototiller_task :performance_deprovision_with_abs do
   raise 'Failed to de-provision ABS hosts' unless returned_hosts == abs_resource_hosts
 end
 
+desc 'Setup Agent for recordings'
+rototiller_task :setup_recording_agent do
+  ENV['BEAKER_HOSTS'] ||= "log/latest/hosts_preserved.yml"
+  ENV['ABS_RESOURCE_HOSTS'] = File.open("last_abs_resource_hosts.log").readlines[0] if File.exist? "last_abs_resource_hosts.log"
+  ENV['BEAKER_PRE_SUITE'] = "setup/install_gatling/00_pre_install/05_initialize_helpers.rb,setup/install_gatling/setup_metrics_as_agent.rb"
+  ENV['BEAKER_TESTS'] = ""
+  Rake::Task["performance_without_provision"].execute
+end
+
 desc 'Run Performance tests using previously provisioned hosts'
 rototiller_task :performance_against_already_provisioned do
   ENV['BEAKER_HOSTS'] ||= "log/latest/hosts_preserved.yml"

--- a/setup/install_gatling/setup_metrics_as_agent.rb
+++ b/setup/install_gatling/setup_metrics_as_agent.rb
@@ -1,0 +1,3 @@
+test_name 'Setup and configure gatling agent' do
+  setup_metrics_as_agent
+end

--- a/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PerfTestLarge.scala
+++ b/simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations/PerfTestLarge.scala
@@ -26,14 +26,13 @@ class PerfTestLarge extends SimulationWithScenario {
 
 	val baseHeaders = Map("Accept" -> "application/json, text/pson",
 		"Accept-Encoding" -> "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-		"User-Agent" -> "Puppet/5.3.3 Ruby/2.4.2-p198 (x86_64-linux)")
+		"User-Agent" -> "Puppet/6.0.0 Ruby/2.5.1-p57 (x86_64-linux)")
 
-	val headers_0 = baseHeaders ++ Map("X-Puppet-Version" -> "5.3.3")
+	val headers_0 = baseHeaders ++ Map("X-Puppet-Version" -> "6.0.0")
 
 	val headers_6 = baseHeaders ++ Map(
-		"Connection" -> "close",
 		"Content-Type" -> "application/json",
-		"X-Puppet-Version" -> "5.3.3")
+		"X-Puppet-Version" -> "6.0.0")
 
 	val scn = scenario("perf_test_large")
 	    .feed(reportFeeder)
@@ -63,13 +62,9 @@ class PerfTestLarge extends SimulationWithScenario {
 			.formParam("facts", "%7B%22name%22%3A%22${node}%22%2C%22values%22%3A%7B" + "${Fact}" + "${HostFact}" + staticFacts)
 			.formParam("transaction_uuid", "feaf75a3-c82c-4e06-9d02-5387f14034a0")
 			.formParam("static_catalog", "true")
-			.formParam("checksum_type", "md5.sha256")
+			.formParam("checksum_type", "md5.sha256.sha384.sha512.sha224")
 			.formParam("fail_on_404", "true"))
 		.pause(2)
-		.exec(http("filemeta mco plugins")
-			.get("/puppet/v3/file_metadatas/modules/puppet_enterprise/mcollective/plugins?environment=production&links=manage&recurse=true&source_permissions=ignore&checksum_type=md5")
-			.headers(headers_0))
-		.pause(4)
 		.exec((session:Session) => {
 			session.set("reportTimestamp",
 				LocalDateTime.now.toString(ISODateTimeFormat.dateTime()))

--- a/tests/ApplesToApples.rb
+++ b/tests/ApplesToApples.rb
@@ -10,7 +10,7 @@ end
 perf_setup('WarmUpJit.json','PerfTestLarge', '')
 stop_monitoring(master, '/opt/puppetlabs')
 
-gatlingassertions = "SUCCESSFUL_REQUESTS=100 " + "MAX_RESPONSE_TIME_AGENT=20000 "  + "TOTAL_REQUEST_COUNT=70 "
+gatlingassertions = "SUCCESSFUL_REQUESTS=100 " + "MAX_RESPONSE_TIME_AGENT=20000 "
 
 # pass in gatling scenario file name and simulation id
 perf_setup('ApplesToApples.json','PerfTestLarge', gatlingassertions)
@@ -20,10 +20,6 @@ atop_result, gatling_result = perf_result
 step 'max response' do
   # Temporarily disabling this step until SLV-208 is complete
   # assert_later(gatling_result.max_response_time_agent <= 20000, "Max response time per agent run was: #{gatling_result.max_response_time_agent}, expected <= 20000")
-end
-
-step 'request count' do
-  assert_later(gatling_result.request_count == 33600, "Total request count is: #{gatling_result.request_count}, expected 33600")
 end
 
 step 'successful request percentage' do

--- a/tests/ApplesToApples.rb
+++ b/tests/ApplesToApples.rb
@@ -10,7 +10,7 @@ end
 perf_setup('WarmUpJit.json','PerfTestLarge', '')
 stop_monitoring(master, '/opt/puppetlabs')
 
-gatlingassertions = "SUCCESSFUL_REQUESTS=100 " + "MAX_RESPONSE_TIME_AGENT=20000 "
+gatlingassertions = "SUCCESSFUL_REQUESTS=100 " + "MAX_RESPONSE_TIME_AGENT=20000 "  + "TOTAL_REQUEST_COUNT=28800 "
 
 # pass in gatling scenario file name and simulation id
 perf_setup('ApplesToApples.json','PerfTestLarge', gatlingassertions)


### PR DESCRIPTION
removed MCO requests for PerfTestLarge recording.
updated puppet and ruby versions in the recording
enables a rake task to run a presuite that uses perf_helper to setup the metrics node so it can be used to record an agent run.
modified launch gatling to stop requiring it be a git repo and to remove code that was moved to the pre-suite
removed request count assertion from ApplestoApples as it is totally dependent on the recording.