### PR TITLE
(SLV-452) Add .travis.yaml for PR spec testing

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,16 @@
+language: ruby
+sudo: false
+bundler_args: --jobs 4 --retry 2 --without packaging documentation
+before_install:
+  - gem update --system && gem install bundler --no-document
+script:
+  - "bundle exec $CHECK"
+notifications:
+  email: false
+rvm:
+  - 2.6.2
+
+env:
+  matrix:
+    - "CHECK=rspec spec --color"
+    # - "CHECK=rubocop"


### PR DESCRIPTION
This commit adds a `.travis.yaml` file to configure travis-ci to
execute spec tests for this repo.