### PR TITLE
(SLV-415) Soak test updates: rake tasks, duration, AWS reap time

### DIFF
--- a/NEW_README.md
+++ b/NEW_README.md
@@ -193,22 +193,18 @@ The soak performance test executes a long-running scenario under medium load:
 * 600 agents
 * `role::by_size::large`
 
-### Provision, tune, run
-
 A set of 'soak' rake tasks are provided to handle setup and test execution, allowing nodes to be provisioned as part of the run or as a separate step.
-The pre-suite includes tuning of the master via 'puppet infrastructure tune' so this is no longer a manual step.
+The pre-suite includes tuning of the master via 'puppet infrastructure tune'.
 
 Note that when using the soak rake tasks the `BEAKER_PRESERVE_HOSTS` environment variable is always set to 'true', so you will need to de-provision the test nodes with the `performance_deprovision_with_abs` when your testing is complete.
 
-To execute a soak performance run:
-
-#### To provision and set up nodes as part of the run:
+### To provision and set up nodes as part of the run:
 
 ```
 bundle exec rake soak
 ```
 
-#### To provision and set up nodes separately:
+### To provision and set up nodes separately:
 
 Run the `soak_setup` rake task to provision and set up the nodes:
 ```
@@ -220,7 +216,7 @@ Then run the 'soak_provisioned' rake task to run the soak test:
 bundle exec rake soak_provisioned
 ```
 
-#### De-provision the nodes when testing is complete
+### De-provision the nodes when testing is complete
 
 ```
 bundle exec rake performance_deprovision_with_abs

--- a/NEW_README.md
+++ b/NEW_README.md
@@ -94,12 +94,19 @@ your `$HOME/.fog` file.  Here is an example: _FIXME: Reference fog website._
 
 ##### ABS (Always Be Scheduling)
 
-**NOTE: This facility is not publically available and can only be used by
+**NOTE: This facility is not publicly available and can only be used by
 personnel employed by Puppet the company.**
 
-**NOTE:** AWS instances provided by ABS are automatically destroyed after
-24 hours.  The lifetime of these instances  can be set to an alternative value
-by setting the with `ABS_AWS_REAP_TIME` environment variable in seconds.
+**NOTE:** AWS instances provided by ABS are automatically destroyed after 24 hours by the [AWS EC2 Reaper](https://github.com/puppetlabs/aws_resource_reaper/tree/master/lambdas/ec2#aws-ec2-reaper).  
+The lifetime of these instances can be set to an alternative value by setting the desired lifetime with the `ABS_AWS_REAP_TIME` environment variable in seconds.
+
+Alternatively, the lifetime can be specified in days via the `ABS_AWS_REAP_DAYS` environment variable.
+Setting this variable will override any value set for the `ABS_AWS_REAP_TIME` environment variable.
+
+In either case, the value is ultimately specified in seconds as the `reap_time` parameter of the request to the [`awsdirect` endpoint](https://github.com/puppetlabs/always-be-scheduling#apiv2awsdirect).
+This is translated to the `termination_date` tag specified by ABS for the EC2 instance; it can be manually edited in the EC2 console to change the specified value.
+
+The Terminator component of the Reaper runs periodically to ensure that all EC2 instances are terminated if they are past their `termination_date`.
 
 * In order to use an AWS account with access to
 puppetlabs network resources, you need to use
@@ -198,6 +205,9 @@ The pre-suite includes tuning of the master via 'puppet infrastructure tune'.
 
 Note that when using the soak rake tasks the `BEAKER_PRESERVE_HOSTS` environment variable is always set to 'true', so you will need to de-provision the test nodes with the `performance_deprovision_with_abs` when your testing is complete.
 
+To ensure AWS instances are not terminated before the test completes and post-test steps are performed the soak rake task sets the reap time to 30 days via the `ABS_AWS_REAP_DAYS` environment variable.
+This value can be overridden by specifying a different value for the environment variable.
+
 ### To provision and set up nodes as part of the run:
 
 ```
@@ -221,6 +231,7 @@ bundle exec rake soak_provisioned
 ```
 bundle exec rake performance_deprovision_with_abs
 ```
+
 
 ## Scale performance tests
 
@@ -316,6 +327,8 @@ for `ABS_OS` and `BEAKER_HOSTS`.  Here is an example:
 ```
 ABS_OS=centos-7-x86-64-west BEAKER_HOSTS=config/beaker_hosts/pe-perf-test.cfg
 ```
