### PR TITLE
(SLV-317) remove private key for control repo

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -108,7 +108,7 @@ rototiller_task :performance_without_provision do |t|
   t.add_env({:name => 'ABS_RESOURCE_HOSTS', :message => 'The string returned from the ABS service describing your hosts'}) if ENV['BEAKER_HOSTS'] == 'config/beaker_hosts/pe-perf-test.cfg' ||
       ENV['BEAKER_HOSTS'] == 'config/beaker_hosts/foss-perf-test.cfg'
   t.add_env({:name => 'ENVIRONMENT_TYPE', :message => 'Either gatling or clamps', :default => 'gatling'})
-  t.add_env({:name => 'PUPPET_GATLING_R10K_CONTROL_REPO', :default => 'git@github.com:puppetlabs/puppetlabs-puppetserver_perf_control.git'})
+  t.add_env({:name => 'PUPPET_GATLING_R10K_CONTROL_REPO', :default => 'https://github.com/puppetlabs/puppetlabs-puppetserver_perf_control.git'})
   if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
     t.add_env({:name => 'PUPPET_GATLING_R10K_BASEDIR', :default => '/etc/puppetlabs/code/environments'})
   else

--- a/setup/install/10_install/00_install_pe.rb
+++ b/setup/install/10_install/00_install_pe.rb
@@ -4,17 +4,14 @@ test_name 'install PE for a scale environment' do
   if !is_pre_aio_version?
     # Must include the dashboard so that split installs add these answers to classification
     r10k_remote = '/opt/puppetlabs/server/data/puppetserver/r10k/control-repo'
-    r10k_private_key = '/root/.ssh/id_rsa'
 
     if use_meep?(master['pe_ver'] || options['pe_ver'])
       @options[:answers] ||= {}
       @options[:answers]['puppet_enterprise::profile::master::r10k_remote'] = r10k_remote
-      @options[:answers]['puppet_enterprise::profile::master::r10k_private_key'] = r10k_private_key
     else
       [master, compile_masters, dashboard].flatten.uniq.each do |host|
         host[:custom_answers] = {
           :q_puppetmaster_r10k_remote      => r10k_remote,
-          :q_puppetmaster_r10k_private_key => r10k_private_key
         }
       end
 

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -76,29 +76,10 @@ describe PerfHelperClass do
 
     let!(:masters) {[{'platform' => Beaker::Platform.new('centos-6.5-x86_64')}]}
 
-    it 'adds the private key, configures ssh, and installs git on each master' do
-
-      ssh_files = PerfHelper::TEST_SSH_FILES
-      files_url = PerfHelper::TEST_FILES_URL
-      temp_ssh_dir = PerfHelper::TEMP_SSH_DIR
-      root_ssh_dir = PerfHelper::ROOT_SSH_DIR
+    it 'installs git on each master' do
 
       allow(subject).to receive(:masters).and_return(masters)
       expect(subject).to receive(:select_hosts).with({:roles => ['master', 'compile_master']}).and_return(masters)
-
-      expect(File).to receive(:directory?).with(temp_ssh_dir).and_return(false)
-      expect(FileUtils).to receive(:mkdir_p).with(temp_ssh_dir)
-
-      ssh_files.each do |file|
-        expect(subject).to receive(:download_file)
-          .with("#{files_url}/#{file}", "#{temp_ssh_dir}/#{file}")
-
-        expect(subject).to receive(:scp_to)
-          .with(masters[0], "#{temp_ssh_dir}/#{file}", "#{root_ssh_dir}/#{file}")
-      end
-
-      expect(subject).to receive(:on)
-          .with(masters[0], "chmod 600 #{root_ssh_dir}/id_rsa #{root_ssh_dir}/config" )
 
       expect(subject).to receive(:install_package).with(masters[0], 'git')
       subject.setup_r10k

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -202,7 +202,7 @@ describe PerfHelperClass do
       test_pe_ver = '2017.3'
       let!(:master) { {'pe_ver' => test_pe_ver} }
 
-      test_updated_options = {:answers=>{"puppet_enterprise::profile::master::r10k_remote"=>"/opt/puppetlabs/server/data/puppetserver/r10k/control-repo", "puppet_enterprise::profile::master::r10k_private_key"=>"/root/.ssh/id_rsa"}}
+      test_updated_options = {:answers=>{"puppet_enterprise::profile::master::r10k_remote"=>"/opt/puppetlabs/server/data/puppetserver/r10k/control-repo"}}
 
       it 'includes the dashboard and installs pe' do
 


### PR DESCRIPTION
control repo is a public github repo.  But we were accessing it using ssh, so we needed a key.  change to http and no longer need the key.

This was driven by the untimely death of the int-resources server that were using to store the key for the repo.