### PR TITLE
(SLV-208) GPLT - automate scaling up node count to help find scale test limit

### DIFF
--- a/config/env/env_setup_2019.0.1
+++ b/config/env/env_setup_2019.0.1
@@ -1,0 +1,8 @@
+# export PUPPET_GATLING_SCALE_ITERATIONS=3
+# export PUPPET_GATLING_SCALE_INCREMENT=10
+# export PUPPET_GATLING_SCALE_SCENARIO="Scale_sm.json"
+# export PUPPET_GATLING_SCALE_SIMULATION_ID="PerfAutoScaleSmall"
+
+export BEAKER_INSTALL_TYPE=pe
+export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.0.1
+export BEAKER_PE_VER=2019.0.1

--- a/rakefile
+++ b/rakefile
@@ -286,7 +286,6 @@ rototiller_task :autoscale_provisioned do |t|
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
   ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
-  ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
   Rake::Task["performance_against_already_provisioned"].execute
 end
 
@@ -295,7 +294,6 @@ rototiller_task :autoscale_provisioned_sm do |t|
   ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '10'
   ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '10'
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_sm.json'
-  ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
   Rake::Task["autoscale_provisioned"].execute
 end
 
@@ -304,7 +302,6 @@ rototiller_task :autoscale_provisioned_med do |t|
   ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '10'
   ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '100'
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_med.json'
-  ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
   Rake::Task["autoscale_provisioned"].execute
 end
 

--- a/rakefile
+++ b/rakefile
@@ -114,6 +114,7 @@ rototiller_task :performance_without_provision do |t|
   else
     t.add_env({:name => 'PUPPET_GATLING_R10K_BASEDIR', :default => '/etc/puppetlabs/code-staging/environments'})
   end
+
   t.add_env({:name => 'PUPPET_GATLING_R10K_ENVIRONMENTS', :default => 'production'})
   t.add_env({:name => 'PUPPET_BIN_DIR', :default => '/opt/puppetlabs/puppet/bin'})
   t.add_env({:name => 'PUPPET_R10K_VERSION', :default => '2.3.0'})
@@ -263,6 +264,48 @@ rototiller_task :acceptance do |t|
   # Need to change this from an AWS OS image to a vmpooler OS image
   ENV['ABS_OS'] ||= 'centos-7-x86_64'
   Rake::Task["performance"].execute
+end
+
+desc 'Run Scale setup and test for gatling'
+rototiller_task :autoscale do |t|
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
+  ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
+  ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
+  Rake::Task["performance"].execute
+end
+
+desc 'Run Scale setup for gatling'
+rototiller_task :autoscale_setup do |t|
+  ENV['BEAKER_TESTS'] = ''
+  Rake::Task["autoscale"].execute
+end
+
+desc 'Run Scale test for gatling on previously provisioned hosts'
+rototiller_task :autoscale_provisioned do |t|
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
+  ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
+  ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
+  Rake::Task["performance_against_already_provisioned"].execute
+end
+
+desc 'Run small Scale test for gatling on previously provisioned hosts'
+rototiller_task :autoscale_provisioned_sm do |t|
+  ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '10'
+  ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '10'
+  ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_sm.json'
+  ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
+  Rake::Task["autoscale_provisioned"].execute
+end
+
+desc 'Run medium Scale test for gatling on previously provisioned hosts'
+rototiller_task :autoscale_provisioned_med do |t|
+  ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '10'
+  ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '100'
+  ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_med.json'
+  ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
+  Rake::Task["autoscale_provisioned"].execute
 end
 
 desc "Run spec tests"

