### PR TITLE
(SLV-361) Create ctrl repo from prod env via bolt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ jenkins-integration/dev/target_machine_local.yml
 # Artifacts created by run
 tmp
 results
+
+# Bolt
+.rerun.json

--- a/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.json
+++ b/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.json
@@ -1,0 +1,10 @@
+{
+  "description": "Creates a git repo from puppet production environment directory",
+  "input_method": "environment",
+  "parameters": {
+    "ctrl_repo_path": {
+      "description": "The fully qualified path where the control repo will be created",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.sh
+++ b/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+CTRL_REPO_PATH="${PT_ctrl_repo_path:-/opt/puppet/control-repo.git}"
+[ -z "$CTRL_REPO_PATH" ] && echo "Must specify a control repo path" && exit 1
+
+CTRL_REPO_BASEDIR=$(dirname $CTRL_REPO_PATH)
+
+ENVIRONMENT=production
+PUPPET_PROD_ENV_DIR=/etc/puppetlabs/code/environments/$ENVIRONMENT
+CHECKOUT_DIR=/tmp/control-repo
+
+
+mkdir -p "$CTRL_REPO_BASEDIR"
+
+if [ -d "$CTRL_REPO_PATH" ]; then
+    echo "ERROR: The control repo destination already exists" >&2
+    exit 1
+fi
+
+git init --bare $CTRL_REPO_PATH
+git clone $CTRL_REPO_PATH $CHECKOUT_DIR
+cp -r $PUPPET_PROD_ENV_DIR/* $CHECKOUT_DIR
+rm -fr $CHECKOUT_DIR/modules
+cd $CHECKOUT_DIR \
+    || { echo "ERROR: Failed to cd into $CHECKOUT_DIR" >&2 ; exit 1 ; }
+git add .
+git commit -m "Initial commit"
+git branch -m $ENVIRONMENT
+git push -u origin $ENVIRONMENT
+cd $CTRL_REPO_PATH
+git symbolic-ref HEAD refs/heads/$ENVIRONMENT
+
+rm -rf $CHECKOUT_DIR
+
+# send structured data to bolt
+printf '{"control_repo_path":"%s"}\n' "$CTRL_REPO_PATH"

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,43 @@
+# Bolt Tasks
+
+This repo includes bolt tasks.  The available tasks are enumerated here.
+
+The following `bolt` commands must be executed from the root directory of a
+checkout of this repository.
+
+## gplt::create_control_repo_from_production_env
+
+This task creates a git repo using the contents from the given node's
+puppet production environment.  Therefore, the specified node should be
+the primary puppet master.
+
+The task takes one optional argument `ctrl_repo_path=<value>` which is used
+as the fully qualified path for creating the git repository.
+
+Note: The bolt task needs to be run as the `root` user (which is the default)
+in order for the default `ctrl_repo_path` to be successfully created.
+
+The built in documentation for the task can be seen by running the following:
+```
+bolt task show gplt::create_control_repo_from_production_env
+
+gplt::create_control_repo_from_production_env - Creates a git repo from puppet production environment directory
+
+USAGE:
+bolt task run --nodes <node-name> gplt::create_control_repo_from_production_env ctrl_repo_path=<value>
+
+PARAMETERS:
+- ctrl_repo_path: String[1]
+    The fully qualified path to be used for creating the control repo
+```
+
+Typical usage on an ABS instance would use the following bolt pattern:
+```
+bolt task run \
+  --user root \
+  --no-host-key-check \
+  --private-key ~/.ssh/id_rsa-acceptance \
+  --nodes ip-10-xx-xx-xx.amz-dev.puppet.net \
+  gplt::create_control_repo_from_production_env \
+  ctrl_repo_path="/opt/puppet/control-repo.git"
+```


### PR DESCRIPTION
This commit adds a bolt task for creating a control repo on a
puppet master host using the current contents of the production
environment code directory as its initial commit.

The `Boltdir` directory tree scaffolding is added to allow bolt
to automatically discover the task.

Show the task:
```
$ bolt task show
...
gplt::create_control_repo_from_production_env
...
```

Run the task:
```
bolt task run \
  --no-host-key-check \
  --private-key ~/.ssh/id_rsa-acceptance \
  --nodes ip-10-xx-xx-xx.amz-dev.puppet.net \
  gplt::create_control_repo_from_production_env
```