### PR TITLE
(SLV-206) Fixed bug in optional base instances

### DIFF
--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -351,7 +351,7 @@ module PerfRunHelper
     json_base_instances = json["nodes"][0]["num_instances"]
 
     # TODO: refactor
-    if Integer(env_base_instances)
+    if !env_base_instances.nil?
       puts "Using environment specified base instances: #{env_base_instances}"
       @scale_base_instances = Integer(env_base_instances)
 


### PR DESCRIPTION
The previous update allowing the base number of instances to be set via the PUPPET_GATLING_SCALE_BASE_INSTANCES environment variable has a bug requiring the value to be specified. This update fixes that issue allowing the default value to be used as expected.