### PR TITLE
SLV-346 Improve readability of NEW_README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ Gemfile.local
 log
 junit
 jenkins-integration/dev/target_machine_local.yml
+
+# Artifacts created by run
+tmp
+results

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -148,6 +148,8 @@ At the end of the run, the Gatling results and atop results will be copied back 
 
     *  export `BEAKER_HOSTS=\<your beaker_hosts file>`
 
+* In order to have a baseline comparison performed at the end of the test run, set: `export BASELINE_PE_VER=`
+
 * Execute
 ```
     bundle exec rake performance_gatling    # (takes about 4 hours)
@@ -225,11 +227,12 @@ In order to execute a Scale performance run:
 
 A set of 'autoscale' rake tasks are provided to handle setup and scale test execution.
 The pre-suite has been updated to include tuning of the master via 'puppet infrastructure tune' for scale tests so this is no longer a manual step.
-As with the other configurations tests,  nodes can be provisioned as part of the run or as a separate step.
+As with the other test types, nodes can be provisioned as part of the run or as a separate step.
 
 Note that when using the autoscale rake tasks the `BEAKER_PRESERVE_HOSTS` environment variable is always set to 'true', so you will need to de-provision the test nodes with the `performance_deprovision_with_abs` when your testing is complete.
 
-To provision nodes as part of the run:
+#### To provision nodes as part of the run:
+
 ```
 bundle exec rake autoscale
 ```
@@ -257,7 +260,7 @@ bundle exec rake performance_deprovision_with_abs
 There are additional rake tasks for small and medium autoscale runs to allow testing of the environment and autoscale functionality without waiting for a full run:
 
 `autoscale_provisioned_tiny`
-- 1 agents
+- 1 agent
 - 3 iterations
 - increment by 1
 
@@ -317,15 +320,12 @@ If you want to push the metrics to BigQuery at the end of the test run set:
 
 By default this will be set to `false` when running locally and `true` when jobs run in CI.
 
-In order to have a baseline comparison performed at the end of the test run, set:
-
-`export BASELINE_PE_VER=`
-
 to the version of PE you want to compare against.
 
 Things to note:
 
-* If `BASELINE_PE_VER` has not been set than the baseline comparison assertions in the last test step will not be run (test step will be skipped).
+* If `BASELINE_PE_VER` has not been set then the baseline comparison
+  assertions in the last test step will not be run (test step will be skipped).
 
 * The string specified for the `BASELINE_PE_VER` must exactly match the string
   specified as the `BEAKER_PE_VER` when that test run was executed. For
@@ -352,7 +352,7 @@ GROUP BY pe_build_number'
 Another use for the performance task would be to record and playback a new scenario either for one-off testing,
 or for a new scenario that will be checked in and used.  Additionally, you may just want to execute the setup standalone and then execute the tests later.
 
-* Follow the above instructions, but also `export BEAKER_TESTS=` and `BEAKER_PRESERVE_HOSTS=always` prior to executing the rake task to tell beaker not to execute any tests and preserve the machines.
+* Follow the _Apples to Apples_ instructions, but also `export BEAKER_TESTS=` and `BEAKER_PRESERVE_HOSTS=always` prior to executing the rake task to tell beaker not to execute any tests and preserve the machines.
 
 * Depending on your use case, you can also choose to execute the 'acceptance' task which will run in vmpooler rather than AWS. This is useful when testing/debugging but not for actual performance measurement.
 
@@ -447,9 +447,7 @@ For example:
 ```
 bundle exec rake performance_against_already_provisioned \
     BEAKER_INSTALL_TYPE=pe \
-    BEAKER_PRE_SUITE=  #FIXME: value missing \
     BEAKER_PRESERVE_HOSTS=always \
