### PR TITLE
(SLV-433) Update for foss compatability

### DIFF
--- a/NEW_README.md
+++ b/NEW_README.md
@@ -247,6 +247,10 @@ After each iteration completes the results are checked and if a KO is found the 
 The results for each iteration are copied to a folder named 'PERF_SCALE{$SCALE_TIMESTAMP}' in `results/scale`.
 The sub-directory for each iteration is named based on the scenario, iteration, and number of agents.
 
+As with the Apples to Apples performance tests, to run against a FOSS build, set
+`BEAKER_INSTALL_TYPE=foss` and provide values for `PACKAGE_BUILD_VERSION` and
+`PUPPET_AGENT_VERSION` environment variables.
+
 In order to execute a Scale performance run:
 
 ### Provision, tune, run

--- a/config/beaker_hosts/foss-perf-test.cfg
+++ b/config/beaker_hosts/foss-perf-test.cfg
@@ -1,1 +1,57 @@
-perf-test.cfg
+default_vmname: &default_vmname centos-7-x86_64
+default_platform: &default_platform el-7-x86_64
+default_snapshot: &default_snapshot pe
+
+:root_keys: true
+
+:answers:
+  :console_admin_password: puppetlabs
+:department: eso-dept
+:disable_iptables: false
+:project: scale-testing
+
+:host_tags:
+  :run_type: persistent
+  :sub-proj: hoyt
+  :lifetime: 16w
+
+scale:
+  num_nonroot_users: 1
+  facts_per_agent: 300
+  percent_facts_to_change: 0
+  module_roles: 150
+  static_files: 500
+  dynamic_files: 0
+  environments: 100
+
+HOSTS:
+  perf-test-mom:
+    amisize: c4.2xlarge
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 300
+    template: *default_vmname
+    ssh:
+    roles:
+      - master
+      - default
+      - certificate_authority
+      - database
+      - dashboard
+  perf-test-metrics:
+    amisize: c4.large
+    hypervisor: abs
+    platform: *default_platform
+    snapshot: *default_snapshot
+    volume_size: 50
+    template: *default_vmname
+    ssh:
+    ports:
+      - 2003
+      - 7777
+      - 80
+    roles:
+      - metric
+      - frictionless
+      - agent

--- a/config/beaker_hosts/foss-perf-test.cfg
+++ b/config/beaker_hosts/foss-perf-test.cfg
@@ -26,7 +26,7 @@ scale:
 
 HOSTS:
   perf-test-mom:
-    amisize: c4.2xlarge
+    amisize: c5.2xlarge
     hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot
@@ -40,7 +40,7 @@ HOSTS:
       - database
       - dashboard
   perf-test-metrics:
-    amisize: c4.large
+    amisize: c5.2xlarge
     hypervisor: abs
     platform: *default_platform
     snapshot: *default_snapshot

--- a/rakefile
+++ b/rakefile
@@ -125,7 +125,6 @@ rototiller_task :performance_without_provision do |t|
   t.add_env({:name => 'PUPPET_GATLING_SCENARIO', :default => 'ApplesToApples.json'})
   t.add_env({:name => 'BEAKER_TESTS', :default => 'tests/ApplesToApples.rb'})
   t.add_env({:name => 'BEAKER_POST_SUITE', :default => ''})
-  t.add_env({:name => 'PUPPET_SERVER_SERVICE_NAME', :default => 'pe-puppetserver'})
   t.add_env({:name => 'SUT_ARCHIVE_FILES', :default => ''})
   t.add_env({:name => 'PACKAGE_BUILD_VERSION', :default => 'latest'}) if ENV['BEAKER_INSTALL_TYPE'] == 'foss'
   t.add_env({:name => 'PUPPET_AGENT_VERSION', :default => 'latest'}) if ENV['BEAKER_INSTALL_TYPE'] == 'foss'

--- a/setup/helpers/gatling_config_helper.rb
+++ b/setup/helpers/gatling_config_helper.rb
@@ -61,7 +61,7 @@ def parse_scenario_file(scenario_file)
 end
 
 def get_puppet_server_service_name_from_env()
-  ENV['PUPPET_SERVER_SERVICE_NAME']
+  ENV['BEAKER_INSTALL_TYPE'] == 'pe' ? 'pe-puppetserver' : 'puppetserver'
 end
 
 def get_puppet_server_java_args_from_env()

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -552,8 +552,8 @@ module PerfHelper
       on metric, 'yum -y install \
                          java-1.8.0-openjdk java-1.8.0-openjdk-devel xauth'
     end
-    step "install scala build tool (sbt)" do
-      on metric, "rpm -ivh http://dl.bintray.com/sbt/rpm/sbt-0.13.7.rpm"
+    step 'install scala build tool (sbt)' do
+      on metric, 'yum localinstall -y http://dl.bintray.com/sbt/rpm/sbt-0.13.7.rpm'
     end
     step "create key for metrics to talk to primary master" do
       on metric, 'yes | ssh-keygen -q -t rsa -b 4096 \

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -659,12 +659,5 @@ module PerfHelper
     create_remote_file(master, custom_fact_path, custom_fact_content)
     on(master, 'puppet apply -e "include puppet_metrics_collector"', :acceptable_exit_codes => [0,2])
   end
