### PR TITLE
(SLV-318) Remove credentials from scooter call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,7 @@ gem 'beaker-pe', '~>2.0'
 gem 'beaker-aws'
 gem 'beaker-abs', '~>0.1'
 gem 'beaker-pe-large-environments', '~>0.3'
-
-# scooter 4.3.1 caused authentication issues
-# see https://tickets.puppetlabs.com/browse/PE-25817
-# see also https://github.com/puppetlabs/scooter/pull/122
-# TODO: revert to '~>4.3' when the issue has been resolved
-gem 'scooter', '=4.3.0'
+gem 'scooter', '~>4.3'
 gem 'rototiller', '~>1.0'
 gem 'rspec', '~>3.0'
 

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -351,7 +351,7 @@ EOS
   end
 
   def get_classifier
-    classifier = Scooter::HttpDispatchers::ConsoleDispatcher.new(dashboard, {:login => 'admin', :password => 'puppetlabs', :resolve_dns => true})
+    classifier = Scooter::HttpDispatchers::ConsoleDispatcher.new(dashboard)
     # Updating classes can take a VERY long time, like the OPS deployment
     # which has ~80 environments each with hundreds of classes.
     # Set the connection timeout to 60 minutes to accomodate this.


### PR DESCRIPTION
This commit removes the user/password credentials when creating a
`ConsoleDispatcher` object.  With the release of scooter 4.3.1, a ca
cert acquisition bug was fixed that causes the auth to fail if it is also
passed credentials.  These credentials have been removed in order for
the dispatcher will use its native cert-based auth.