+
+
 
 ## Other Topics
 

--- a/config/env/env_setup_2019.1.0
+++ b/config/env/env_setup_2019.1.0
@@ -5,5 +5,5 @@
 # export PUPPET_GATLING_SCALE_SIMULATION_ID="PerfAutoScaleSmall"
 
 export BEAKER_INSTALL_TYPE=pe
-export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/internal/2019.1
-export BEAKER_PE_VER=2019.1.0-rc11
+export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.1.0
+export BEAKER_PE_VER=2019.1.0

--- a/rakefile
+++ b/rakefile
@@ -290,7 +290,7 @@ rototiller_task :soak do
   ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
   ENV['PUPPET_SCALE_CLASS'] = ENV['PUPPET_SCALE_CLASS'] || 'role::by_size::large'
   ENV['PUPPET_GATLING_SCALE_TUNE'] = ENV['PUPPET_GATLING_SCALE_TUNE'] || 'true'
-  ENV['ABS_AWS_REAP_DAYS'] = ENV['ABS_AWS_REAP_DAYS'] || '20'
+  ENV['ABS_AWS_REAP_DAYS'] = ENV['ABS_AWS_REAP_DAYS'] || '30'
   Rake::Task["performance"].execute
 end
 

--- a/rakefile
+++ b/rakefile
@@ -283,6 +283,32 @@ rototiller_task :performance_setup do
   Rake::Task["performance"].execute
 end
 
+desc 'Run Soak setup and test for gatling'
+rototiller_task :soak do
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Soak.rb'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
+  ENV['PUPPET_SCALE_CLASS'] = ENV['PUPPET_SCALE_CLASS'] || 'role::by_size::large'
+  ENV['PUPPET_GATLING_SCALE_TUNE'] = ENV['PUPPET_GATLING_SCALE_TUNE'] || 'true'
+  ENV['ABS_AWS_REAP_DAYS'] = ENV['ABS_AWS_REAP_DAYS'] || '20'
+  Rake::Task["performance"].execute
+end
+
+desc 'Run Soak setup for gatling'
+rototiller_task :soak_setup do
+  ENV['BEAKER_TESTS'] = ''
+  Rake::Task["soak"].execute
+end
+
+desc 'Run Soak test for gatling on previously provisioned hosts'
+rototiller_task :soak_provisioned do
+  ENV['ENVIRONMENT_TYPE'] = 'gatling'
+  ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Soak.rb'
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
+  ENV['PUPPET_SCALE_CLASS'] = ENV['PUPPET_SCALE_CLASS'] || 'role::by_size::large'
+  Rake::Task["performance_against_already_provisioned"].execute
+end
+
 desc 'Run Scale setup and test for gatling'
 rototiller_task :autoscale do
   ENV['ENVIRONMENT_TYPE'] = 'gatling'

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -20,8 +20,9 @@ module AbsHelper
   # centos-7-x86-64-west is an AWS image, centos-7-x86_64 is vmpooler
   ABS_BEAKER_ENGINE = "aws".freeze
 
-  # TODO: is this the value we want to use?
-  AWS_REAP_TIME = "86400".freeze
+  # default reap time is one day
+  SECONDS_PER_DAY = 86400.freeze
+  AWS_REAP_TIME = SECONDS_PER_DAY.to_s.freeze
 
   # TODO: update mom and metrics config
   MOM_VOLUME_SIZE = AWS_VOLUME_SIZE.freeze
@@ -46,7 +47,15 @@ module AbsHelper
       @aws_platform = ENV["ABS_AWS_PLATFORM"] ? ENV["ABS_AWS_PLATFORM"] : AWS_PLATFORM
       @aws_image_id = ENV["ABS_AWS_IMAGE_ID"] ? ENV["ABS_AWS_IMAGE_ID"] : AWS_IMAGE_ID
       @aws_region = ENV["ABS_AWS_REGION"] ? ENV["ABS_AWS_REGION"] : AWS_REGION
