### PR TITLE
(SLV-319) Set warmup 300 agents - 10 min iteration

### DIFF
--- a/simulation-runner/config/scenarios/WarmUpJit.json
+++ b/simulation-runner/config/scenarios/WarmUpJit.json
@@ -1,12 +1,12 @@
 {
-    "run_description": "'role::by_size_large' role from perf control repo, 20 agents, one 1 minute iteration",
+    "run_description": "'role::by_size_large' role from perf control repo, 300 agents, one 10 minute iteration",
     "nodes": [
         {
             "node_config": "PerfTestLarge.json",
-            "num_instances": 20,
-            "ramp_up_duration_seconds": 60,
+            "num_instances": 300,
+            "ramp_up_duration_seconds": 600,
             "num_repetitions": 1,
-            "sleep_duration_seconds": 60
+            "sleep_duration_seconds": 600
         }
     ]
 }

--- a/tests/ApplesToApples.rb
+++ b/tests/ApplesToApples.rb
@@ -6,7 +6,7 @@ teardown do
   perf_teardown
 end
 
-# Execute 60 agent runs to warm up the JIT before starting our monitoring.
+# Execute agent runs to warm up the JIT before starting our monitoring.
 perf_setup('WarmUpJit.json','PerfTestLarge', '')
 stop_monitoring(master, '/opt/puppetlabs')
 


### PR DESCRIPTION
This commit updates the `WarmUpJit.json` data to run 300 agents in a
single 10 minute iteration.

An inaccurate comment related to this data was removed from the
`ApplesToApples.rb` test.