### PR TITLE
(SLV-341) AWS AMI instance update

### DIFF
--- a/config/beaker_hosts/foss-perf-test.cfg
+++ b/config/beaker_hosts/foss-perf-test.cfg
@@ -26,7 +26,7 @@ scale:
 
 HOSTS:
   perf-test-mom:
-    amisize: c4.2xlarge
+    amisize: c5.2xlarge
     hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot
@@ -40,7 +40,7 @@ HOSTS:
       - database
       - dashboard
   perf-test-metrics:
-    amisize: c4.large
+    amisize: c5.large
     hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot

--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -59,21 +59,6 @@ AMI:
       :pe: ami-9a77fdaa
     :region: us-west-2
 
-  debian-6-amd64-west:
-    :image: 
-      :pe: ami-4eea627e
-    :region: us-west-2
-
-  debian-6-amd64-west-2:
-    :image:
-      :pe: ami-fd4401cd
-    :region: us-west-2
-
-  debian-6-i386-west:
-    :image: 
-      :pe: ami-fcf27fcc
-    :region: us-west-2
-
   sles-11-x86-64-west:
     :image: 
       :pe: ami-3ef2670e
@@ -116,12 +101,6 @@ AMI:
     :image:
       :pe: ami-d6e860e6
       :foss: ami-d6e860e6
-    :region: us-west-2
-
-  debian6-amd64-west:
-    :image:
-      :pe: ami-4eea627e
-      :foss: ami-4eea627e
     :region: us-west-2
 
   el-6-i386:

--- a/config/image_templates/ec2.yaml
+++ b/config/image_templates/ec2.yaml
@@ -49,16 +49,6 @@ AMI:
       :pe: ami-92f366a2
     :region: us-west-2
 
-  ubuntu-1004-amd64-west:
-    :image: 
-      :pe: ami-e2c154d2
-    :region: us-west-2
-
-  ubuntu-1004-i386-west:
-    :image: 
-      :pe: ami-e6c154d6
-    :region: us-west-2
-
   ubuntu-1204-amd64-west:
     :image: 
       :pe: ami-d6e860e6
@@ -122,12 +112,6 @@ AMI:
       :foss: ami-4a6df87a
     :region: us-west-2
 
-  ubuntu-10.04-amd64-west:
-    :image:
-      :pe: ami-52ea6262
-      :foss: ami-52ea6262
-    :region: us-west-2
-
   ubuntu-12.04-amd64-west:
     :image:
       :pe: ami-d6e860e6
@@ -150,12 +134,6 @@ AMI:
     :image:
       :pe: ami-0bd16d62
       :foss: ami-0bd16d62
-    :region: us-east-1
-
-  ubuntu-10.04-i386:
-    :image:
-      :pe: ami-f5d76b9c
-      :foss: ami-f5d76b9c
     :region: us-east-1
 
   debian-7-amd64-west:

--- a/rakefile
+++ b/rakefile
@@ -41,11 +41,11 @@ end
 
 def configure_opsworks
   ENV['BEAKER_HOSTS'] = 'config/beaker_hosts/opsworks-perf-test.cfg'
-  # sizes can be any of the 3 below, specifying nothing defaults to c4.2xlarge so that is ok too
-  opsworks_instance_sizes = ["m5.large", "c4.xlarge", "c4.2xlarge", ""]
-  if ["c4.2xlarge", ""].include? ENV['ABS_AWS_MOM_SIZE']
+  # sizes can be any of the 3 below, specifying nothing defaults to c5.2xlarge so that is ok too
+  opsworks_instance_sizes = ["m5.large", "c5.xlarge", "c5.2xlarge", ""]
+  if ["c5.2xlarge", ""].include? ENV['ABS_AWS_MOM_SIZE']
     opsworks_size = "Large"
-  elsif "c4.xlarge" == ENV['ABS_AWS_MOM_SIZE']
+  elsif "c5.xlarge" == ENV['ABS_AWS_MOM_SIZE']
     opsworks_size = "Med"
   elsif "m5.large" == ENV['ABS_AWS_MOM_SIZE']
     opsworks_size = "Small"
@@ -73,8 +73,8 @@ rototiller_task :performance_provision_with_abs do |t|
   t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
-  t.add_env({:name => 'ABS_AWS_METRICS_SIZE', :default => 'c4.2xlarge', :message => 'The AWS instance size for the Metrics host'})
-  t.add_env({:name => 'ABS_AWS_MOM_SIZE', :default => 'c4.2xlarge', :message => 'The AWS instance size for the MOM host'})
+  t.add_env({:name => 'ABS_AWS_METRICS_SIZE', :default => 'c5.2xlarge', :message => 'The AWS instance size for the Metrics host'})
+  t.add_env({:name => 'ABS_AWS_MOM_SIZE', :default => 'c5.2xlarge', :message => 'The AWS instance size for the MOM host'})
 
   abs_resource_hosts = get_abs_resource_hosts(get_a2a_hosts)
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
@@ -367,28 +367,28 @@ end
 
 desc 'Provision a cd4pe host via ABS'
 rototiller_task :abs_provision_host_cd4pe do
-  host_to_provision = get_host_to_provision("cd4pe", "c4.2xlarge", "80")
+  host_to_provision = get_host_to_provision("cd4pe", "c5.2xlarge", "80")
   abs_resource_hosts = get_abs_resource_hosts(host_to_provision)
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end
 
 desc 'Provision a gitlab host via ABS'
 rototiller_task :abs_provision_host_gitlab do
-  host_to_provision = get_host_to_provision("gitlab", "c4.xlarge", "80")
+  host_to_provision = get_host_to_provision("gitlab", "c5.xlarge", "80")
   abs_resource_hosts = get_abs_resource_hosts(host_to_provision)
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end
 
 desc 'Provision an agent host via ABS'
 rototiller_task :abs_provision_host_agent do
-  host_to_provision = get_host_to_provision("agent", "c4.large", "40")
+  host_to_provision = get_host_to_provision("agent", "c5.large", "40")
   abs_resource_hosts = get_abs_resource_hosts(host_to_provision)
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end
 
 desc 'Provision a worker host via ABS'
 rototiller_task :abs_provision_host_worker do
-  host_to_provision = get_host_to_provision("worker", "c4.xlarge", "80")
+  host_to_provision = get_host_to_provision("worker", "c5.xlarge", "80")
   abs_resource_hosts = get_abs_resource_hosts(host_to_provision)
   raise 'Unable to provision hosts via ABS' unless abs_resource_hosts
 end

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -12,7 +12,7 @@ include InParallel
 module AbsHelper
   ABS_BASE_URL = "https://cinext-abs.delivery.puppetlabs.net/api/v2".freeze
   AWS_PLATFORM = "centos-7-x86_64".freeze
-  AWS_IMAGE_ID = "ami-a042f4d8".freeze
+  AWS_IMAGE_ID = "ami-01ed306a12b7d1c96".freeze
   AWS_VOLUME_SIZE = "80".freeze
   AWS_REGION = "us-west-2".freeze
 


### PR DESCRIPTION
This PR updates existing ami definitions to use the newer `c5` version and deletes ami definitions for operating systems [no longer supported by Puppet Enterprise](https://puppet.com/docs/pe/2019.0/supported_operating_systems.html).