### PR TITLE
(SLV-414) Add scale test script

### DIFF
--- a/docs/scale_run_script.md
+++ b/docs/scale_run_script.md
@@ -1,0 +1,73 @@
+# Using the scale run script
+
+The [utils/scale_run.sh](../utils/scale_run.sh) script is used to automate the
+execution of scale testing for the various EC2 instance types.  This script
+runs 5 rounds each of cold start and warm start scenarios.  It creates a
+directory for each run.
+
+Out of the box, it will run the following.  The variable values are declared
+in the begining of the script.
+
+* 1 cold start run for the trial license (10 hosts) scenario.  Tuning is set
+  to true, but is not forced, so it will not be applied to this instance due
+  to insufficient ram.
+    * m5.large: Starting with `TRIAL_L_COLD_TUNED_BASE_INSTANCES` instances.
+* 5 cold start runs (provisioning on the first) with tune set to true on the
+  following:
+    * c5.xlarge: Starting with `STD_XL_COLD_TUNED_BASE_INSTANCES` instances
+    * c5.2xlarge: Starting with `STD_2XL_COLD_TUNED_BASE_INSTANCES` instances
+    * c5.4xlarge: Starting with `STD_4XL_COLD_TUNED_BASE_INSTANCES` instances
+* 5 warm start runs (using the provisioned hosts from the cold run above) with
+  tune set to true on the following:
+    * c5.xlarge: Starting with `STD_XL_WARM_TUNED_BASE_INSTANCES` instances
+    * c5.2xlarge: Starting with `STD_2XL_WARM_TUNED_BASE_INSTANCES` instances
+    * c5.4xlarge: Starting with `STD_4XL_WARM_TUNED_BASE_INSTANCES` instances
+
+This behaviour is executed via the following command:
+```
+./util/scale_run.sh 2019.1.0
+```
+
+
+## Environment Preparation
+
+This script should be executed on a test runner set up as per the
+[gplt setup instructions](slv_environment_setup.md) with adequate
+storage space for all of the logs (100GB recommended).
+
+
+## Command line flags
+
+### No-op mode
+
+The script provides a simple no-op mode that will echo out the ENV variable
+settings as well as the scale command to be executed for each run.  This
+mode is invoked with the `-n` or `--noop` flag.
+
+
+### Tuning
+
+The application of pe-tune can be toggled using the `--tune` or `--notune`
+flags.  Having tuning applied is the default.
+
+
+### Run ID
+
+The script provides the `-i` or `--run-id` flag to enable the user to supply
+an identifier to be used in the naming of the created run directories.  This
+allows the user to run the script multiple times and label the runs in a
+meaningful way for future reference.  For example, a JIRA ticket number might
+be used with this flag.
+
+```
+./util/scale_run.sh -n -i SLV-999 2019.1.0
+...
+cmd=bundle exec rake autoscale_cold > "20190617160446-SLV-999-trial-c5.large-tune-true-cold-0.log"
+```
+
+## Customizing the settings
+
+There are numerous variables used by the underlying `autoscale` rake tasks.
+For the user's convenience, they have been grouped at the beginning of the
+script.  The user should review and set these variables as desired prior
+to running the script.

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -112,10 +112,8 @@ ABS_AWS_MOM_SIZE=$ABS_AWS_MOM_SIZE
 function prep_gplt () {
     mkdir -p "$WORK_DIR"
     cd "$WORK_DIR" || exit 1
-    mkdir "$1"
+    git clone git@github.com:puppetlabs/gatling-puppet-load-test "$1"
     cd "$1" || exit 1
-    git clone git@github.com:puppetlabs/gatling-puppet-load-test
-    cd gatling-puppet-load-test || exit 1
     bundle install --path vendor/bundle
 }
 

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -8,6 +8,8 @@
 ##########
 
 WORK_DIR="$HOME/gatling"
+PREFIX=$(date -u +%Y%m%d%H%M%S)
+
 
 ##########
 # Function Definitions
@@ -23,6 +25,8 @@ usage () {
     echo "Mandatory arguments to long options are mandatory for short options too."
     echo "  -h|--help             show this help text"
     echo "  -d|--debug            debug mode: prints ENV values and commands to be executed, but does not run anything"
+    echo "  -i|--run-id           Set a value to prepend to scale run directories"
+    echo "                        (default: '')"
     echo
 }
 
