### PR TITLE
(SLV-287) Set up CD4PE environment

### DIFF
--- a/cd4pe/CD4PE.md
+++ b/cd4pe/CD4PE.md
@@ -1,0 +1,153 @@
+CD4PE Test Environment
+=========================
+
+# Background
+This approach to setting up a cd4pe test environment uses the alternate config `pe-perf-test-cd4pe-agent.cfg`.
+This configuration builds upon the existing `pe-perf-test.cfg` file and adds the following nodes:
+* perf-test-cdpe: the node where cd4pe will be installed
+* perf-test-agent-testing: an agent node for use in the testing environment
+* perf-test-worker: the node where the Distelli agent will be installed
+* perf-test-gitlab: the node where the Docker-based Gitlab instance will be installed
+
+The cd4pe installation uses the [module-based installation instructions](https://puppet.com/docs/continuous-delivery/2.x/install_module.html#task-8759).
+
+# Set up the test environment
+## Provision hosts and run the pre-suite
+Run the `cd4pe_provision_and_presuite` rake task to provision the nodes and run the pre-suite.
+The following error is currently encountered when using the 'puppetserver_perf_control' repo with cd4pe:
+```
+Rolling Deployment Failed. POST https://ip-10-227-3-224.amz-dev.puppet.net:4433/classifier-api/v1/groups -> HTTP 400: {"kind":"data-not-allowed","msg":"The 'config_data' field of node groups is not allowed because the 'allow-config-data' configuration setting has not been set to 'true'."}
+```
+
+In order to get a working test environment the `cd4pe_provision_and_presuite` rake task ends the pre-suite after the initial PE installation (10_install_pe).
+
+## Set up Gitlab
+The test environment uses a Docker-based installation of Gitlab.
+
+### Install Docker and Gitlab container
+Run the `cd4pe_setup_gitlab` rake task to install Docker and set up the Gitlab container on the designated host.
+
+### Set the root password
+Once the Gitlab container is running, navigate to the host in a browser.
+* Set the password for the 'root' account to 'puppetlabs'.
+* Navigate to `admin/application_settings/network` and enable the 'Allow requests to the local network from hooks and services' setting.
+
+### Import the control repo
+Run the `cd4pe_setup_gitlab_control_repo` rake task to import the control repo.
+You should now see the control repo in Gitlab.
+* Disable the 'auto-dev-ops' pipeline
+
+# Set up PE
+## Enable Code Manager
+We'll be using code manager to deploy the cd4pe module, so we'll set it up before proceeding based on [the docs](https://puppet.com/docs/pe/2019.0/code_mgr_config.html#enable-code-manager-after-installation)
+
+### Prepare master
+@TODO: automate
+* SSH to the master
+* Add a entry for the Gitlab host to `/etc/hosts`:
+```
+<GITLAB_HOST_IP_ADDRESS>	gplt-gitlab
+```
+
+* Add the following to `~/.ssh/config`:
+```
+Host *
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+Host gplt-gitlab
+  User git
+  IdentityFile /etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa
+  PreferredAuthentications publickey
+  UserKnownHostsFile=/dev/null
+  Port 8022
+```
+
+* Prepare directory for control repo key
+```
+mkdir /etc/puppetlabs/puppetserver/ssh
+cd /etc/puppetlabs/puppetserver
+chown pe-puppet:pe-puppet ssh
+```
+
+* Generate the key
+```
+ssh-keygen -t rsa -b 2048 -C "gplt@puppet.com" -f /etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa -q -N "" 
+
+```
+
+* Set file permissions
+```
+cd ssh
+chown pe-puppet:pe-puppet id-control_repo.rsa id-control_repo.rsa.pub
+
+```
+
+* Get the public key
+```
+cat id-control_repo.rsa.pub
+```
+
+* Copy the key and add it to Gitlab
+
+### Enable Code Manager
+https://puppet.com/docs/pe/2019.0/code_mgr_config.html#enable-code-manager-after-installation
+
+In the console, set the following parameters in the puppet_enterprise::profile::master class in the PE Master node group:
+* code_manager_auto_configure - true
+* r10k_remote - 'ssh://git@gplt-gitlab:8022/root/control-repo.git'
+* r10k_private_key - '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa'
+
+### Set up authentication for Code Manager
+https://puppet.com/docs/pe/2019.0/code_mgr_config.html#set-up-authentication-for-code-manager
+
+#### Create the Code Manager user
+* Create the Code Manager user: 'Code Manager User' / 'code_manager_user'
+* Add the user to the Code Deployers role
+* Perform a password reset: 'puppetlabs'
+
+#### Request the access token
+https://puppet.com/docs/pe/2019.0/code_mgr_config.html#request-an-authentication-token
+
+```
+puppet-access login --lifetime 1y
+```
+
+### Test the control repo
+https://puppet.com/docs/pe/2019.0/code_mgr_config.html#test-the-control-repo
+
+* Verify the control repo
+```
+[root@ip-10-227-1-53 ssh]# puppet-code deploy --dry-run
+--dry-run implies --wait.
+--dry-run implies --all.
+Dry-run deploying all environments.
+Found 1 environments.
+```
+
+* Deploy the production environment
+```
+puppet-code deploy production --wait
+```
+
+# Install CD4PE
+https://puppet.com/docs/continuous-delivery/2.x/install_module.html
+
+Install CD4PE using the instructions above.
+
+## Configure CD4PE using a task
+https://puppet.com/docs/continuous-delivery/2.x/install_module.html#task-8759
+
+Configure CD4PE using the task-based instructions above.
+
+## Integrate CD4PE with Gitlab
+https://puppet.com/docs/continuous-delivery/2.x/integrations.html#task-7720
+
+---
+
+# TODO: Update the PE integration instructions after the next release
+https://puppet.com/docs/continuous-delivery/2.x/integrate_with_puppet_enterprise.html
+
+
+## Update the control repo for CD4PE
+
+

--- a/cd4pe/CD4PE.md
+++ b/cd4pe/CD4PE.md
@@ -37,6 +37,15 @@ Run the `cd4pe_setup_gitlab_control_repo` rake task to import the control repo.
 You should now see the control repo in Gitlab.
 * Disable the 'auto-dev-ops' pipeline
 
+### Update the control repo for CD4PE
+CD4PE is designed to use the master branch as the default with additional branches per environment.
+
+* Create a 'master' branch from the 'production' branch.
+* Set the 'master' branch as the default.
+* Create additional branches per environment.
+* Remove extraneous branches.
+* Ensure all branches are unprotected.
+
 # Set up PE
 ## Enable Code Manager
 We'll be using code manager to deploy the cd4pe module, so we'll set it up before proceeding based on [the docs](https://puppet.com/docs/pe/2019.0/code_mgr_config.html#enable-code-manager-after-installation)
@@ -86,8 +95,6 @@ cat id-control_repo.rsa.pub
 ```
 
 * Copy the key and add it to Gitlab
-
-## Update the control repo for CD4PE
 
 ### Enable Code Manager
 https://puppet.com/docs/pe/2019.0/code_mgr_config.html#enable-code-manager-after-installation
@@ -146,6 +153,10 @@ Configure CD4PE using the task-based instructions above.
 
 ## Integrate CD4PE with Gitlab
 https://puppet.com/docs/continuous-delivery/2.x/integrations.html#task-7720
+
+Configure the Gitlab integration based on the instructions above.
+
+
 
 ---
 

--- a/cd4pe/CD4PE.md
+++ b/cd4pe/CD4PE.md
@@ -2,7 +2,7 @@ CD4PE Test Environment
 =========================
 
 # Background
-This approach to setting up a cd4pe test environment uses the alternate config `pe-perf-test-cd4pe-agent.cfg`.
+This approach to setting up a cd4pe test environment uses the alternate config `pe-perf-test-cd4pe.cfg`.
 This configuration builds upon the existing `pe-perf-test.cfg` file and adds the following nodes:
 * perf-test-cdpe: the node where cd4pe will be installed
 * perf-test-agent-testing: an agent node for use in the testing environment
@@ -41,7 +41,7 @@ You should now see the control repo in Gitlab.
 ## Enable Code Manager
 We'll be using code manager to deploy the cd4pe module, so we'll set it up before proceeding based on [the docs](https://puppet.com/docs/pe/2019.0/code_mgr_config.html#enable-code-manager-after-installation)
 
-### Prepare master
+### Prepare the master
 @TODO: automate
 * SSH to the master
 * Add a entry for the Gitlab host to `/etc/hosts`:
@@ -60,13 +60,12 @@ Host gplt-gitlab
   PreferredAuthentications publickey
   UserKnownHostsFile=/dev/null
   Port 8022
+  
 ```
 
 * Prepare directory for control repo key
 ```
-mkdir /etc/puppetlabs/puppetserver/ssh
-cd /etc/puppetlabs/puppetserver
-chown pe-puppet:pe-puppet ssh
+cd /etc/puppetlabs/puppetserver && mkdir ssh && chown pe-puppet:pe-puppet ssh
 ```
 
 * Generate the key
@@ -77,8 +76,7 @@ ssh-keygen -t rsa -b 2048 -C "gplt@puppet.com" -f /etc/puppetlabs/puppetserver/s
 
 * Set file permissions
 ```
-cd ssh
-chown pe-puppet:pe-puppet id-control_repo.rsa id-control_repo.rsa.pub
+cd ssh && chown pe-puppet:pe-puppet id-control_repo.rsa id-control_repo.rsa.pub
 
 ```
 
@@ -89,13 +87,20 @@ cat id-control_repo.rsa.pub
 
 * Copy the key and add it to Gitlab
 
+## Update the control repo for CD4PE
+
 ### Enable Code Manager
 https://puppet.com/docs/pe/2019.0/code_mgr_config.html#enable-code-manager-after-installation
 
 In the console, set the following parameters in the puppet_enterprise::profile::master class in the PE Master node group:
 * code_manager_auto_configure - true
-* r10k_remote - 'ssh://git@gplt-gitlab:8022/root/control-repo.git'
-* r10k_private_key - '/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa'
+* r10k_remote - "ssh://git@gplt-gitlab:8022/root/control-repo.git"
+* r10k_private_key - "/etc/puppetlabs/puppetserver/ssh/id-control_repo.rsa"
+
+Run puppet on the master via the console or with the command:
+```
+puppet agent -t
+```
 
 ### Set up authentication for Code Manager
 https://puppet.com/docs/pe/2019.0/code_mgr_config.html#set-up-authentication-for-code-manager
@@ -148,6 +153,6 @@ https://puppet.com/docs/continuous-delivery/2.x/integrations.html#task-7720
 https://puppet.com/docs/continuous-delivery/2.x/integrate_with_puppet_enterprise.html
 
 
-## Update the control repo for CD4PE
+
 
 

--- a/cd4pe/gitlab/gitlab_control_repo_setup.sh
+++ b/cd4pe/gitlab/gitlab_control_repo_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script attempts to handle all the Gitlab control repo setup steps described here:
+# https://confluence.puppetlabs.com/pages/viewpage.action?pageId=169839939
+#
+
+# TODO: update to use puppetserver_perf_control when 'classifier::allow-config-data' issue is resolved
+#repo_url=https://github.com/puppetlabs/puppetlabs-puppetserver_perf_control.git
+repo_url=https://github.com/puppetlabs/control-repo.git
+
+docker exec -i cd4pe-gitlab mkdir -p /var/opt/gitlab/git-data/repository-import
+
+docker exec -i cd4pe-gitlab git -C /var/opt/gitlab/git-data/repository-import clone --bare ${repo_url}
+
+docker exec -i cd4pe-gitlab chown -R git:git /var/opt/gitlab/git-data/repository-import
+
+docker exec -i cd4pe-gitlab gitlab-rake gitlab:import:repos['/var/opt/gitlab/git-data/repository-import']

--- a/cd4pe/gitlab/gitlab_https_setup.sh
+++ b/cd4pe/gitlab/gitlab_https_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script attempts to handle the Gitlab https setup steps described here:
+# https://confluence.puppetlabs.com/pages/viewpage.action?pageId=169839939
+#
+
+export GITVARDIR=$(docker volume inspect cd4pe_cd4pe_gitlab_etc |grep Mount |awk -F'"' '{ print $4 }')
+mkdir "${GITVARDIR}"/ssl
+chmod 700 "${GITVARDIR}"/ssl
+openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -subj "/C=US/ST=Oregon/L=Portland/O=Puppet/CN=gitlab" -keyout "${GITVARDIR}/ssl/gitlab.key" -out "${GITVARDIR}/ssl/gitlab.crt"
+
+echo "external_url 'https://gitlab'" >> "${GITVARDIR}"/gitlab.rb
+
+docker restart cd4pe-gitlab

--- a/cd4pe/gitlab/install_docker.sh
+++ b/cd4pe/gitlab/install_docker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Install Docker per the instructions here:
+# https://confluence.puppetlabs.com/pages/viewpage.action?pageId=169839939
+#
+
+cat > /etc/yum.repos.d/CentOS-Base.repo << 'EOF'
+[base]
+name=CentOS-$releasever - Base
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=0
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=0
+EOF
+yum update -y xfsprogs
+yum install -y yum-utils device-mapper-persistent-data lvm2
+yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+yum install -y docker-ce
+systemctl start docker
+yum update -y
+curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose

--- a/config/beaker_hosts/pe-perf-test-cd4pe.cfg
+++ b/config/beaker_hosts/pe-perf-test-cd4pe.cfg
@@ -1,0 +1,129 @@
+default_vmname: &default_vmname centos-7-x86_64
+default_platform: &default_platform el-7-x86_64
+default_snapshot: &default_snapshot pe
+
+:root_keys: true
+
+:answers:
+  :console_admin_password: puppetlabs
+:department: eso-dept
+:disable_iptables: false
+:project: scale-testing
+
+:host_tags:
+  :run_type: persistent
+  :sub-proj: hoyt
+  :lifetime: 16w
+
+scale:
+  num_nonroot_users: 1
+  facts_per_agent: 300
+  percent_facts_to_change: 0
+  module_roles: 150
+  static_files: 500
+  dynamic_files: 0
+  environments: 100
+
+HOSTS:
+  perf-test-mom:
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 300
+    template: *default_vmname
+    ssh:
+    roles:
+      - master
+      - default
+      - certificate_authority
+      - database
+      - dashboard
+
+  perf-test-metrics:
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 50
+    template: *default_vmname
+    ssh:
+    ports:
+      - 2003
+      - 7777
+      - 80
+    roles:
+      - metric
+      - frictionless
+      - agent
+
+  perf-test-cdpe:
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 50
+    template: *default_vmname
+    ssh:
+    ports:
+      - 2003
+      - 7777
+      - 443
+      - 22
+      - 80
+      - 7000
+      - 8000
+      - 8022
+      - 8080
+      - 8081
+      - 7780
+      - 7722
+    roles:
+      - cd4pe
+      - frictionless
+      - agent
+
+  perf-test-agent-testing:
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 50
+    template: *default_vmname
+    ssh:
+    ports:
+      - 2003
+      - 7777
+      - 80
+    roles:
+      - frictionless
+      - agent
+      - testing
+
+  perf-test-worker:
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 50
+    template: *default_vmname
+    ssh:
+    ports:
+      - 2003
+      - 7777
+      - 80
+    roles:
+      - frictionless
+      - agent
+      - worker
+
+  perf-test-gitlab:
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 50
+    template: *default_vmname
+    ssh:
+    ports:
+      - 2003
+      - 7777
+      - 80
+    roles:
+      - frictionless
+      - agent
+      - gitlab

--- a/rakefile
+++ b/rakefile
@@ -16,6 +16,7 @@ rototiller_task :performance do
       (ENV['BEAKER_HOSTS'] &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg' &&
+          ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test-cd4pe.cfg' &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/opsworks-perf-test.cfg')
   Rake::Task["performance_without_provision"].execute
   Rake::Task["performance_deprovision_with_abs"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' ||
@@ -24,14 +25,14 @@ rototiller_task :performance do
 end
 
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup ' +
-    'and tests for opsworks'
+         'and tests for opsworks'
 rototiller_task :opsworks_performance do
   # If BEAKER_TESTS is not set at all, default it to tests/OpsWorks.rb
   ENV["BEAKER_TESTS"] = "tests/OpsWorks.rb" if ENV["BEAKER_TESTS"].nil?
 
   # If the test is anything other than OpsWorks.rb OR empty string so it can be executed later then raise
   raise "The test must be Opsworks.rb, or '' if you plan to execute tests later" unless
-    ["", "tests/OpsWorks.rb"].include? ENV["BEAKER_TESTS"]
+      ["", "tests/OpsWorks.rb"].include? ENV["BEAKER_TESTS"]
   configure_opsworks
   Rake::Task["performance"].execute
 end
@@ -73,7 +74,8 @@ rototiller_task :performance_provision_with_abs do |t|
   t.add_env({:name => 'ABS_AWS_METRICS_SIZE', :default => 'c4.2xlarge', :message => 'The AWS instance size for the Metrics host'})
   t.add_env({:name => 'ABS_AWS_MOM_SIZE', :default => 'c4.2xlarge', :message => 'The AWS instance size for the MOM host'})
 
-  abs_resource_hosts = get_abs_resource_hosts(get_a2a_hosts)
+  # get_abs_resource_hosts will determine the hosts to provision based on ENV['BEAKER_HOSTS']
+  abs_resource_hosts = get_abs_resource_hosts
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end
 
@@ -99,7 +101,10 @@ desc 'Run Performance tests using previously provisioned hosts'
 rototiller_task :performance_against_already_provisioned do
   ENV['BEAKER_HOSTS'] ||= "log/latest/hosts_preserved.yml"
   ENV['ABS_RESOURCE_HOSTS'] = File.open("last_abs_resource_hosts.log").readlines[0] if File.exist? "last_abs_resource_hosts.log"
-  ENV['BEAKER_PRE_SUITE'] = ""
+
+  # TODO: seems necessary when using an alternate host config?
+  ENV['BEAKER_PRE_SUITE'] = ENV['BEAKER_PRE_SUITE'] || ""
+
   Rake::Task["performance_without_provision"].execute
 end
 
@@ -127,7 +132,7 @@ rototiller_task :performance_without_provision do |t|
   t.add_env({:name => 'PACKAGE_BUILD_VERSION', :default => 'latest'}) if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
   t.add_env({:name => 'PUPPET_AGENT_VERSION', :default => 'latest'}) if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
   t.add_env({:name => 'PUSH_TO_BIGQUERY', :default => 'false',
-    :message => 'True if you want to store a new set of results as a baseline value'})
+             :message => 'True if you want to store a new set of results as a baseline value'})
 
   configure_opsworks if ENV["BEAKER_TESTS"] == 'tests/OpsWorks.rb'
   # env vars needed for Beaker
@@ -332,6 +337,111 @@ task :autoscale_copy_log do
   puts "Copying from #{source} to #{dest}..."
   FileUtils.copy_entry source, dest
 end
+
+
+########################################################
+# TODO: remove after testing
+desc 'autoscale_provisioned_post_install'
+rototiller_task :autoscale_provisioned_post_install do
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
+
+  # TODO: seems necessary when using an alternate host config?!?
+  ENV['BEAKER_PRE_SUITE'] = 'setup/install_gatling/00_nothing.rb'
+
+  # ENV["BEAKER_TESTS"] = "setup/install_gatling/00_pre_install/05_initialize_helpers.rb,"\
+  #                       "setup/install_gatling/40_post_install/10_install_hiera_config.rb,"\
+  #                       "setup/install_gatling/40_post_install/30_final_puppet_run.rb"\
+  #                       "setup/install_gatling/40_post_install/40_configure_gatling_auth.rb,"\
+  #                       "setup/install_gatling/40_post_install/50_configure_permissive_server_auth.rb,"\
+  #                       "setup/install_gatling/40_post_install/60_restart_server.rb,"\
+  #                       "setup/install_gatling/40_post_install/70_disable_firewall.rb,"\
+  #                       "setup/install_gatling/40_post_install/80_install_deps.rb,"\
+  #                       "setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb"
+
+
+
+  # ENV["BEAKER_TESTS"] = "setup/install_gatling/00_pre_install/05_initialize_helpers.rb,"\
+  #                       "setup/install_gatling/40_post_install/30_final_puppet_run.rb"
+
+  #
+  # ENV["BEAKER_TESTS"] = "setup/install_gatling/00_pre_install/05_initialize_helpers.rb,"\
+  #                       "setup/install_gatling/01_puppet_run.rb"
+
+  ENV["BEAKER_TESTS"] = "setup/install_gatling/00_pre_install/05_initialize_helpers.rb,"\
+                        "setup/install_gatling/30_classification/20_enable_file_sync.rb"
+
+  Rake::Task["performance_against_already_provisioned"].execute
+end
+
+########################################################
+# TODO: Do we need these separate cd4pe tasks / beaker config?
+# - see the 'abs_provision_cd4pe' task example for ad-hoc provisioning
+########################################################
+
+desc 'Run cd4pe provision for gatling'
+rototiller_task :cd4pe_provision do
+  ENV['BEAKER_HOSTS'] = 'config/beaker_hosts/pe-perf-test-cd4pe.cfg'
+  Rake::Task["performance_provision_with_abs"].execute
+end
+
+desc 'Run cd4pe setup for gatling'
+rototiller_task :cd4pe_provision_and_presuite do
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_HOSTS'] = 'config/beaker_hosts/pe-perf-test-cd4pe.cfg'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
+  ENV['BEAKER_TESTS'] = ''
+
+  # TODO: remove when the 'classifier::allow-config-data' issue has been resolved
+  # only run the pre-suite through the PE installation
+  #
+  ENV["BEAKER_PRE_SUITE"] = "setup/install_gatling/00_pre_install/05_initialize_helpers.rb,"\
+                            "setup/install_gatling/00_pre_install/20_rpm_setup.rb,"\
+                            "setup/install_gatling/00_pre_install/30_r10k_git_setup.rb,"\
+                            "setup/install_gatling/10_pe_install/10_install_pe.rb"
+
+  Rake::Task["performance"].execute
+end
+
+desc 'Install docker and run gitlab container'
+rototiller_task :cd4pe_setup_gitlab do
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_HOSTS'] = 'config/beaker_hosts/pe-perf-test-cd4pe.cfg'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
+
+  # TODO: seems necessary when using an alternate host config?!?
+  ENV['BEAKER_PRE_SUITE'] = 'setup/install_gatling/60_cd4pe/00_nothing.rb'
+
+  # TODO: the full install + setup requires a manual step
+  ENV["BEAKER_TESTS"] = "setup/install_gatling/60_cd4pe/10_setup_gitlab.rb"
+
+  Rake::Task["performance_against_already_provisioned"].execute
+end
+
+desc 'Import control repo on gitlab container'
+rototiller_task :cd4pe_setup_gitlab_control_repo do
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_HOSTS'] = 'config/beaker_hosts/pe-perf-test-cd4pe.cfg'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
+
+  # TODO: seems necessary when using an alternate host config?!?
+  ENV['BEAKER_PRE_SUITE'] = 'setup/install_gatling/60_cd4pe/00_nothing.rb'
+
+  # TODO: the full install + setup requires a manual step
+  ENV["BEAKER_TESTS"] = "setup/install_gatling/60_cd4pe/20_setup_gitlab_control_repo.rb"
+
+  Rake::Task["performance_against_already_provisioned"].execute
+end
+
+########################################################
+
+desc 'Provision a cd4pe host via ABS'
+rototiller_task :abs_provision_cd4pe do
+  host_to_provision = get_host_to_provision("cd4pe", "c4.2xlarge", "80")
+  abs_resource_hosts = get_abs_resource_hosts(host_to_provision)
+  raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
+end
+
 
 desc "Run spec tests"
 RSpec::Core::RakeTask.new(:spec) do |t|

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -56,6 +56,49 @@ module AbsHelper
     user_has_token
   end
 
+  # Gets the list of hosts to provision based on ENV['BEAKER_HOSTS']
+  #
+  # @author Bill Claytor
+  #
+  # @return [Hash] The hosts to provision
+  #
+  # @example
+  #   hosts_to_provision = get_hosts_to_provision
+  #
+  def get_hosts_to_provision
+    # TODO: update to get hosts from cfg
+    if ENV['BEAKER_HOSTS'] == 'config/beaker_hosts/pe-perf-test-cd4pe.cfg'
+      hosts_to_provision = get_cd4pe_hosts
+    else
+      hosts_to_provision = get_a2a_hosts
+    end
+
+    return hosts_to_provision
+  end
+
+  # Initializes AbsHelper and returns the specified host
+  #
+  # @author Bill Claytor
+  #
+  # @return [Hash] The ABS hosts
+  #
+  # @example
+  #   host = get_host_to_provision(role, size, volume_size)
+  #
+  # TODO: spec test
+  #
+  def get_host_to_provision(role, size, volume_size)
+    abs_initialize
+    host =
+        { 'role': role,
+          'size': size,
+          'volume_size': volume_size }
+
+    host_array = [host]
+
+    return host_array
+  end
+
   # Initializes AbsHelper and returns the hosts for an ApplesToApples run
   #
   # @author Bill Claytor
@@ -82,6 +125,54 @@ module AbsHelper
     return hosts
   end
 
+  # Initializes AbsHelper and returns the hosts for a cd4pe run
+  #
+  # @author Bill Claytor
+  #
+  # @return [Hash] The hosts
+  #
+  # @example
+  #   hosts = get_cd4pe_hosts
+  #
+  # TODO: update to define host params in abs_initialize
+  #
+  def get_cd4pe_hosts
+    abs_initialize
+    mom =
+        { 'role': "mom",
+          'size': @mom_size,
+          'volume_size': @mom_volume_size }
+
+    metrics =
+        { 'role': "metrics",
+          'size': @metrics_size,
+          'volume_size': @metrics_volume_size }
+
+    cdpe =
+        { 'role': "cd4pe",
+          'size': @metrics_size,
+          'volume_size': @metrics_volume_size }
+
+    testing =
+        { 'role': "testing",
+          'size': "c4.xlarge",
+          'volume_size': "40" }
+
+    worker =
+        { 'role': "worker",
+          'size': "c4.xlarge",
+          'volume_size': "40" }
+
+    gitlab =
+        { 'role': "gitlab",
+          'size': "c4.xlarge",
+          'volume_size': "40" }
+
+    hosts = [mom, metrics, cdpe, testing, worker, gitlab]
+
+    return hosts
+  end
+
   # Attempts to provision the specified hosts via ABS
   #
   # hosts will likely come from abs_get_a2a_hosts:
@@ -99,7 +190,7 @@ module AbsHelper
   # @example
   #   abs_resource_hosts = abs_get_resource_hosts(hosts_to_request)
   #
-  def get_abs_resource_hosts(hosts_to_request)
+  def get_abs_resource_hosts(hosts_to_request=get_hosts_to_provision)
     hosts = []
     abs_resource_hosts = nil
 

--- a/setup/install_gatling/60_cd4pe/00_nothing.rb
+++ b/setup/install_gatling/60_cd4pe/00_nothing.rb
@@ -1,0 +1,5 @@
+test_name "do nothing" do
+  step "do nothing" do
+    puts "doing nothing..."
+  end
+end

--- a/setup/install_gatling/60_cd4pe/10_setup_gitlab.rb
+++ b/setup/install_gatling/60_cd4pe/10_setup_gitlab.rb
@@ -1,0 +1,19 @@
+test_name "setup gitlab" do
+
+  step "copy gitlab files" do
+    scp_to(gitlab, "#{__dir__}/../../../cd4pe/gitlab", "/root")
+  end
+
+  step "install docker" do
+    command = "cd gitlab && chmod 777 install_docker.sh && ./install_docker.sh"
+    puts command
+    on gitlab, command
+  end
+
+  step "run gitlab container" do
+    command = "docker run --name=cd4pe-gitlab -d -p 80:80 -p 443:443 -p 8022:22 -v gitlab_etc:/etc/gitlab -v gitlab_opt:/var/opt/gitlab -v gitlab_log:/var/log/gitlab gitlab/gitlab-ce:latest"
+    puts command
+    on gitlab, command
+  end
+
+end

--- a/setup/install_gatling/60_cd4pe/20_setup_gitlab_control_repo.rb
+++ b/setup/install_gatling/60_cd4pe/20_setup_gitlab_control_repo.rb
@@ -1,0 +1,10 @@
+test_name "setup gitlab control repo" do
+
+  # you must log in first
+  step "set up control repo" do
+    command = "cd gitlab && chmod 777 gitlab_control_repo_setup.sh && ./gitlab_control_repo_setup.sh"
+    puts command
+    on gitlab, command
+  end
+
+end


### PR DESCRIPTION
This update provides several new rake tasks to assist in provisioning a CD4PE test environment via ABS. 
```
rake cd4pe_provision                          # Run cd4pe provision for gatling
rake cd4pe_provision_and_presuite             # Run cd4pe setup for gatling
rake cd4pe_setup_gitlab                       # Install docker and run gitlab container
rake cd4pe_setup_gitlab_control_repo          # Import control repo on gitlab container
```
These tasks use the alternate config `pe-perf-test-cd4pe.cfg` which builds upon the existing `pe-perf-test.cfg` file and adds the following nodes:
* perf-test-cdpe: the node where cd4pe will be installed
* perf-test-agent-testing: an agent node for use in the testing environment
* perf-test-worker: the node where the Distelli agent will be installed
* perf-test-gitlab: the node where the Docker-based Gitlab instance will be installed

Instructions are included in the cd4pe/CD4PE.md document.

This approach can be useful when starting from scratch but it may often be necessary to provision hosts separately. The `abs_provision_cd4pe` task has been added to provision a CD4PE host via ABS without Beaker. Additional tasks can be added for other hosts (gitlab, worker, agent, etc...) as needed. 

The initial benefit of setting up the additional CD4PE hosts with Beaker was in automating the CD4PE and Gitlab setup steps. CD4PE can now be installed via a Puppet module, and the Docker-based Gitlab installation can be performed by manually running the scripts used by the rake tasks listed above.


