### PR TITLE
(SLV-336) Remove bespoke hiera.yaml install

### DIFF
--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -230,7 +230,7 @@ module PerfHelper
   end
 
   ## TODO This probably needs more work to finish hooking up everything that
-  ##      comes in the control repository, like a hiera.yaml config file.
+  ##      comes in the control repository.
   ##
   ##      Also, r10k will manage the entire environment directory, which means
   ##      previous gatling installation steps (e.g. 50_install_modules.rb) may
@@ -410,25 +410,6 @@ node 'default' {}
     create_remote_file(host, manifestfile, sitepp)
     on(host, "chmod 644 #{manifestfile}")
     on(host, "cat #{manifestfile}")
-  end
-
-  def update_hiera_datadir_in_local_config
-    # TODO: REMOVE
-    # config = YAML.load_file(@local_hiera_config_path)
-    # config[:yaml][:datadir] = '/etc/puppetlabs/code/environments/production/hieradata/'
-    # File.open(@local_hiera_config_path, 'w') { |f| f.write(config.to_yaml) }
-  end
-
-  def install_hiera_config(host)
-    @source_hiera_config_path = '/etc/puppetlabs/code/environments/production/root_files/hiera.yaml'
-    @target_hiera_config_path = on(master, puppet('config print hiera_config')).stdout.chomp
-    local_hiera_dir = Dir.mktmpdir
-    scp_from(master, @source_hiera_config_path, local_hiera_dir)
-    @local_hiera_config_path = File.join(local_hiera_dir, 'hiera.yaml')
-    update_hiera_datadir_in_local_config
-
-    scp_to(host, @local_hiera_config_path, @target_hiera_config_path)
-    on(host, "chmod 644 #{@target_hiera_config_path}")
   end
 
   def configure_gatling_auth

--- a/setup/install_gatling/40_post_install/10_install_hiera_config.rb
+++ b/setup/install_gatling/40_post_install/10_install_hiera_config.rb
@@ -1,3 +1,0 @@
-test_name 'Install hiera config' do
-  install_hiera_config(master)
-end

--- a/setup/options/options_foss.rb
+++ b/setup/options/options_foss.rb
@@ -7,7 +7,6 @@
     'setup/install_gatling/20_foss_install/10_install_dev_repos.rb',
     'setup/install_gatling/30_classification/10_r10k_deploy.rb',
     'setup/install_gatling/30_classification/50_classify_nodes_via_site_pp.rb',
-    'setup/install_gatling/40_post_install/10_install_hiera_config.rb',
     'setup/install_gatling/40_post_install/30_final_puppet_run.rb',
     'setup/install_gatling/40_post_install/40_configure_gatling_auth.rb',
     'setup/install_gatling/40_post_install/50_configure_permissive_server_auth.rb',

--- a/setup/options/options_pe.rb
+++ b/setup/options/options_pe.rb
@@ -10,7 +10,6 @@
     'setup/install_gatling/30_classification/30_sync_codedir.rb',
     'setup/install_gatling/30_classification/40_classify_nodes_via_nc.rb',
     'setup/install_gatling/30_classification/45_classify_master_via_nc.rb',
-    'setup/install_gatling/40_post_install/10_install_hiera_config.rb',
     'setup/install_gatling/40_post_install/30_final_puppet_run.rb',
     'setup/install_gatling/40_post_install/40_configure_gatling_auth.rb',
     'setup/install_gatling/40_post_install/50_configure_permissive_server_auth.rb',


### PR DESCRIPTION
This commit removes methods (and their calls) for installing a
`hiera.yaml` file on the target hosts.  Such a file should be managed by
the control repo in order to be customized on an environment specific
basis.