@@ -30,6 +34,10 @@ usage () {
 # expected environment variables.
 function echo_env () {
     echo "============================================
+Provided args:
+RUN_ID=$RUN_ID
+PE_VERSION=$PE_VERSION
+
 In subshell for $test $run_type round $i
 cmd=$cmd
 BEAKER_INSTALL_TYPE=$BEAKER_INSTALL_TYPE
@@ -70,6 +78,11 @@ do
             DEBUG=true
             shift
             ;;
+        -i|--run-id)
+          RUN_ID=$2
+          PREFIX="$PREFIX-$RUN_ID"
+          shift 2
+          ;;
         --) # end argument parsing
             shift
             break
@@ -149,7 +162,7 @@ echo "Testing Standard Ref Arch: For Trial Use"
 
     run_type="cold"
     ec2=$ABS_AWS_MOM_SIZE
-    test="slv-414-ref1-$ec2"
+    test="$PREFIX-trial-$ec2"
     cmd="bundle exec rake autoscale_$run_type > \"$test-$run_type.log\""
     if [ -z $DEBUG ]; then
         prep_gplt "$test"
@@ -194,7 +207,7 @@ echo "Testing Standard Ref Arch: Standard Deployment"
                 export PUPPET_GATLING_SCALE_BASE_INSTANCES=3800
             fi
             export ABS_AWS_MOM_SIZE="$ec2"
-            test="slv-414-ref2-$ec2-tune-$tune"
+            test="$PREFIX-std-$ec2-tune-$tune"
             cmd="bundle exec rake $task > \"$test-$run_type-$i.log\""
             if [ -z $DEBUG ]; then
                 prep_gplt "$test"
@@ -233,7 +246,7 @@ echo "Testing Standard Ref Arch: Standard Deployment"
                 export PUPPET_GATLING_SCALE_BASE_INSTANCES=3800
             fi
             export ABS_AWS_MOM_SIZE="$ec2"
-            test="slv-414-ref2-$ec2-tune-$tune"
+            test="$PREFIX-std-$ec2-tune-$tune"
             cmd="bundle exec rake $task > \"$test-$run_type-$i.log\""
             if [ -z $DEBUG ]; then
                 cd "$WORK_DIR/$test/gatling-puppet-load-test" || exit 1

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -140,7 +140,7 @@ export PUPPET_GATLING_SCALE_TUNE=$tune
 
 
 echo "========================================================================"
-echo "Testing Ref Arch 1: Monolithic deploy for 10 or fewer nodes"
+echo "Testing Standard Ref Arch: For Trial Use"
 
     export PUPPET_GATLING_SCALE_BASE_INSTANCES=100
     export PUPPET_GATLING_SCALE_ITERATIONS=1
@@ -160,7 +160,7 @@ echo "Testing Ref Arch 1: Monolithic deploy for 10 or fewer nodes"
 
 
 echo "========================================================================"
-echo "Testing Ref Arch 2: Monolithic deploy for up to 4,000 nodes"
+echo "Testing Standard Ref Arch: Standard Deployment"
 
     export PUPPET_GATLING_SCALE_ITERATIONS=15
     export PUPPET_GATLING_SCALE_INCREMENT=100
@@ -244,9 +244,5 @@ echo "Testing Ref Arch 2: Monolithic deploy for up to 4,000 nodes"
         done
     done
 
