### PR TITLE
(SLV-246) GPLT - Run 'puppet infrastructure tune' for autoscale setup, capture puppet-metrics-collector output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea
 .idea_modules
 target
-results
 simulation-runner/cache
 simulation-runner/config/gatling.conf
 simulation-runner/config/tmp

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -60,17 +60,53 @@ These values can be specified via the 'PUPPET_GATLING_SCALE_ITERATIONS' and 'PUP
 
 After each iteration completes the results are checked and if a KO is found the test is failed.
 
-The results for each iteration are copied to a folder named 'PERF_SCALE{$SCALE_TIMESTAMP}'. 
+The results for each iteration are copied to a folder named 'PERF_SCALE{$SCALE_TIMESTAMP}' in `results/scale`. 
 The sub-directory for each iteration is named based on the scenario, iteration, and number of agents.
 
 In order to execute a Scale performance run:
-* See the instructions in the "Kick off Soak performance tests" section above to set up the testing environment and tune the master
-* Run the 'autoscale_provisioned' rake task
+#### Pre-requisites
+See the 'Kick off Apples to Apples performance tests' above regarding pre-requisites, environment variables, etc...
+It can be helpful to use an env file to manage these environment variables. The file `config/env/env_setup_2019.0.1` is provided as an example.
+Apply this configuration with the following command:
+```
+source config/env/env_setup_2019.0.1
+```
+
+#### Provision, tune, run
+A set of 'autoscale' rake tasks are provided to handle setup and scale test execution.
+The pre-suite has been updated to include tuning of the master via 'puppet infrastructure tune' for scale tests so this is no longer a manual step.
+As with the other configurations test nodes can be provisioned as part of the run or as a separate step.
+
+Note that when using the autoscale rake tasks the `BEAKER_PRESERVE_HOSTS` environment variable is always set to 'true', so you will need to de-provision the test nodes with the `performance_deprovision_with_abs` when your testing is complete. 
+
+* To provision nodes as part of the run:
+```
+bundle exec rake autoscale
+```
+
+* To provision nodes separately:
+
+run the `autoscale_setup` rake task to provision the nodes:
+```
+bundle exec rake autoscale_setup
+```
+
+then run the 'autoscale_provisioned' rake task to run the scale test:
 ```
 bundle exec rake autoscale_provisioned
 ```
 
+* De-provision the nodes when testing is complete:
+```
+bundle exec rake performance_deprovision_with_abs
+```
+
 There are additional rake tasks for small and medium autoscale runs to allow testing of the environment and autoscale functionality without waiting for a full run:
+* autoscale_provisioned_tiny
+- 1 agents
+- 3 iterations
+- increment by 1
+
 * autoscale_provisioned_sm
 - 10 agents
 - 10 iterations

--- a/rakefile
+++ b/rakefile
@@ -270,7 +270,7 @@ desc 'Run Scale setup and test for gatling'
 rototiller_task :autoscale do
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
-  ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
   ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
   ENV['SCALE_TUNE'] = ENV['SCALE_TUNE'] || 'true'
   Rake::Task["performance"].execute
@@ -283,7 +283,7 @@ rototiller_task :autoscale_setup do
   Rake::Task["autoscale"].execute
 end
 
-desc 'Run puppet infrastructure tune setup for gatling'
+desc 'Run puppet infrastructure tune setup for gatling on a previously provisioned master'
 rototiller_task :autoscale_tune do
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = 'setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb'

--- a/rakefile
+++ b/rakefile
@@ -272,6 +272,7 @@ rototiller_task :autoscale do
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
   ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
   ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
+  ENV['SCALE_TUNE'] = ENV['SCALE_TUNE'] || 'true'
   Rake::Task["performance"].execute
   Rake::Task["autoscale_copy_log"].execute unless ENV['BEAKER_TESTS'] == ''
 end
@@ -280,6 +281,15 @@ desc 'Run Scale setup for gatling'
 rototiller_task :autoscale_setup do
   ENV['BEAKER_TESTS'] = ''
   Rake::Task["autoscale"].execute
+end
+
+desc 'Run puppet infrastructure tune setup for gatling'
+rototiller_task :autoscale_tune do
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_TESTS'] = 'setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb'
+  ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
+  ENV['SCALE_TUNE'] = 'true'
+  Rake::Task["performance_against_already_provisioned"].execute
 end
 
 desc 'Run Scale test for gatling on previously provisioned hosts'