-    BEAKER_HOSTS=log/hosts_preserved.yml \
     PUPPET_GATLING_REPORTS_ONLY=true \
     PUPPET_GATLING_REPORTS_TARGET=PerfTestLarge-1524773045554
 ```

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -57,9 +57,6 @@ below.  They are as follows.
 _(git, foss, pe)_ : Determines the underlying path structure of the
 puppet install.
 
-`BEAKER_OPTIONS_FILE`
-: Path to file containing additionally defined beaker options.
-
 `BEAKER_PE_VER`
 : The desired PE version to be installed. Must be available within
 the `BEAKER_PE_DIR`.

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -34,6 +34,7 @@ requirements installed.
 
 * [Ruby](https://www.ruby-lang.org/en/)
 * [Bundler](https://bundler.io/)
+* [OpenJDK](https://openjdk.java.net/)
 
 
 ### Environment setup

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -1,62 +1,212 @@
-Kick off Apples to Apples performance tests
-=========================
-By default, the performance rake task will set up a puppet master and a Gatling driver/metrics node.
-It will then kick off a gatling scenario defined for apples to apples performance tests.
-At the end of the run, the gatling results and atop results will be copied back to the test runner.
+# Running Performance Test Profiles
+
+#### Table of Contents
+
+1. [Setup](#setup)
+1. [Apples to Apples performance tests](#apples-to-apples-performance-tests)
+1. [Opsworks performance tests](#opsworks-performance-tests)
+1. [Soak performance tests](#soak-performance-tests)
+1. [Scale performance tests](#scale-performance-tests)
+1. [Acceptance tests](#acceptance-tests)
+1. [Assertions and Baseline Comparisons](#assertions-and-baseline-comparisons)
+1. [Other Topics](#other-topics)
+    * [BigQuery Data Comparisons](#bigquery-data-comparisons)
+    * [Just Setup PE and Gatling](#set-up-puppet-enterprise-and-gatling-but-do-not-execute-a-gatling-scenario)
+    * [Record a Gatling run](#record-a-gatling-run)
+    * [Start a pre-recorded run](#start-a-pre-recorded-run)
+    * [Analyze results](#analyze-results)
+    * [Abort a test run](#abort-a-test-run)
+    * [Generate reports for aborted runs](#generate-reports-for-aborted-runs)
+
+
+## Setup
+
+**TODO:**
+
+* Define the term 'Apples to Apples'.
+
+* Define the term 'KO'.
+
+
+### Requirements
+
+In order to run the the software in this repo, you need the following
+requirements installed.
+
+* [Ruby](https://www.ruby-lang.org/en/)
+* [Bundler](https://bundler.io/)
+
+
+### Environment setup
 
 * Clone the gatling-puppet-load-test repo locally: https://github.com/puppetlabs/gatling-puppet-load-test
 * cd into the gatling-puppet-load-test root directory
-* For apples to apples runs, you can use the checked-in hosts files: [pe-perf-test.cfg](config/beaker_hosts/pe-perf-test.cfg) or [foss-perf-test.cfg](config/beaker_hosts/foss-perf-test.cfg). These are the defaults for the performance rake task based on the specified BEAKER_INSTALL_TYPE (pe or foss).
-* In order for us to take advantage of the new AWS account with access to internal network resources, you need to use [ABS](https://github.com/puppetlabs/always-be-scheduling). The 'performance' task will automatically use ABS to provision 2 AWS instances and then execute tests against those instances.
-* ABS requires a token when making requests. See the [Token operations](https://github.com/puppetlabs/always-be-scheduling#token-operations) section of the ABS README file for instructions to generate a token.
-Once generated, either set the ABS_TOKEN environment variable with your token or add it to the .fog file in your home directory using the abs_token parameter. For example:
+
+Several infrastructure variants are currently supported by the rake tasks in
+this repo.  The specific environment setup steps for each environment are
+outlined below.
+
+#### Environment variables
+
+The following environment variables are largly common to the rake tasks shown
+below.  They are ase follows.
+
+`BEAKER_INSTALL_TYPE`
+_(git, foss, pe)_ : Determines the underlying path structure of the
+puppet install.
+
+`BEAKER_OPTIONS_FILE`
+: Path to file containing additionally defined beaker options.
+
+`BEAKER_PE_VER`
+: The desired PE version to be installed. Must be available within
+the `BEAKER_PE_DIR`.
+
+`BEAKER_PE_DIR`
+: Path or URL where PE builds are stored for the `BEAKER_PE_VER`.
+
+
+It can be helpful to use an env file to manage these environment variables. The file
+[config/env/env_setup_2019.0.1](config/env/env_setup_2019.0.1) is provided as an example.
+
+Apply this configuration with the following command:
+```
+source config/env/env_setup_2019.0.1
+```
+
+For more information, see the beaker documentation on
+[beaker environment variables](https://github.com/puppetlabs/beaker/blob/master/docs/concepts/argument_processing_and_precedence.md#environment-variables)
+
+
+#### For AWS Execution
+
+[Create an AWS access key pair for your AWS account.](https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/)
+Ensure that the key id and secret key are present in an appropriate section of
+your `$HOME/.fog` file.  Here is an example: _FIXME: Reference fog website._
+```
+:default:
+  :aws_access_key_id: <access key here>
+  :aws_secret_access_key: <secret key here>
+```
+##### ABS (Always Be Scheduling)
+**NOTE: This facility is not publically available and can only be used by
+personnel employed by Puppet the company.**
+
+* In order for to take advantage of the an AWS account with access to
+puppetlabs network resources, you need to use
+[ABS](https://github.com/puppetlabs/always-be-scheduling).
+The 'performance' task will automatically use ABS to provision 2 AWS
+instances and then execute tests against those instances.
+
+* ABS requires a token when making requests. See the
+[Token operations](https://github.com/puppetlabs/always-be-scheduling#token-operations)
+section of the ABS README file for instructions to generate a token.
+Once generated, either set the `ABS_TOKEN` environment variable with your token
+or add it to the .fog file in your home directory using the abs_token
+parameter. For example:
+
 ```
 :default:
   :abs_token: <your abs token>
 ```
 
-* To run additional tests against an existing set of hosts, run the performance_against_already_provisioned task. This task is only intended to be run against the very latest set of provisioned hosts.
-* If the hosts are preserved via Beaker's 'preserve_hosts' setting, then you will need to manually execute the 'performance_deprovision_with_abs' rake task when you are done with the hosts.
-* For a run against a PE build set BEAKER_INSTALL_TYPE=pe and provide values for BEAKER_PE_VER and BEAKER_PE_DIR environment variables
-* For a run against a FOSS build set BEAKER_INSTALL_TYPE=foss and provide values for PACKAGE_BUILD_VERSION and PUPPET_AGENT_VERSION environment variables
-* If you want to do something custom (which should not normally be necessary): create a beaker config file using one of the configs in [config/beaker_hosts](config/beaker_hosts) as a template.
-    *  export BEAKER_HOSTS=\<your hosts file>
-* Execute:
-    * bundle install
-    * bundle exec rake performance_gatling (takes about 4 hours)
+#### For VMPooler Execution
 
-### Kick off Opsworks performance tests
-In order to execute the tests successfully with the opsworks_performance rake task, you must set the following environment variables:
-* BEAKER_TESTS to 'tests/OpsWorks.rb'
-* ABS_AWS_MOM_SIZE to one of: "m5.large", "c4.xlarge", "c4.2xlarge", ""
-* PUPPET_SCALE_CLASS to one of: "role::by_size::small", "role::by_size::medium", "role::by_size::large", ""
+Get an access token for your
+[vmpooler](https://github.com/puppetlabs/vmpooler) instance:
+```
+curl -u jdoe --url https://vmpooler.example.com/api/v1/token
+```
+For more detailed information, please refer to the
+[vmpooler documentation](https://github.com/puppetlabs/vmpooler/blob/master/docs)
+
+
+## Apples to Apples performance tests
+
+By default, the performance rake task will set up a puppet master and a Gatling driver/metrics node.
+It will then kick off a gatling scenario defined for apples to apples performance tests.
+At the end of the run, the gatling results and atop results will be copied back to the test runner.
+
+* For apples to apples runs, you can use the checked-in hosts files: [pe-perf-test.cfg](config/beaker_hosts/pe-perf-test.cfg) or [foss-perf-test.cfg](config/beaker_hosts/foss-perf-test.cfg). These are the defaults for the performance rake task based on the specified `BEAKER_INSTALL_TYPE` (pe or foss).
+
+* To run additional tests against an existing set of hosts, run the `performance_against_already_provisioned` task. This task is only intended to be run against the very latest set of provisioned hosts.
+
+* If the hosts are preserved via Beaker's `preserve_hosts` setting, then you will need to manually execute the `performance_deprovision_with_abs` rake task when you are done with the hosts.
+
+* For a run against a PE build set `BEAKER_INSTALL_TYPE=pe` and provide values for `BEAKER_PE_VER` and `BEAKER_PE_DIR` environment variables.
+
+* For a run against a FOSS build set `BEAKER_INSTALL_TYPE=foss` and provide values for `PACKAGE_BUILD_VERSION` and `PUPPET_AGENT_VERSION` environment variables
+
+* If you want to do something custom (which should not normally be necessary), create a beaker config file using one of the configs in [config/beaker_hosts](config/beaker_hosts) as a template.
+
+    *  export `BEAKER_HOSTS=\<your beaker_hosts file>`
+
+* Execute
+```
+    bundle install
+    bundle exec rake performance_gatling    # (takes about 4 hours)
+```
+
+
+## Opsworks performance tests
+
+In order to execute the tests successfully with the `opsworks_performance` rake task, you must set the following environment variables:
+
+* `BEAKER_TESTS=tests/OpsWorks.rb`
+
+* `ABS_AWS_MOM_SIZE` to one of the following:
+    * `ABS_AWS_MOM_SIZE=m5.large`
+    * `ABS_AWS_MOM_SIZE=c4.xlarge`
+    * `ABS_AWS_MOM_SIZE=c4.2xlarge`
+    * `ABS_AWS_MOM_SIZE=""`
+
+* `PUPPET_SCALE_CLASS` to one of the following:
+    * `PUPPET_SCALE_CLASS=role::by_size::small`
+    * `PUPPET_SCALE_CLASS=role::by_size::medium`
+    * `PUPPET_SCALE_CLASS=role::by_size::large`
+    * `PUPPET_SCALE_CLASS=""`
 
 Execute:
-* bundle install
-* bundle exec rake opsworks_performance (takes about 1.5 hours)
+```
+bundle install
+bundle exec rake opsworks_performance    # (takes about 1.5 hours)
+```
 
-### Kick off Soak performance tests
+
+## Soak performance tests
+
 In order to execute a Soak performance run:
-* Follow the instructions from "Set up Puppet Enterprise and Gatling but do not execute a gatling scenario".
+
+* Follow the instructions from
+[Just Setup PE and Gatling](#set-up-puppet-enterprise-and-gatling-but-do-not-execute-a-gatling-scenario).
+
 * Then manually tune the master by running `puppet infrastructure tune` on the master.
+
 * You will have to edit '/etc/puppetlabs/puppet/hiera.yaml' to add 'nodes/%{fqdn}' to the top of the hiera hierarchy.
+
 * Then create '/etc/puppetlabs/code/environments/production/hieradata/nodes/\<master fqdn>.yaml' where master fqdn is the result of `facter networking.fqdn` (run on master), and put the output of the tune command in it.
-* Verify that worked by running `puppet lookup puppet_enterprise::master::puppetserver::jruby_max_active_instances --explain` and checking that it got the key from your new file
-* Run `puppet agent -t` on the master
+
+* Verify that worked by running `puppet lookup puppet_enterprise::master::puppetserver::jruby_max_active_instances --explain` and checking that it got the key from your new file.
+
+* Run `puppet agent -t` on the master.
 
 Then set the following environment variables (with other variables still set from first step above):
-*  BEAKER_TESTS to 'tests/Soak.rb'
+*  `BEAKER_TESTS` to 'tests/Soak.rb'
 
 Execute:
-* bundle exec rake performance_against_already_provisioned (takes about 10 days)
+```
+bundle exec rake performance_against_already_provisioned     # (takes about 10 days)
+```
 
-### Kick off Scale performance tests
+
+## Scale performance tests
+
 The scale performance test runs a single repetition of the scenario, increasing the agent count over multiple iterations.
 The default Scale scenario starts with 3000 agents and a 30 minute ramp up (corresponding to the default puppet agent check-in interval).
-The scenario to run can be specified via the 'PUPPET_GATLING_SCALE_SCENARIO' environment variable.
+The scenario to run can be specified via the `PUPPET_GATLING_SCALE_SCENARIO` environment variable.
 
 By default the scenario is run for 10 iterations, increasing the agent count by 100 for each iteration.
-These values can be specified via the 'PUPPET_GATLING_SCALE_ITERATIONS' and 'PUPPET_GATLING_SCALE_INCREMENT' environment variables.
+These values can be specified via the `PUPPET_GATLING_SCALE_ITERATIONS` and `PUPPET_GATLING_SCALE_INCREMENT` environment variables.
 
 After each iteration completes the results are checked and if a KO is found the test is failed.
 
@@ -64,69 +214,95 @@ The results for each iteration are copied to a folder named 'PERF_SCALE{$SCALE_T
 The sub-directory for each iteration is named based on the scenario, iteration, and number of agents.
 
 In order to execute a Scale performance run:
-#### Pre-requisites
-See the 'Kick off Apples to Apples performance tests' above regarding pre-requisites, environment variables, etc...
-It can be helpful to use an env file to manage these environment variables. The file `config/env/env_setup_2019.0.1` is provided as an example.
-Apply this configuration with the following command:
-```
-source config/env/env_setup_2019.0.1
-```
 
-#### Provision, tune, run
+
+### Provision, tune, run
+
 A set of 'autoscale' rake tasks are provided to handle setup and scale test execution.
 The pre-suite has been updated to include tuning of the master via 'puppet infrastructure tune' for scale tests so this is no longer a manual step.
-As with the other configurations test nodes can be provisioned as part of the run or as a separate step.
+As with the other configurations tests,  nodes can be provisioned as part of the run or as a separate step.
 
 Note that when using the autoscale rake tasks the `BEAKER_PRESERVE_HOSTS` environment variable is always set to 'true', so you will need to de-provision the test nodes with the `performance_deprovision_with_abs` when your testing is complete.
 
-* To provision nodes as part of the run:
+To provision nodes as part of the run:
 ```
 bundle exec rake autoscale
 ```
 
-* To provision nodes separately:
+#### To provision nodes separately:
 
-run the `autoscale_setup` rake task to provision the nodes:
+Run the `autoscale_setup` rake task to provision the nodes:
 ```
 bundle exec rake autoscale_setup
 ```
 
-then run the 'autoscale_provisioned' rake task to run the scale test:
+Then run the 'autoscale_provisioned' rake task to run the scale test:
 ```
 bundle exec rake autoscale_provisioned
 ```
 
-* De-provision the nodes when testing is complete:
+#### De-provision the nodes when testing is complete
+
 ```
 bundle exec rake performance_deprovision_with_abs
 ```
 
+#### Smaller autoscale tasks
+
 There are additional rake tasks for small and medium autoscale runs to allow testing of the environment and autoscale functionality without waiting for a full run:
-* autoscale_provisioned_tiny
+
+`autoscale_provisioned_tiny`
 - 1 agents
 - 3 iterations
 - increment by 1
 
-* autoscale_provisioned_sm
+`autoscale_provisioned_sm`
 - 10 agents
 - 10 iterations
 - increment by 10
 
-* autoscale_provisioned_med
+`autoscale_provisioned_med`
 - 500 agents
 - 10 iterations
 - increment by 100
 
-### Acceptance tests
-You can execute the 'acceptance' rake task which will run everything in VMPooler rather than AWS and do a much shorter gatling run. This is useful for quickly testing changes to the performance test setup. If you need to execute acceptance tests in the AWS environment, you can set the following env vars:
 
-`ABS_OS=centos-7-x86-64-west BEAKER_HOSTS=config/beaker_hosts/pe-perf-test.cfg`
+## Acceptance tests
 
-### Assertions and Baseline Comparisons
+You can execute the `acceptance` rake task resulting in a much shorter gatling
+run.  This task runs VMPooler by default.  This is useful for quickly testing
+changes to the performance test setup.
+
+The [expected environment variables](#environment-variables) must be set prior
+to executing this task.  You must also set an an environment variable for
+`BEAKER_OPTIONS_FILE` prior to executing this task.  This repo includes
+[options files](setup/options), but if you have specific needs you must craft
+an options file that meets your needs.  Here is an example.
+
+```
+export BEAKER_OPTIONS_FILE='setup/options/options_pe.rb'
+```
+
+
+### Using AWS
+
+To run the task in an AWS environment, you need to set environment variables
+for `ABS_OS` and `BEAKER_HOSTS`.  Here is an example:
+
+```
+ABS_OS=centos-7-x86-64-west BEAKER_HOSTS=config/beaker_hosts/pe-perf-test.cfg
+```
+
+## Other Topics
+
+### BigQuery Data Comparisons
+
 In order to use the BigQuery integration, you will need to perform the following steps:
 
 * Choose to create a new key for the perf-metrics service account - https://console.developers.google.com/iam-admin/serviceaccounts/project?project=perf-metrics&organizationId=635869474587
+
 * Download it and save locally.
+
 * `export GOOGLE_APPLICATION_CREDENTIALS=` setting to the location you have saved the json key file.
 
 If you want to push the metrics to BigQuery at the end of the test run set:
@@ -143,75 +319,111 @@ to the version of PE you want to compare against.
 
 Things to note:
 
-* If BASELINE_PE_VER has not been set than the baseline comparison assertions in the last test step will not be run (test step will be skipped).
-* Whatever string you pass to the job to indicate the BEAKER_PE_VER needs to be used consistently. For example, if you set the version in the format `2018.1.1-rc0-11-g8fbde83` you need to use this again as the BASELINE_PE_VER or the test will error/not return expected results.
-* If BASELINE_PE_VER is not found in BigQuery then the last step will error.
-* Results are not overwritten, we get the latest result that matches BASELINE_PE_VER and the current test name.
+* If `BASELINE_PE_VER` has not been set than the baseline comparison assertions in the last test step will not be run (test step will be skipped).
+
+* Whatever string you pass to the job to indicate the `BEAKER_PE_VER` needs to be used consistently. For example, if you set the version in the format `2018.1.1-rc0-11-g8fbde83` you need to use this again as the `BASELINE_PE_VER` or the test will error/not return expected results.
+
+* If `BASELINE_PE_VER` is not found in BigQuery then the last step will error.
+
+* Results are not overwritten, we get the latest result that matches `BASELINE_PE_VER` and the current test name.
+
 * We currently only push up the data we need in order to perform the assertions.
 
 To directly query bigquery:
+
 * Navigate to https://console.cloud.google.com/bigquery?project=perf-metrics
+
 * Execute 'SELECT pe_build_number FROM \`perf-metrics.perf_metrics.atop_metrics\`
 GROUP BY pe_build_number'
 
+
 ### Set up Puppet Enterprise and Gatling but do not execute a gatling scenario
+
 Another use for the performance task would be to record and playback a new scenario either for one-off testing,
 or for a new scenario that will be checked in and used.  Additionally, you may just want to execute the setup standalone and then execute the tests later.
+
 * Follow the above instructions, but also `export BEAKER_TESTS=` and `BEAKER_PRESERVE_HOSTS=always` prior to executing the rake task to tell beaker not to execute any tests and preserve the machines.
+
 * Depending on your use case, you can also choose to execute the 'acceptance' task which will run in vmpooler rather than AWS. This is useful when testing/debugging but not for actual performance measurement.
 
-### Record a Gatling run:
+
+### Record a Gatling run
+
 Assuming that you ran the performance task with no tests, you can follow the directions below to record and then play back a recording manually.
+
 * Ensure you are still SSH'd to the Gatling driver node (metrics) using the -Y argument `ssh -Y root@<driver-host>`
+
 * Execute `cd ~/gatling-puppet-load-test/proxy-recorder`
+
 * Execute `sh ./launch-gatling-proxy.sh`
+
 * Follow the steps from the script
+
 * In the Gatling recorder GUI:
-    * Change the ‘listening port’ to 7000
-    * Change ‘class name’ to a unique value with no spaces such as ‘HoytApples’ - remember this, as this is the \<GatlingClassName> in subsequent steps.
+    * Change the 'listening port' to 7000
+    * Change 'class name' to a unique value with no spaces such as 'HoytApples' - remember this, as this is the \<GatlingClassName> in subsequent steps.
     * Press start
-* Back in the cmd line on the Gatling driver node, press “enter”
+
+* Back in the cmd line on the Gatling driver node, press 'enter'
+
 * Copy the command to execute on the agent node
+
 * SSH into the agent node and:  (Ignore instructions from the script)
     * Paste in the command
     * Replace value for --server with the FQDN of the MOM
     * Replace value for --http_proxy_host with the IP address of the Gatling driver node
     * Change the value for --http_proxy_port to 7000
     * Execute the command
-* Ensure that traffic was captured (rows should appear in the ‘executed events’ section of the Gatling recorder GUI)
-* Press ‘Stop and Save’
+
+* Ensure that traffic was captured (rows should appear in the 'executed events' section of the Gatling recorder GUI)
+
+* Press 'Stop and Save'
+
 * Close the GUI
+
 * On the Gatling driver node, press enter
+
 * Continue to follow the script.
-    * When asked for the certname prefix enter any value containing the string ‘agent’. For example perf-agent-0
+    * When asked for the certname prefix enter any value containing the string 'agent'. For example perf-agent-0
     * When asked for Puppet classes, enter the configuration which defaults to: role::by_size::large
         * You can use a different puppet class by specifying it as the `PUPPET_SCALE_CLASS` environment variable for the performance_gatling rake task.
 
-### Getting a pre-recorded run started
+
+### Start a pre-recorded run
+
 For the following steps, GatlingClassName is the value entered into the ClassName field during the recording step.
 From root of the gatling-puppet-load-test source dir on the Gatling driver (metrics):
+
 * First time only:
-    * edit /usr/share/sbt/conf/sbtopts and change “-mem” to 2048 (and uncomment)
+    * edit /usr/share/sbt/conf/sbtopts and change '-mem' to 2048 (and uncomment)
+
 * For each new simulation:
     * `cd ~/gatling-puppet-load-test/simulation-runner`
     * `export GEM_SOURCE=http://rubygems.delivery.puppetlabs.net`
     * `export SUT_HOST=<MOM_OR_LB_HOSTNAME>.us-west-2.compute.internal`