-      @aws_reap_time = ENV["ABS_AWS_REAP_TIME"] ? ENV["ABS_AWS_REAP_TIME"] : AWS_REAP_TIME
+
+      # override default reap time with days?
+      if ENV["ABS_AWS_REAP_DAYS"]
+        days = ENV["ABS_AWS_REAP_DAYS"].to_i
+        @aws_reap_time = (days * SECONDS_PER_DAY).to_s
+      else
+        @aws_reap_time = ENV["ABS_AWS_REAP_TIME"] ? ENV["ABS_AWS_REAP_TIME"] : AWS_REAP_TIME
+      end
+
       @mom_size = ENV["ABS_AWS_MOM_SIZE"]
       @mom_volume_size = ENV["ABS_AWS_MOM_VOLUME_SIZE"] ? ENV["ABS_AWS_MOM_VOLUME_SIZE"] : MOM_VOLUME_SIZE
       @metrics_size = ENV["ABS_AWS_METRICS_SIZE"]

--- a/simulation-runner/config/scenarios/Soak.json
+++ b/simulation-runner/config/scenarios/Soak.json
@@ -1,11 +1,11 @@
 {
-    "run_description": "'role::by_size_large' role from perf control repo, 600 agents, 480 iterations. ~10 days",
+    "run_description": "'role::by_size_large' role from perf control repo, 600 agents, 672 iterations. ~14 days",
     "nodes": [
         {
             "node_config": "PerfTestLarge.json",
             "num_instances": 600,
             "ramp_up_duration_seconds": 1800,
-            "num_repetitions": 480,
+            "num_repetitions": 672,
             "sleep_duration_seconds": 1800
         }
     ]

--- a/tests/Soak.rb
+++ b/tests/Soak.rb
@@ -6,7 +6,7 @@ teardown do
   perf_teardown
 end
 
-# Execute 60 agent runs to warm up the JIT before starting our monitoring.
+# Execute agent runs to warm up the JIT before starting our monitoring.
 perf_setup('WarmUpJit.json','PerfTestLarge', '')
 stop_monitoring(master, '/opt/puppetlabs')
 
@@ -17,17 +17,21 @@ perf_setup('Soak.json','PerfTestLarge', gatlingassertions)
 
 atop_result, gatling_result = perf_result
 
+# TODO: remove commented steps below
+
 step 'max response' do
   # Temporarily disabling this step until SLV-208 is complete
   # assert_later(gatling_result.max_response_time_agent <= 20000, "Max response time per agent run was: #{gatling_result.max_response_time_agent}, expected <= 20000")
 end
 
 step 'successful request percentage' do
-  assert_later(gatling_result.successful_requests == 100, "Total successful request percentage was: #{gatling_result.successful_requests}%, expected 100%" )
+  # Temporarily disabling this step for Kearney testing
+  # assert_later(gatling_result.successful_requests == 100, "Total successful request percentage was: #{gatling_result.successful_requests}%, expected 100%" )
 end
 
 step 'average memory' do
-  assert_later(atop_result.avg_mem < 3000000, "Average memory was: #{atop_result.avg_mem}, expected < 3000000")
+  # Temporarily disabling this step for Kearney testing
+  # assert_later(atop_result.avg_mem < 3000000, "Average memory was: #{atop_result.avg_mem}, expected < 3000000")
 end
 
 ##This step will only be run if BASELINE_PE_VER and has been set.

--- a/tests/Soak.rb
+++ b/tests/Soak.rb
@@ -6,7 +6,7 @@ teardown do
   perf_teardown
 end
 
-# Execute agent runs to warm up the JIT before starting our monitoring.
+# Execute 60 agent runs (hitting the endpoints 300 times) to warm up the JIT before starting our monitoring.
 perf_setup('WarmUpJit.json','PerfTestLarge', '')
 stop_monitoring(master, '/opt/puppetlabs')
 


### PR DESCRIPTION
## Rake tasks
This update adds the following rake tasks:
```
rake soak                                     # Run Soak setup and test for gatling
rake soak_provisioned                         # Run Soak test for gatling on previously provisioned hosts
rake soak_setup                               # Run Soak setup for gatling
```
## Duration
The scenario has been updated from 10 to 14 days.

## AWS reap time
To ensure AWS instances are not reaped before the test completes and post-test steps are performed the `soak` rake task sets the reap time to 20 days. `abs_helper.rb` has been updated to allow the default reap time to be overridden by specifying the value in days with the `ABS_AWS_REAP_DAYS` environment variable.

## Assertions
The unnecessary assertions in `Soak.rb` have been temporarily commented out.

TODO: 
* remove unnecessary assertions in `Soak.rb`
* ~~update Soak test section in NEW_README~~