--- a/rakefile
+++ b/rakefile
@@ -296,7 +296,7 @@ desc 'Run Scale test for gatling on previously provisioned hosts'
 rototiller_task :autoscale_provisioned do
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
-  ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
   Rake::Task["performance_against_already_provisioned"].execute
   Rake::Task["autoscale_copy_log"].execute
 end

--- a/rakefile
+++ b/rakefile
@@ -323,12 +323,6 @@ task :autoscale_copy_log do
   FileUtils.copy_entry source, dest
 end
 
-desc 'testing'
-task :autoscale_test do
-  timestamp = Time.now.strftime("%Y.%m.%d_%H.%M.%S")
-  puts "timestamp: #{timestamp}"
-end
-
 desc "Run spec tests"
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = ['--color']

--- a/rakefile
+++ b/rakefile
@@ -267,30 +267,40 @@ rototiller_task :acceptance do |t|
 end
 
 desc 'Run Scale setup and test for gatling'
-rototiller_task :autoscale do |t|
+rototiller_task :autoscale do
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
   ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
   ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
   Rake::Task["performance"].execute
+  Rake::Task["autoscale_copy_log"].execute
 end
 
 desc 'Run Scale setup for gatling'
-rototiller_task :autoscale_setup do |t|
+rototiller_task :autoscale_setup do
   ENV['BEAKER_TESTS'] = ''
   Rake::Task["autoscale"].execute
 end
 
 desc 'Run Scale test for gatling on previously provisioned hosts'
-rototiller_task :autoscale_provisioned do |t|
+rototiller_task :autoscale_provisioned do
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
   ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
   Rake::Task["performance_against_already_provisioned"].execute
+  Rake::Task["autoscale_copy_log"].execute
+end
+
+desc 'Run tiny Scale test for gatling on previously provisioned hosts'
+rototiller_task :autoscale_provisioned_tiny do
+  ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '3'
+  ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '1'
+  ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_tiny.json'
+  Rake::Task["autoscale_provisioned"].execute
 end
 
 desc 'Run small Scale test for gatling on previously provisioned hosts'
-rototiller_task :autoscale_provisioned_sm do |t|
+rototiller_task :autoscale_provisioned_sm do
   ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '10'
   ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '10'
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_sm.json'
@@ -303,6 +313,20 @@ rototiller_task :autoscale_provisioned_med do |t|
   ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '100'
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_med.json'
   Rake::Task["autoscale_provisioned"].execute
+end
+
+desc 'Copy latest log to latest scale results'
+task :autoscale_copy_log do
+  source = File.realpath("log/latest")
+  dest = File.realpath("results/scale/latest/log")
+  puts "Copying from #{source} to #{dest}..."
+  FileUtils.copy_entry source, dest
+end
+
+desc 'testing'
+task :autoscale_test do
+  timestamp = Time.now.strftime("%Y.%m.%d_%H.%M.%S")
+  puts "timestamp: #{timestamp}"
 end
 
 desc "Run spec tests"

--- a/rakefile
+++ b/rakefile
@@ -273,7 +273,7 @@ rototiller_task :autoscale do
   ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
   ENV['PUPPET_SCALE_CLASS'] = 'role::by_size::small'
   Rake::Task["performance"].execute
-  Rake::Task["autoscale_copy_log"].execute
+  Rake::Task["autoscale_copy_log"].execute unless ENV['BEAKER_TESTS'] == ''
 end
 
 desc 'Run Scale setup for gatling'

--- a/results/RESULTS.md
+++ b/results/RESULTS.md
@@ -1,0 +1,10 @@
+# Performance and Scale Results
+gatling-puppet-load-test results are now copied to this directory rather than the parent directory.
+
+# Perf Results
+Perf test results will be copied to the `results/perf` directory.
+
+# Scale Results
+Scale test results will be copied to the `results/scale` directory.
+The `latest` link is created during scale test initialization and will point to the latest scale test results.
+This is used by the `autoscale_copy_log` rake task to copy the test results after the test run.

--- a/results/RESULTS.md
+++ b/results/RESULTS.md
@@ -1,5 +1,5 @@
 # Performance and Scale Results