-echo "========================================================================"
-echo "NOT IN SCOPE: Ref Arch 3: Monolithic with Compiler deploy for up to 20,000 nodes"
-echo "========================================================================"
-
-# Create report from data
+# TODO: Create report from data
 # for i in $(ls -d PERF_SCALE_*); do ; cat $i/PERF_SCALE_*.csv| sed 's/,/|/g' | sed 's/^/|/' | sed 's/$/|/' >> unified_results.txt ; done

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+
+# Run scale tests for each Standard Ref Arch size on docs page
+#   Ref: https://puppet.com/docs/pe/latest/hardware_requirements.html
+
+
+##########
+# Function Definitions
+##########
+
+# Display usage help
+usage () {
+    echo "$0 [-h] [-d] PE_VERSION -- Run scale testing on specified PE_VERSION"
+    echo
+    echo "where:"
+    echo "            -h  show this help text"
+    echo "            -d  debug mode: prints ENV values and commands to be executed, but does not run anything"
+    echo "    PE_VERSION  in semver notation (e.g 2019.1.0)"
+    echo
+}
+
+# Debug function to validate that bash subshells inherit
+# expected environment variables.
+function echo_env () {
+    echo "============================================
+In subshell for $test $run_type round $i
+cmd=$cmd
+BEAKER_INSTALL_TYPE=$BEAKER_INSTALL_TYPE
+BEAKER_PE_DIR=$BEAKER_PE_DIR
+BEAKER_PE_VER=$BEAKER_PE_VER
+PUPPET_GATLING_SCALE_BASE_INSTANCES=$PUPPET_GATLING_SCALE_BASE_INSTANCES
+PUPPET_GATLING_SCALE_ITERATIONS=$PUPPET_GATLING_SCALE_ITERATIONS
+PUPPET_GATLING_SCALE_INCREMENT=$PUPPET_GATLING_SCALE_INCREMENT
+PUPPET_GATLING_SCALE_SCENARIO=$PUPPET_GATLING_SCALE_SCENARIO
+ABS_AWS_MOM_SIZE=$ABS_AWS_MOM_SIZE
+============================================"
+}
+
+# Link scale results to nginx content location
+function link_results () {
+    # test name is arg1, pe_ver is arg2
+    source=$HOME/gplt/$1/gatling-puppet-load-test/results/scale
+    dest=/usr/share/nginx/html/gplt/scale/$1/$2
+
+    sudo mkdir -p "${dest}"
+    sudo ln -s "${source}" "${dest}"
+}
+
+# Prepare checkout of puppet-gatling-load-test
+function prep_gplt () {
+    cd "$HOME/gplt" || exit 1
+    mkdir "$1"
+    cd "$1" || exit 1
+    git clone git@github.com:puppetlabs/gatling-puppet-load-test
+    cd gatling-puppet-load-test || exit 1
+    bundle install --path vendor/bundle
+}
+
+
+##########
+# Argument checking
+##########
+
+ARGS=()
+while [ $# -gt 0 ]
+do
+    unset OPTIND
+    unset OPTARG
+    while getopts hd  options
+    do
+    case $options in
+        h)  usage
+            exit 1
+            ;;
+        d)  DEBUG=true
+            ;;
+        esac
+   done
+   shift $((OPTIND-1))
+   ARGS+=($1)
+   shift
+done
+
+# Ensure PE_VERSION is provided
+if [ "${#ARGS[@]}" -le "0" ]; then
+    echo "PE_VERSION not provided"
+    echo
+    usage
+    exit 1
+fi
+PE_VERSION=${ARGS[0]}
+
+# Ensure PE_VERSION is semver
+# e.g. 2019.1.1-rc0-207-g4e47830
+# Regex from: https://regexr.com/39s32
+if ! [[ $PE_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+((-[0-9a-zA-Z-]+)*)?$ ]]; then
+    echo "Supplied PE_VERSION is malformed"
+    echo
+    usage
+    exit 1
+fi
+
+
+##########
+# Main
+##########
+
+tune=false
+# Global settings
+export BEAKER_INSTALL_TYPE=pe
+export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.1.0
+export BEAKER_PE_VER=$PE_VERSION
+export PUPPET_GATLING_SCALE_TUNE=$tune
+# export PUPPET_GATLING_SCALE_TUNE_FORCE=true
+
+
+mkdir "$HOME/gplt"
+
+echo "========================================================================"
+echo "Testing Ref Arch 1: Monolithic deploy for 10 or fewer nodes"
+
+    export PUPPET_GATLING_SCALE_BASE_INSTANCES=100
+    export PUPPET_GATLING_SCALE_ITERATIONS=1
+    export PUPPET_GATLING_SCALE_SCENARIO="Scale.json"
+    export ABS_AWS_MOM_SIZE="m5.large"
+
+    run_type="cold"
+    ec2=$ABS_AWS_MOM_SIZE
+    test="slv-414-ref1-$ec2"
+    cmd="bundle exec rake autoscale_$run_type > \"$test-$run_type.log\""
+    if [ -z $DEBUG ]; then
+        prep_gplt "$test"
+        (bundle exec rake autoscale_$run_type > "$test-$run_type.log") &
+    else
+        (echo_env) &
+    fi
+
+
+echo "========================================================================"
+echo "Testing Ref Arch 2: Monolithic deploy for up to 4,000 nodes"
+
+    export PUPPET_GATLING_SCALE_ITERATIONS=15
+    export PUPPET_GATLING_SCALE_INCREMENT=100
+    export PUPPET_GATLING_SCALE_SCENARIO="Scale.json"
+
+    run_type="cold"
+    declare -a ec2_types=("c5.xlarge" "c5.2xlarge" "c5.4xlarge")
+    for i in {0..4}; do
+        wait
+        [[ $i = 0 ]] && task="autoscale_$run_type" || task="autoscale_provisioned_$run_type"
+        for ec2 in "${ec2_types[@]}"; do
+            if [[ $ec2 == "c5.xlarge" ]]; then
+                if [[ $tune == "false" ]]; then
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=2000
+                else
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=2000
+                fi
+            elif [[ $ec2 == "c5.2xlarge" ]]; then
+                if [[ $tune == "false" ]]; then
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=3800
+                else
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=4100
+                fi
+            elif [[ $ec2 == "c5.4xlarge" ]]; then
+                if [[ $tune == "false" ]]; then
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=4100
+                else
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=3800
+                fi
+            else
+                export PUPPET_GATLING_SCALE_BASE_INSTANCES=3800
+            fi
+            export ABS_AWS_MOM_SIZE="$ec2"
+            test="slv-414-ref2-$ec2-tune-$tune"
+            cmd="bundle exec rake $task > \"$test-$run_type-$i.log\""
+            if [ -z $DEBUG ]; then
+                prep_gplt "$test"
+                link_results "$test" "$BEAKER_PE_VER"
+                (bundle exec rake $task > "$test-$run_type-$i.log") &
+            else
+                (echo_env) &
+            fi
+        done
+    done
+
+    wait
+    run_type="warm"
+    for i in {0..4}; do
+        wait
+        task=autoscale_provisioned_$run_type
+        for ec2 in "${ec2_types[@]}"; do
+            if [[ $ec2 == "c5.xlarge" ]]; then
+                if [[ $tune == "false" ]]; then
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=1800
+                else
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=1800
+                fi
+            elif [[ $ec2 == "c5.2xlarge" ]]; then
+                if [[ $tune == "false" ]]; then
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=3800
+                else
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=5000
+                fi
+            elif [[ $ec2 == "c5.4xlarge" ]]; then
+                if [[ $tune == "false" ]]; then
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=4000
+                else
+                    export PUPPET_GATLING_SCALE_BASE_INSTANCES=6000
+                fi
+            else
+                export PUPPET_GATLING_SCALE_BASE_INSTANCES=3800
+            fi
+            export ABS_AWS_MOM_SIZE="$ec2"
+            test="slv-414-ref2-$ec2-tune-$tune"
+            cmd="bundle exec rake $task > \"$test-$run_type-$i.log\""
+            if [ -z $DEBUG ]; then
+                cd "$HOME/gplt/$test/gatling-puppet-load-test" || exit 1
+                (bundle exec rake $task > "$test-$run_type-$i.log") &
+            else
+                (echo_env) &
+            fi
+        done
+    done
+
+echo "========================================================================"
+echo "NOT IN SCOPE: Ref Arch 3: Monolithic with Compiler deploy for up to 20,000 nodes"
+echo "========================================================================"
+
+# Create report from data
+# for i in $(ls -d PERF_SCALE_*); do ; cat $i/PERF_SCALE_*.csv| sed 's/,/|/g' | sed 's/^/|/' | sed 's/$/|/' >> unified_results.txt ; done

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -175,11 +175,11 @@ PE_VERSION=${ARGS[0]}
 # Ensure PE_VERSION is semver
 # e.g. 2019.1.1-rc0-207-g4e47830
 # Regex from: https://regexr.com/39s32
