### PR TITLE
(SLV-206) Add results CSV and beaker environment files to scale results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,12 @@ gem 'beaker-pe', '~>2.0'
 gem 'beaker-aws'
 gem 'beaker-abs', '~>0.1'
 gem 'beaker-pe-large-environments', '~>0.3'
-gem 'scooter', '~>4.3'
+
+# scooter 4.3.1 caused authentication issues
+# see https://tickets.puppetlabs.com/browse/PE-25817
+# see also https://github.com/puppetlabs/scooter/pull/122
+# TODO: revert to '~>4.3' when the issue has been resolved
+gem 'scooter', '=4.3.0'
 gem 'rototiller', '~>1.0'
 gem 'rspec', '~>3.0'
 

--- a/tests/Scale.rb
+++ b/tests/Scale.rb
@@ -2,7 +2,7 @@ require_relative 'helpers/perf_run_helper'
 
 test_name 'Scale'
 
-# The assertions that will be specifed for each iteration of the scenario
+# The assertions that will be specified for each iteration of the scenario
 assertions = "SUCCESSFUL_REQUESTS=100 " + "MAX_RESPONSE_TIME_AGENT=20000 "  + "TOTAL_REQUEST_COUNT=28800 "
 
 # The scenario file that will be used as a base to build the auto-scaled scenarios

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -99,6 +99,8 @@ module PerfRunHelper
   def create_scale_results_csv(perf_scale_dir)
     CSV.open("#{perf_scale_dir}/PERF_SCALE_#{@scale_timestamp}.csv", "wb") do |csv|
       headings = ["agents",
+                  "ok",
+                  "ko",
                   "combined mean",
                   "catalog mean",
                   "filemeta plugins mean",
@@ -262,7 +264,10 @@ module PerfRunHelper
     log_timestamp = File.basename(log_path)
     FileUtils.touch("#{perf_scale_dir}/log/#{log_timestamp}.txt")
 
-    # copy puppet-metrics-collector
+    # copy puppet-metrics-collector to iteration result dir
+    copy_puppet_metrics_collector(scale_result_dir)
+
+    # copy puppet-metrics-collector to parent results dir
     copy_puppet_metrics_collector(perf_scale_dir)
 
   end
@@ -328,6 +333,8 @@ module PerfRunHelper
     # results for csv
     results = []
     results << scale_scenario_instances
+    results << totals["numberOfRequests"]["ok"]
+    results << totals["numberOfRequests"]["ko"]
     results << totals["meanResponseTime"]["total"]
     results << catalog["meanResponseTime"]["total"]
     results << filemeta_plugins["meanResponseTime"]["total"]

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -319,7 +319,7 @@ module PerfRunHelper
 
     # get atop results
     # get_scale_atop_results
-    atop_csv_path = "#{perf_scale_iteration_dir}/master/atop_log_#{scenario.gsub(".json", "_json")}.csv"
+    atop_csv_path = "#{perf_scale_iteration_dir}/master/atop_log_#{scenario.downcase.gsub(".json", "_json")}.csv"
     atop_csv_data = CSV.read(atop_csv_path)
 
     # results for csv

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -186,13 +186,16 @@ module PerfRunHelper
       scenario_name = generate_scale_scenario_name(scale_basename, iteration, instances)
       File.write("#{scenarios_dir}/#{scenario_name}", json.to_json)
 
+      # add scenario hash to the array
+      @scale_scenarios << {:name => scenario_name, :instances => instances}
+
       # update the data for the next iteration
       instances = instances + @scale_increment
       desc = "'role::by_size_small' role from perf control repo, #{instances} agents, 1 iteration"
       json["run_description"] = desc
       json["nodes"][0]["num_instances"] = instances
 
-      @scale_scenarios << {:name => scenario_name, :instances => instances}
+
 
     end
 


### PR DESCRIPTION
This update adds a results CSV file with the following values for each scale iteration:
* agents
* ok
* ko
* combined mean
* catalog mean
* filemeta plugins mean
* filemeta pluginfacts mean
* locales mean
* node mean
* report mean
* average CPU %
* average memory

A 'beaker environment' file has also been added to capture the relevant environment values for the scale run:
* BEAKER_INSTALL_TYPE
* BEAKER_PE_DIR
* BEAKER_PE_VER
* BEAKER_TESTS
* PUPPET_GATLING_SCALE_SCENARIO
* PUPPET_GATLING_SCALE_ITERATIONS
* PUPPET_GATLING_SCALE_INCREMENT