-gatling-puppet-load-test results are now copied to this directory rather than the parent directory.
+gatling-puppet-load-test results are now copied to the `results/perf` and `results/scale` directories rather than the parent directory.
 
 # Perf Results
 Perf test results will be copied to the `results/perf` directory.

--- a/results/perf/PERF_RESULTS.md
+++ b/results/perf/PERF_RESULTS.md
@@ -1,0 +1,2 @@
+# Perf Results
+This directory contains results for each perf run.

--- a/results/scale/SCALE_RESULTS.md
+++ b/results/scale/SCALE_RESULTS.md
@@ -1,0 +1,2 @@
+# Scale Results
+This directory contains results for each scale test run.

--- a/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
+++ b/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
@@ -1,0 +1,46 @@
+test_name 'Run puppet infrastructure tune' do
+
+  def run_puppet_infrastructure_tune
+    common_yaml = "/etc/puppetlabs/code-staging/environments/production/hieradata/common.yaml"
+
+    puts "Running 'puppet infrastructure tune' on master..."
+    puts
+
+    output = on(master, "puppet infrastructure tune").output
+
+    # get data between '---' and the first empty line
+    data = output.match(/## Specify(.*)## CPU/m)[1].gsub("---", "").strip
+
+    # remove control codes
+    data = data.match(/0;32m(.*)\n.*\[/m)[1].strip + "\n"
+
+    puts "Extracted the following data:"
+    puts data
+
+    puts "Appending to common.yml"
+    puts
+    on master, "echo \"#{data}\" >> #{common_yaml}"
+
+    puts "Committing..."
+    puts
+    commit = "curl --request POST --header \"Content-Type: application/json\" --data '{\"commit-all\": true}' --cert $(puppet config print hostcert) --key $(puppet config print hostprivkey) --cacert $(puppet config print localcacert) https://$(hostname):8140/file-sync/v1/commit"
+    on master, commit
+
+    begin
+      on master, "puppet agent -t"
+    rescue
+      puts "Expected non-zero exit code, running again..."
+      on master, "puppet agent -t"
+    end
+  end
+
+  step 'run puppet infrastructure tune' do
+    if ENV['SCALE_TUNE'] == 'true'
+      run_puppet_infrastructure_tune
+    else
+      puts "SCALE_TUNE is not set to 'true'; skipping puppet infrastructure tune..."
+    end
+
+  end
+
+end

--- a/setup/options/options_pe.rb
+++ b/setup/options/options_pe.rb
@@ -18,6 +18,7 @@
     'setup/install_gatling/40_post_install/70_disable_firewall.rb',
     'setup/install_gatling/40_post_install/80_install_deps.rb',
     'setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb',
+    'setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb'
   ],
   'is_puppetserver'            => true,
   'use-service'                => true, # use service scripts to start/stop stuff

--- a/simulation-runner/config/scenarios/Scale_tiny.json
+++ b/simulation-runner/config/scenarios/Scale_tiny.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "'role::by_size_small' role from perf control repo, 1 agents, 1 iteration",
+    "nodes": [
+        {
+            "node_config": "PerfTestLarge.json",
+            "num_instances": 1,
+            "ramp_up_duration_seconds": 30,
+            "num_repetitions": 1,
+            "sleep_duration_seconds": 30
+        }
+    ]
+}


### PR DESCRIPTION
This update adds `setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb` to the pre-suite. This test performs the steps to run and apply `puppet infrastructure tune` on the master if the `SCALE_TUNE` environment variable is set to 'true', so it is only run during the autoscale setup or in the standalone 'autoscale_tune' rake task.

Since the autoscale runs produce a separate 'PERF' folder for each iteration the results have been moved to a `results/perf` for individual runs / iterations and `results/scale` for the collected scale run results. The scale results also provide a `results/scale/latest` link which points to the latest 'PERF_SCALE' result folder. This is used in the autoscale rake tasks to copy the latest log output to the latest scale result folder after the beaker run is complete.

The results gathering has also been updated to include the output from puppet-metrics-collector on the master. The output folders are purged before each iteration of the autoscale run so that only the applicable output is captured. 

The autoscale rake tasks currently include 'tiny', 'small', and 'medium' variants which run alternate versions of the scale test to provide a quick way to test the autoscale and results gathering functionality. These can be removed before merging if they are no longer required.

--