-RE='[^0-9]*\([0-9]*\)[.]\([0-9]*\)[.]\([0-9]*\)\([0-9A-Za-z-]*\)'
-PE_MAJOR=$(echo "$PE_VERSION" | sed -e "s#$RE#\1#")
-PE_MINOR=$(echo "$PE_VERSION" | sed -e "s#$RE#\2#")
-PE_PATCH=$(echo "$PE_VERSION" | sed -e "s#$RE#\3#")
-PE_BUILD=$(echo "$PE_VERSION" | sed -e "s#$RE#\4#")
+RE='[^0-9]*([0-9]*)[.]([0-9]*)[.]([0-9]*)([0-9A-Za-z-]*)'
+PE_MAJOR=$(echo "$PE_VERSION" | sed -nEe "s/$RE/\1/p")
+PE_MINOR=$(echo "$PE_VERSION" | sed -nEe "s/$RE/\2/p")
+PE_PATCH=$(echo "$PE_VERSION" | sed -nEe "s/$RE/\3/p")
+PE_BUILD=$(echo "$PE_VERSION" | sed -nEe "s/$RE/\4/p")
 echo "PE_MAJOR=$PE_MAJOR"
 echo "PE_MINOR=$PE_MINOR"
 echo "PE_PATCH=$PE_PATCH"

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -3,6 +3,11 @@
 # Run scale tests for each Standard Ref Arch size on docs page
 #   Ref: https://puppet.com/docs/pe/latest/hardware_requirements.html
 
+##########
+# Variables
+##########
+
+WORK_DIR="$HOME/gatling"
 
 ##########
 # Function Definitions
@@ -36,19 +41,10 @@ ABS_AWS_MOM_SIZE=$ABS_AWS_MOM_SIZE
 ============================================"
 }
 