-    * Create a json file containing your settings at config/scenarios/\<GatlingClassName>.json, example here: Gist
+    * Create a json file containing your settings at config/scenarios/\<GatlingClassName>.json, example here: Gist **FIXME: Broken gist link**
+
         * Change node_config to \<GatlingClassName>.json (this file should exist in simulation-runner/config/nodes)
     * `export PUPPET_GATLING_SIMULATION_CONFIG=../simulation-runner/config/scenarios/<GatlingClassName>.json`
     * `export PUPPET_GATLING_SIMULATION_ID=<GatlingClassName>`
     * `PUPPET_GATLING_MASTER_BASE_URL=https://$SUT_HOST:8140 sbt run`
 
-### Analyzing results
+
+### Analyze results
+
 * Gatling results, including HTML visualizations show up in the directory: gatling-puppet-load-test/simulation-runner/results/\<GatlingClassName>-\<epoch_time>/
     * scp them locally and you can view them in your browser.
+
 * atop files containing cpu, mem, disk and network usage overall and broken down per process are available to view on the mom: atop -r /var/log/atop/atop\_\<date>
     * See the atop man file for interactive commands
 
-### Aborting a test run
+
+### Abort a test run
+
 The easiest way to immediately kill a test run is to kill the corresponding Java process on the metrics node. Find the process id with top and then use `kill <PID>`.
 
