### PR TITLE
(maint) Removed erroneous " from tune commit

### DIFF
--- a/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
+++ b/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
@@ -39,7 +39,7 @@ test_name "Run puppet infrastructure tune" do # rubocop:disable Metrics/BlockLen
       --cert $(puppet config print hostcert)
       --key $(puppet config print hostprivkey)
       --cacert $(puppet config print localcacert)
-      https://$(hostname):8140/file-sync/v1/commit"
+      https://$(hostname):8140/file-sync/v1/commit
     ].join(" ")
     on master, commit
 


### PR DESCRIPTION
After the recent rubocop update running the scale test setup fails when attempting to apply the tune with the following error:
```
   " >> /etc/puppetlabs/code-staging/environments/production/hieradata/common.yaml
    
    ip-10-227-0-238.amz-dev.puppet.net (perf-test-mom) executed in 0.07 seconds
Committing...

    
    ip-10-227-0-238.amz-dev.puppet.net (perf-test-mom) 15:37:02$ curl --request POST --header "Content-Type: application/json" --data '{"commit-all": true}' --cert $(p
uppet config print hostcert) --key $(puppet config print hostprivkey) --cacert $(puppet config print localcacert) https://$(hostname):8140/file-sync/v1/commit"
      bash: -c: line 0: unexpected EOF while looking for matching `"'
      bash: -c: line 1: syntax error: unexpected end of file
```

This is due to an erroneous '"' at the end of the last line. Removing this allows the tune step to complete successfully.