-# Link scale results to nginx content location
-function link_results () {
-    # test name is arg1, pe_ver is arg2
-    source=$HOME/gplt/$1/gatling-puppet-load-test/results/scale
-    dest=/usr/share/nginx/html/gplt/scale/$1/$2
-
-    sudo mkdir -p "${dest}"
-    sudo ln -s "${source}" "${dest}"
-}
-
 # Prepare checkout of puppet-gatling-load-test
 function prep_gplt () {
-    cd "$HOME/gplt" || exit 1
+    mkdir -p "$WORK_DIR"
+    cd "$WORK_DIR" || exit 1
     mkdir "$1"
     cd "$1" || exit 1
     git clone git@github.com:puppetlabs/gatling-puppet-load-test
@@ -114,7 +110,6 @@ export PUPPET_GATLING_SCALE_TUNE=$tune
 # export PUPPET_GATLING_SCALE_TUNE_FORCE=true
 
 
-mkdir "$HOME/gplt"
 
 echo "========================================================================"
 echo "Testing Ref Arch 1: Monolithic deploy for 10 or fewer nodes"
@@ -175,7 +170,6 @@ echo "Testing Ref Arch 2: Monolithic deploy for up to 4,000 nodes"
             cmd="bundle exec rake $task > \"$test-$run_type-$i.log\""
             if [ -z $DEBUG ]; then
                 prep_gplt "$test"
-                link_results "$test" "$BEAKER_PE_VER"
                 (bundle exec rake $task > "$test-$run_type-$i.log") &
             else
                 (echo_env) &
@@ -214,7 +208,7 @@ echo "Testing Ref Arch 2: Monolithic deploy for up to 4,000 nodes"
             test="slv-414-ref2-$ec2-tune-$tune"
             cmd="bundle exec rake $task > \"$test-$run_type-$i.log\""
             if [ -z $DEBUG ]; then
-                cd "$HOME/gplt/$test/gatling-puppet-load-test" || exit 1
+                cd "$WORK_DIR/$test/gatling-puppet-load-test" || exit 1
                 (bundle exec rake $task > "$test-$run_type-$i.log") &
             else
                 (echo_env) &

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -15,12 +15,14 @@ WORK_DIR="$HOME/gatling"
 
 # Display usage help
 usage () {
-    echo "$0 [-h] [-d] PE_VERSION -- Run scale testing on specified PE_VERSION"
+    echo "Usage: $0 [OPTION]... PE_VERSION"
     echo
-    echo "where:"
-    echo "            -h  show this help text"
-    echo "            -d  debug mode: prints ENV values and commands to be executed, but does not run anything"
-    echo "    PE_VERSION  in semver notation (e.g 2019.1.0)"
+    echo "Run scale testing on specified PE_VERSION."
+    echo "  PE_VERSION in semver notation (e.g 2019.1.0)"
+    echo
+    echo "Mandatory arguments to long options are mandatory for short options too."
+    echo "  -h|--help             show this help text"
+    echo "  -d|--debug            debug mode: prints ENV values and commands to be executed, but does not run anything"
     echo
 }
 
@@ -60,21 +62,27 @@ function prep_gplt () {
 ARGS=()
 while [ $# -gt 0 ]
 do
-    unset OPTIND
-    unset OPTARG
-    while getopts hd  options
-    do
-    case $options in
-        h)  usage
+    case "$1" in
+        -h|--help)  usage
             exit 1
             ;;
-        d)  DEBUG=true
+        -d|--debug)
+            DEBUG=true
+            shift
+            ;;
+        --) # end argument parsing
+            shift
+            break
+            ;;
+        -*|--*=) # unsupported flags
+            echo "Error: Unsupported flag $1" >&2
+            exit 1
+            ;;
+        *) # preserve positional arguments
+            ARGS+=("$1")
+            shift
             ;;
         esac
-   done
-   shift $((OPTIND-1))
-   ARGS+=($1)
-   shift
 done
 
 # Ensure PE_VERSION is provided


### PR DESCRIPTION
This commit adds a bash script for automating running scale testing
against the defined reference architectures defined in the PE docs

https://puppet.com/docs/pe/latest/hardware_requirements.html

This script will run a single iteration of the "10 or fewer" architecture.  It
will then run the following iterations on three different EC2 instance
definitions to test the scale of the "Up to 4,000" architecture options.

1. Cold start run provisioning the EC2 instances.
1. 4 more cold start iterations on the instance created above.
1. 5 warm start iterations on the instances created above.

The "Monolithic with compilers" architecture is not executed.