-### Generating reports for aborted runs
+### Generate reports for aborted runs
+
 If a Gatling scenario is aborted the reports may not be generated. In this case you can run Gatling in reports-only mode to generate the reports for a previous run (assuming that the hosts have been preserved).
 You'll need to specify the name of the folder on the metrics node containing the simulation.log file for the run.
 Look in `~/gatling-puppet-load-test/simulation-runner/results` for a folder that starts with 'PerfTestLarge-' followed by the run id and verify that the folder contains a valid (non-empty) simulation.log file.
@@ -219,8 +431,17 @@ Look in `~/gatling-puppet-load-test/simulation-runner/results` for a folder that
 If you find that the simulation.log file is not being populated during your run you may need to reduce the log buffer size from the 8kb default.
 Set `gatling.data.file.bufferSize` in `simulation-runner/gatling.conf` to a smaller value like 256 (this may impact performance).
 
-To run in reports-only mode, run as you normally would against previously provisioned hosts and set the environment variables PUPPET_GATLING_REPORTS_ONLY=true and PUPPET_GATLING_REPORTS_TARGET=<YOUR_RESULT_FOLDER>.
+To run in reports-only mode, run as you normally would against previously provisioned hosts and set the environment variables `PUPPET_GATLING_REPORTS_ONLY=true` and `PUPPET_GATLING_REPORTS_TARGET=<YOUR_RESULT_FOLDER>`.
 