-
-  def setup_puppet_metrics_collector_for_foss
-    custom_fact_content = 'pe_server_version=""'
-    custom_fact_path = '/opt/puppetlabs/facter/facts.d/custom.txt'
-    create_remote_file(master, custom_fact_path, custom_fact_content)
-    on(master, 'puppet apply -e "include puppet_metrics_collector"', :acceptable_exit_codes => [0,2])
-  end
 end
 # rubocop:enable Style/SpecialGlobalVars

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -257,7 +257,7 @@ module PerfHelper
     step "Install Puppet Agent." do
       install_package agent, "puppet-agent"
       on(agent, "puppet agent -t --server #{master}")
-      on(master, "puppet config remove --section master autosign")
+      on(master, "puppet config delete --section master autosign")
     end
   end
 
@@ -301,8 +301,8 @@ module PerfHelper
   end
 
   def r10k_deploy
-    bin = ENV["PUPPET_BIN_DIR"]
-    r10k_version = ENV["PUPPET_R10K_VERSION"]
+    bin = ENV['PUPPET_BIN_DIR']
+    r10k_version = ENV['PUPPET_R10K_VERSION'] || '3.0.0'
 
     step "Install and configure r10k" do
       r10k_config = get_r10k_config_from_env

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -302,7 +302,7 @@ module PerfHelper
 
   def r10k_deploy
     bin = ENV['PUPPET_BIN_DIR']
-    r10k_version = ENV['PUPPET_R10K_VERSION'] || '3.0.0'
+    r10k_version = ENV['PUPPET_R10K_VERSION'] || '3.2.0'
 
     step "Install and configure r10k" do
       r10k_config = get_r10k_config_from_env

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -652,5 +652,12 @@ module PerfHelper
       "classes" => { "role::puppet_master" => nil }
     )
   end
+
+  def setup_puppet_metrics_collector_for_foss
+    custom_fact_content = 'pe_server_version=""'
+    custom_fact_path = '/opt/puppetlabs/facter/facts.d/custom.txt'
+    create_remote_file(master, custom_fact_path, custom_fact_content)
+    on(master, 'puppet apply -e "include puppet_metrics_collector"', :acceptable_exit_codes => [0,2])
+  end
 end
 # rubocop:enable Style/SpecialGlobalVars

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -659,5 +659,12 @@ module PerfHelper
     create_remote_file(master, custom_fact_path, custom_fact_content)
     on(master, 'puppet apply -e "include puppet_metrics_collector"', :acceptable_exit_codes => [0,2])
   end
+
+  def setup_puppet_metrics_collector_for_foss
+    custom_fact_content = 'pe_server_version=""'
+    custom_fact_path = '/opt/puppetlabs/facter/facts.d/custom.txt'
+    create_remote_file(master, custom_fact_path, custom_fact_content)
+    on(master, 'puppet apply -e "include puppet_metrics_collector"', :acceptable_exit_codes => [0,2])
+  end
 end
 # rubocop:enable Style/SpecialGlobalVars

--- a/setup/install_gatling/30_classification/50_classify_nodes_via_site_pp.rb
+++ b/setup/install_gatling/30_classification/50_classify_nodes_via_site_pp.rb
@@ -1,5 +1,23 @@
-test_name "Classify Puppet agents on master"
-skip_test 'Installing PE, not FOSS' unless ENV['BEAKER_INSTALL_TYPE'] == 'foss'
+test_name "Classify Puppet agents on master" do
+  skip_test "Only runs on FOSS" unless ENV["BEAKER_INSTALL_TYPE"] == "foss"
 
-classify_foss_nodes(master)
-setup_puppet_metrics_collector_for_foss
+  # Remove classifier data sources from the hiera configs on foss
+  hiera_configs = []
+
+  hc_global = puppet_config(master, "hiera_config")
+  hiera_configs << hc_global if master.file_exist?(hc_global)
+
+  env_path = puppet_config(master, "environmentpath")
+  env = puppet_config(master, "environment")
+  hc_env = [env_path, env, "hiera.yaml"].join("/")
+  hiera_configs << hc_env if master.file_exist?(hc_env)
+
+  hiera_configs.each do |hiera_config|
+    config = YAML.load(on(master, "cat #{hiera_config}").stdout)
+    config["hierarchy"].reject! { |backend| backend["name"] =~ /Classifier/i }
+    create_remote_file(master, hiera_config, config.to_yaml)
+  end
+
+  classify_foss_nodes(master)
+  setup_puppet_metrics_collector_for_foss
+end

