### PR TITLE
(SLV363)Task take public github repo as source

### DIFF
--- a/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.json
+++ b/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.json
@@ -1,9 +1,21 @@
 {
-  "description": "Creates a git repo from puppet production environment directory",
+  "description": "Creates a local git repo for puppet code",
   "input_method": "environment",
   "parameters": {
     "ctrl_repo_path": {
       "description": "The fully qualified path where the control repo will be created",
+      "type": "Optional[String[1]]"
+    },
+    "code_source_path": {
+      "description": "The fully qualified path to the source code",
+      "type": "Optional[String[1]]"
+    },
+    "code_source_url": {
+      "description": "The URL to a public github repo that contains the source code",
+      "type": "Optional[String[1]]"
+    },
+    "code_source_branch": {
+      "description": "The branch of the public github repo in code_source_url to use as production",
       "type": "Optional[String[1]]"
     }
   }

--- a/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.sh
+++ b/Boltdir/site-modules/gplt/tasks/create_control_repo_from_production_env.sh
@@ -1,32 +1,63 @@
 #!/bin/bash
 
+#sends all stderr to stdout to be sure it gets seen. (Bolt hides stderr if there is anything on stdout)
+exec 2>&1
+
+#fail the script if any command fails
 set -e
+
+#input arg checking
+[[ $PT_code_source_path ]] && [[ $PT_code_source_url ]] && \
+echo "Only one source allowed, can't give both a code_source_path and code_source_url" && exit 1
+
+[[ $PT_code_source_branch ]] && [[ $PT_code_source_path ]] && \
+echo "A code_source_branch has no meaning with a code_source_path" && exit 1
+
+[[ $PT_code_source_branch ]] && [ -z "PT_code_source_url" ] && \
+echo "code_source_url is required if a code_source_branch is specified" && exit 1
+
+#currently we only create the production env in the new repo
+ENVIRONMENT=production
+
+PUPPET_PROD_ENV_DIR=/etc/puppetlabs/code/environments/$ENVIRONMENT
+
+#TODO would like to see this randomized to avoid conflicts with previous failed runs of this task
+CHECKOUT_DIR=/tmp/control-repo
 
 CTRL_REPO_PATH="${PT_ctrl_repo_path:-/opt/puppet/control-repo.git}"
 [ -z "$CTRL_REPO_PATH" ] && echo "Must specify a control repo path" && exit 1
 
+CODE_SOURCE_PATH="${PT_code_source_path:-/etc/puppetlabs/code/environments/$ENVIRONMENT}"
+CODE_SOURCE_URL=${PT_code_source_url}
+CODE_SOURCE_BRANCH=${PT_code_source_branch}
+
 CTRL_REPO_BASEDIR=$(dirname $CTRL_REPO_PATH)
-
-ENVIRONMENT=production
-PUPPET_PROD_ENV_DIR=/etc/puppetlabs/code/environments/$ENVIRONMENT
-CHECKOUT_DIR=/tmp/control-repo
-
 
 mkdir -p "$CTRL_REPO_BASEDIR"
 
 if [ -d "$CTRL_REPO_PATH" ]; then
-    echo "ERROR: The control repo destination already exists" >&2
+    echo "ERROR: The control repo destination already exists: $CTRL_REPO_PATH" >&2
+    exit 1
+fi
+
+if [ -d "$CHECKOUT_DIR" ]; then
+    echo "ERROR: Temporary checkout dir already exists: $CHECKOUT_DIR" >&2
     exit 1
 fi
 
 git init --bare $CTRL_REPO_PATH
 git clone $CTRL_REPO_PATH $CHECKOUT_DIR
-cp -r $PUPPET_PROD_ENV_DIR/* $CHECKOUT_DIR
-rm -fr $CHECKOUT_DIR/modules
 cd $CHECKOUT_DIR \
     || { echo "ERROR: Failed to cd into $CHECKOUT_DIR" >&2 ; exit 1 ; }
-git add .
-git commit -m "Initial commit"
+if [[ $CODE_SOURCE_URL ]]
+then
+  git pull $CODE_SOURCE_URL $CODE_SOURCE_BRANCH
+else
+  cp -r $PUPPET_PROD_ENV_DIR/* $CHECKOUT_DIR
+  rm -fr $CHECKOUT_DIR/modules
+  git add .
+  git commit -m "Initial commit"
+fi
 git branch -m $ENVIRONMENT
 git push -u origin $ENVIRONMENT
 cd $CTRL_REPO_PATH

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -7,12 +7,12 @@ checkout of this repository.
 
 ## gplt::create_control_repo_from_production_env
 
-This task creates a git repo using the contents from the given node's
-puppet production environment.  Therefore, the specified node should be
+This task creates a git repo using either a path (commonly the contents from the given node's
+puppet production environment) or a public GitHub URL.  Normally the specified node should be
 the primary puppet master.
 
-The task takes one optional argument `ctrl_repo_path=<value>` which is used
-as the fully qualified path for creating the git repository.
+The task takes optional arguments which can be used to identify the source for the new git repo or
+to specify the fully qualified path for where the new repo should be created.
 
 Note: The bolt task needs to be run as the `root` user (which is the default)
 in order for the default `ctrl_repo_path` to be successfully created.
@@ -21,14 +21,20 @@ The built in documentation for the task can be seen by running the following:
 ```
 bolt task show gplt::create_control_repo_from_production_env
 
-gplt::create_control_repo_from_production_env - Creates a git repo from puppet production environment directory
+gplt::create_control_repo_from_production_env - Creates a local git repo for puppet code
 
 USAGE:
-bolt task run --nodes <node-name> gplt::create_control_repo_from_production_env ctrl_repo_path=<value>
+bolt task run --nodes <node-name> gplt::create_control_repo_from_production_env ctrl_repo_path=<value> code_source_path=<value> code_source_url=<value> code_source_branch=<value>
 
 PARAMETERS:
-- ctrl_repo_path: String[1]
-    The fully qualified path to be used for creating the control repo
+- ctrl_repo_path: Optional[String[1]]
+    The fully qualified path where the control repo will be created
+- code_source_path: Optional[String[1]]
+    The fully qualified path to the source code
+- code_source_url: Optional[String[1]]
+    The URL to a public github repo that contains the source code
+- code_source_branch: Optional[String[1]]
+    The branch of the public github repo in code_source_url to use as production
 ```
 
 Typical usage on an ABS instance would use the following bolt pattern:
@@ -39,5 +45,5 @@ bolt task run \
   --private-key ~/.ssh/id_rsa-acceptance \
   --nodes ip-10-xx-xx-xx.amz-dev.puppet.net \
   gplt::create_control_repo_from_production_env \
-  ctrl_repo_path="/opt/puppet/control-repo.git"
+  code_source_url="https://github.com/puppetlabs/puppetlabs-pe_perf_control_repo.git"
 ```


### PR DESCRIPTION
updated the gplt::create_control_repo_from_production_env task to be able to accept a public github repo to be the source of the local repo it creates.  Also accepts a branch, which it will convert to the production branch in the new repo.
This allows for easy creation of a repo to use with the simulation from any branch of any public control repo.
The intent is to then point code manager at this repo as part of setup.

updated docs on the task as well