### PR TITLE
(SLV-329) Fix baseline variance math

### DIFF
--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -821,7 +821,6 @@ module PerfRunHelper
     baseline = get_baseline_result
     unless baseline.nil?
       baseline.each do |key, value|
-
         if key.to_s == "avg_response_time"
           assert_value = gatling_result.avg_response_time.to_f
         elsif key.to_s.start_with? "process"
@@ -832,23 +831,17 @@ module PerfRunHelper
 
         puts "Value for #{key} is baseline: #{value} Actual: #{assert_value}"
         next if key.to_s.start_with?("process") && key.to_s.end_with?("cpu")
-        allowed_baseline_variance = if key.to_s == 'process_orchestration_services_release_avg_mem'
-                                      15
-                                    else
-                                      10
-                                    end
-        if value.is_a? Integer
-          # If the baseline value is `allowed_baseline_variance` or lower
-          # (usually CPU) then we need to allow more than 10% variance
-          # since it is only whole numbers. If it is
-          # `allowed_baseline_variance` or less, we should allow for +1 or -1
-          if value <= allowed_baseline_variance
-            assert_later(assert_value.between?(value -1, value + 1), "The value of #{key} '#{assert_value}' " +
-                "was not within #{allowed_baseline_variance}% of the baseline '#{value}'")
+        max_baseline_variance = \
+          if key.to_s == 'process_orchestration_services_release_avg_mem'
+            15
           else
-            assert_later((assert_value - value) / value * 100 <= 10, "The value of #{key} '#{assert_value}' " +
-                "was not within #{allowed_baseline_variance}% of the baseline '#{value}'")
+            10
           end
+        if value.is_a? Integer
+          assert_later((assert_value - value) / value * 100 <= max_baseline_variance,
+                       "The value of #{key} '#{assert_value}' " \
+                       "was not within #{max_baseline_variance}% " \
+                       "of the baseline '#{value}'")
         end
       end
     end


### PR DESCRIPTION
This commit removes the conditional for calculating the variance
of 'cpu' process values.  These values are never evaluated due to
`next` condition prior to the conditional used to evaluate them.

This commit also updates the conditional for non-cpu values to
correct the hard-coded 10% value to use the variable
`max_baseline_variance` to determine the calculation.  This variable
is set to 15% for orch_mem and otherwise set to 10%.