-For example: `bundle exec rake performance_against_already_provisioned BEAKER_INSTALL_TYPE=pe BEAKER_PRE_SUITE= BEAKER_PRESERVE_HOSTS=always BEAKER_HOSTS=log/hosts_preserved.yml PUPPET_GATLING_REPORTS_ONLY=true PUPPET_GATLING_REPORTS_TARGET=PerfTestLarge-1524773045554`
+For example:
+```
+bundle exec rake performance_against_already_provisioned \
+    BEAKER_INSTALL_TYPE=pe \
+    BEAKER_PRE_SUITE=  #FIXME: value missing \
+    BEAKER_PRESERVE_HOSTS=always \
+    BEAKER_HOSTS=log/hosts_preserved.yml \
+    PUPPET_GATLING_REPORTS_ONLY=true \
+    PUPPET_GATLING_REPORTS_TARGET=PerfTestLarge-1524773045554
+```
 
 After the run you should see that the report files have been generated within the result folder and copied to your local machine.

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -36,6 +36,9 @@ requirements installed.
 * [Bundler](https://bundler.io/)
 * [OpenJDK](https://openjdk.java.net/)
 
+**NOTE:** These tasks run for several hours. It is not recommended to run them
+directly from a workstation. You should use a dedicated VM instance to control
+these tasks.
 
 ### Environment setup
 
@@ -148,7 +151,10 @@ At the end of the run, the Gatling results and atop results will be copied back 
 
     *  export `BEAKER_HOSTS=\<your beaker_hosts file>`
 
-* In order to have a baseline comparison performed at the end of the test run, set: `export BASELINE_PE_VER=`
+* In order to have a baseline comparison performed at the end of the test run
+  set `BASELINE_PE_VER` and `GOOGLE_APPLICATION_CREDENTIALS` in order to
+  gather the baseline data.  See
+  [BigQuery Data Comparisons](#bigquery-data-comparisons) for details.
 
 * Execute
 ```


### PR DESCRIPTION
This commit attempts to add explicit instructions for running the rake
tasks in the repo.  It makes no prior assumptions about the users
running environment.

Common environment variables have been broken out into their own
section.  All environment variables have been marked up as source code.

A table of contents has been added to make the document more manageable.

Some section headings have been renamed in an attempt to clarify their
meaning.