--- a/simulation-runner/config/scenarios/Scale.json
+++ b/simulation-runner/config/scenarios/Scale.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'role::by_size_small' role from perf control repo, 3000 agents, 1 iteration",
+    "nodes": [
+        {
+            "node_config": "PerfTestLarge.json",
+            "num_instances": 3000,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 1,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}

--- a/simulation-runner/config/scenarios/Scale_med.json
+++ b/simulation-runner/config/scenarios/Scale_med.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'role::by_size_small' role from perf control repo, 500 agents, 1 iteration",
+    "nodes": [
+        {
+            "node_config": "PerfTestLarge.json",
+            "num_instances": 500,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 1,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}

--- a/simulation-runner/config/scenarios/Scale_sm.json
+++ b/simulation-runner/config/scenarios/Scale_sm.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'role::by_size_small' role from perf control repo, 10 agents, 1 iteration",
+    "nodes": [
+        {
+            "node_config": "PerfTestLarge.json",
+            "num_instances": 10,
+            "ramp_up_duration_seconds": 30,
+            "num_repetitions": 1,
+            "sleep_duration_seconds": 30
+        }
+    ]
+}

--- a/tests/Scale.rb
+++ b/tests/Scale.rb
@@ -1,0 +1,22 @@
+require_relative 'helpers/perf_run_helper'
+
+test_name 'Scale'
+
+teardown do
+  # TODO: remove?
+  # perf_teardown
+end
+
+# TODO: remove?
+# Execute 60 agent runs to warm up the JIT before starting our monitoring.
+# perf_setup('WarmUpJit.json','PerfTestLarge', '')
+# stop_monitoring(master, '/opt/puppetlabs')
+
+assertions = "SUCCESSFUL_REQUESTS=100 " + "MAX_RESPONSE_TIME_AGENT=20000 "  + "TOTAL_REQUEST_COUNT=28800 "
+scenario = ENV["PUPPET_GATLING_SCALE_SCENARIO"] || "Scale.json"
+simulation = ENV["PUPPET_GATLING_SCALE_SIMULATION"] || "PerfTestSmall"
+
+# pass in gatling scenario file name and simulation id
+scale_setup(scenario, simulation, assertions)
+
+

--- a/tests/Scale.rb
+++ b/tests/Scale.rb
@@ -2,21 +2,14 @@ require_relative 'helpers/perf_run_helper'
 
 test_name 'Scale'
 
-teardown do
-  # TODO: remove?
-  # perf_teardown
-end
-
-# TODO: remove?
-# Execute 60 agent runs to warm up the JIT before starting our monitoring.
-# perf_setup('WarmUpJit.json','PerfTestLarge', '')
-# stop_monitoring(master, '/opt/puppetlabs')
-
+# The assertions that will be specifed for each iteration of the scenario
 assertions = "SUCCESSFUL_REQUESTS=100 " + "MAX_RESPONSE_TIME_AGENT=20000 "  + "TOTAL_REQUEST_COUNT=28800 "
+
+# The scenario file that will be used as a base to build the auto-scaled scenarios
 scenario = ENV["PUPPET_GATLING_SCALE_SCENARIO"] || "Scale.json"
-simulation = ENV["PUPPET_GATLING_SCALE_SIMULATION"] || "PerfTestSmall"
 
-# pass in gatling scenario file name and simulation id
-scale_setup(scenario, simulation, assertions)
+# The scenario id / name that will appear in the results
+simulation_id = ENV["PUPPET_GATLING_SCALE_SIMULATION_ID"] || "PerfAutoScale"
 
-
+# Execute the auto-scaled scenario
+scale_setup(scenario, simulation_id, assertions)

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -187,26 +187,11 @@ module PerfRunHelper
     scale_assertions(atop_result, gatling_result)
   end
 
+  # TODO: remove atop_result if it isn't being used?
   def scale_assertions(atop_result, gatling_result)
-    step 'max response' do
-      # TODO: enable?
-      # Temporarily disabling this step until SLV-208 is complete
-      # assert_later(gatling_result.max_response_time_agent <= 20000, "Max response time per agent run was: #{gatling_result.max_response_time_agent}, expected <= 20000")
-    end
 
     step 'successful request percentage' do
       assert_later(gatling_result.successful_requests == 100, "Total successful request percentage was: #{gatling_result.successful_requests}%, expected 100%" )
-    end
-
-    step 'average memory' do
-      # TODO: enable?
-      # assert_later(atop_result.avg_mem < 3000000, "Average memory was: #{atop_result.avg_mem}, expected < 3000000")
-    end
-
-    #This step will only be run if BASELINE_PE_VER has been set.
-    step 'baseline assertions' do
-      # TODO: enable?
-      # baseline_assert(atop_result, gatling_result)
     end
 
     assert_all


### PR DESCRIPTION
This update adds functionality to automatically increase the agent count for the scale scenario over a specified number of iterations. The 'pe-pupppetserver' service is restarted before each iteration providing a cold-start test scenario. See the [Kick off Scale performance tests](https://github.com/puppetlabs/gatling-puppet-load-test/blob/SLV-208/NEW_README.md#kick-off-scale-performance-tests) section of the [NEW_README.md](NEW_README.md) file for instructions.
