### PR TITLE
(SLV-342) Update perf_helper to skip update_hiera_datadir_in_local_config

### DIFF
--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -413,9 +413,10 @@ node 'default' {}
   end
 
   def update_hiera_datadir_in_local_config
-    config = YAML.load_file(@local_hiera_config_path)
-    config[:yaml][:datadir] = '/etc/puppetlabs/code/environments/production/hieradata/'
-    File.open(@local_hiera_config_path, 'w') { |f| f.write(config.to_yaml) }
+    # TODO: REMOVE
+    # config = YAML.load_file(@local_hiera_config_path)
+    # config[:yaml][:datadir] = '/etc/puppetlabs/code/environments/production/hieradata/'
+    # File.open(@local_hiera_config_path, 'w') { |f| f.write(config.to_yaml) }
   end
 
   def install_hiera_config(host)


### PR DESCRIPTION
The GPLT pre-suite currently fails at '10_install_hiera_config' after the recent control repo update to use Hiera 5. Temporarily commenting out 'update_hiera_datadir_in_local_config'; added a TODO to remove this code.