--- a/setup/install_gatling/30_classification/50_classify_nodes_via_site_pp.rb
+++ b/setup/install_gatling/30_classification/50_classify_nodes_via_site_pp.rb
@@ -2,3 +2,4 @@ test_name "Classify Puppet agents on master"
 skip_test 'Installing PE, not FOSS' unless ENV['BEAKER_INSTALL_TYPE'] == 'foss'
 
 classify_foss_nodes(master)
+setup_puppet_metrics_collector_for_foss

--- a/setup/install_gatling/40_post_install/60_restart_server.rb
+++ b/setup/install_gatling/40_post_install/60_restart_server.rb
@@ -1,6 +1,10 @@
 test_name 'Restart puppet master to pick up configuration changes'
 
-service_name = get_puppet_server_service_name_from_env()
+if %w(foss aio).include?(ENV['BEAKER_INSTALL_TYPE'])
+  service_name = 'puppetserver'
+elsif ENV['BEAKER_INSTALL_TYPE'] == 'pe'
+  service_name = 'pe-puppetserver'
+end
 
 on(master, "service #{service_name} reload")
 

--- a/setup/install_gatling/40_post_install/60_restart_server.rb
+++ b/setup/install_gatling/40_post_install/60_restart_server.rb
@@ -1,10 +1,6 @@
 test_name 'Restart puppet master to pick up configuration changes'
 
-if %w(foss aio).include?(ENV['BEAKER_INSTALL_TYPE'])
-  service_name = 'puppetserver'
-elsif ENV['BEAKER_INSTALL_TYPE'] == 'pe'
-  service_name = 'pe-puppetserver'
-end
+service_name = get_puppet_server_service_name_from_env()
 
 on(master, "service #{service_name} reload")
 

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -257,33 +257,6 @@ module PerfRunHelper
     return output
   end
 
-  # Restart the pe-puppetserver service
-  #
-  # @author Bill Claytor
-  #
-  # @return [void]
-  #
-  # @example
-  #   restart_puppetserver
-  #
-  def restart_puppetserver
-    if %w(foss aio).include?(ENV['BEAKER_INSTALL_TYPE'])
-      service = 'puppetserver'
-    else
-      service = 'pe-puppetserver'
-    end
-
-    puts "Restarting #{service} service..."
-    puts
-
-    on master, "service #{service} restart"
-
-    puts "Sleeping..."
-    puts
-
-    sleep 60
-  end
-
   # Purge the puppet-metrics-collector log files for each service
   #
   # @author Bill Claytor

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -11,7 +11,7 @@ module PerfRunHelper
   SCALE_ITERATIONS = 15
   SCALE_INCREMENT = 100
   SCALE_MAX_ALLOWED_KO = 10
-  PUPPET_METRICS_COLLECTOR_SERVICES = %w[orchestrator puppetdb puppetserver]
+  PUPPET_METRICS_COLLECTOR_SERVICES = ENV['BEAKER_INSTALL_TYPE'] == 'pe' ? %w[orchestrator puppetdb puppetserver] : ['puppetserver']
 
   def perf_setup(gatling_scenario, simulation_id, gatlingassertions)
     @atop_session_timestamp = start_monitoring(master, gatling_scenario, true, 30)
@@ -143,8 +143,10 @@ module PerfRunHelper
     # create scale results env file
     create_scale_results_env_file(scale_results_parent_dir)
 
-    # create current pe tune file
-    create_pe_tune_file(scale_results_parent_dir)
+    unless %w(foss aio).include?(ENV['BEAKER_INSTALL_TYPE'])
+      # create current pe tune file
+      create_pe_tune_file(scale_results_parent_dir)
+    end
   end
 
   # Create the CSV file for the scale run and add the headings row
@@ -253,6 +255,33 @@ module PerfRunHelper
     puts
 
     return output
+  end
+
+  # Restart the pe-puppetserver service
+  #
+  # @author Bill Claytor
+  #
+  # @return [void]
+  #
+  # @example
+  #   restart_puppetserver
+  #
+  def restart_puppetserver
+    if %w(foss aio).include?(ENV['BEAKER_INSTALL_TYPE'])
+      service = 'puppetserver'
+    else
+      service = 'pe-puppetserver'
+    end
+
+    puts "Restarting #{service} service..."
+    puts
+
+    on master, "service #{service} restart"
+
+    puts "Sleeping..."
+    puts
+
+    sleep 60
   end
 
   # Purge the puppet-metrics-collector log files for each service


### PR DESCRIPTION
This PR provides updates to make gplt compatible with a foss deployment.  These changes have been successfully tested using the [pe_perf_control_repo](https://github.com/puppetlabs/puppetlabs-pe_perf_control_repo).  The [legacy control repo](https://github.com/puppetlabs/puppetlabs-puppetserver_perf_control) is not compatible because its configuration files are sequestered in a "root_files" directory, so the hiera configuration necessary to pass perf testing is not present when that repo is used.