### PR TITLE
(SLV-504) Update the provision_pe_xl_nodes script to use OptionParser

### DIFF
--- a/docs/abs_utils.md
+++ b/docs/abs_utils.md
@@ -34,7 +34,7 @@ The script accepts the following options which override the default values:
     -h, --help                       Display the help text
         --noop                       Run in no-op mode
         --test                       Use test data rather than provisioning hosts
-        --ha                         Specifies that the environment should be set up for HA
+        --ha                         Deploy HA environment
     -i, --id ID                      The value for the AWS 'id' tag
     -o, --output_dir DIR             The directory where the Bolt files should be written
     -v, --pe_version VERSION         The PE version to install
@@ -45,6 +45,7 @@ The script accepts the following options which override the default values:
 #### Default values
 When run without specifying any options the script uses the following default values:
 
+* HA (--ha): false
 * AWS_TAG_ID (-i, --id): slv
 * OUTPUT_DIR (-o, --output_dir): ./
 * PE_VERSION (-v, --pe_version): 2019.1.0
@@ -60,6 +61,24 @@ Run the script from the `gatling-puppet-load-test` directory:
 bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb
 ```
 
+##### id
+Specify the value for the AWS 'id' tag (you will almost always want to specify a value to identify a set of hosts):
+```
+bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb -i non_ha_example
+```
+
+##### ha (and id)
+Deploy HA environment (false unless specified):
+```
+bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --ha -i ha_example
+```
+
+##### pe_version
+Specify the PE version to install:
+```
+bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb -v 2018.1.3
+```
+
 ##### noop
 This option enables no-op mode which provides output but does not provision hosts or create files.
 ```
@@ -70,18 +89,6 @@ bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --noop
 This option enables test mode which uses the included test host arrays to generate the Bolt files and verifies the output.
 ```
 bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --test
-```
-
-##### id
-Specify a unique ID for each set of hosts:
-```
-bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb -i example
-```
-
-##### pe_version
-Specify the PE version to install:
-```
-bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb -v 2018.1.3
 ```
 
 ##### all options

--- a/docs/abs_utils.md
+++ b/docs/abs_utils.md
@@ -57,41 +57,46 @@ When run without specifying any options the script uses the following default va
 Run the script from the `gatling-puppet-load-test` directory:
 
 ##### Default options
+Running the script without specifying any options uses the default values listed above.
 ```
 bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb
 ```
 
-##### id
-Specify the value for the AWS 'id' tag (you will almost always want to specify a value to identify a set of hosts):
+##### Common usage scenarios
+
+###### id
+The `id` parameter specifies the value for the AWS 'id' tag. 
+You will almost always want to specify a value to identify a set of hosts.
+Typically this will be a variation of the JIRA ticket number; for example:
 ```
-bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb -i non_ha_example
+bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb -i slv-504-no-ha
 ```
 
-##### ha (and id)
+###### ha (and id)
 Deploy HA environment (false unless specified):
 ```
-bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --ha -i ha_example
+bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --ha -i slv-504-ha
 ```
 
-##### pe_version
+###### pe_version
 Specify the PE version to install:
 ```
 bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb -v 2018.1.3
 ```
 
-##### noop
+###### noop
 This option enables no-op mode which provides output but does not provision hosts or create files.
 ```
 bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --noop
 ```
 
-##### test
+###### test
 This option enables test mode which uses the included test host arrays to generate the Bolt files and verifies the output.
 ```
 bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --test
 ```
 
-##### all options
+###### all options
 Specify every option:
 ```
 test.user:~/gatling-puppet-load-test> bundle exec ruby ./util/abs/provision_pe_xl_nodes.rb --noop --ha -i example -o ~/tmp -v 2018.1.3 -t c5.4xlarge -s 120

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -29,6 +29,10 @@ DESCRIPTION
 
 options = {}
 
+# Note: looks like 'Store options to a Hash' doesn't work in Ruby 2.3.0.
+# https://ruby-doc.org/stdlib-2.6.3/libdoc/optparse/rdoc/OptionParser.html
+#  `end.parse!(into: options)`
+# TODO: update to use '(into: options)' after Ruby update
 # TODO: error when invalid options are specified
 # TODO: re-order the options?
 OptionParser.new do |opts|
@@ -47,20 +51,33 @@ OptionParser.new do |opts|
   # error when both are specified?
   #
   # omitted short versions to avoid collisions
-  opts.on("--noop", "Run in no-op mode")
-  opts.on("--test", "Use test data rather than provisioning hosts")
+  opts.on("--noop", "Run in no-op mode") { options[:noop] = true }
+  opts.on("--test", "Use test data rather than provisioning hosts") { options[:test] = true }
 
   # TODO: this description seems awkward; suggestions?
-  opts.on("--ha", "Specifies that the environment should be set up for HA")
+  opts.on("--ha", "Specifies that the environment should be set up for HA") { options[:ha] = true }
 
-  opts.on("-i", "--id ID", String, "The value for the AWS 'id' tag")
+  opts.on("-i", "--id ID", String, "The value for the AWS 'id' tag") do |id|
+    options[:id] = id
+  end
 
   # TODO: verify these
-  opts.on("-o", "--output_dir DIR", String, "The directory where the Bolt files should be written")
-  opts.on("-v", "--pe_version VERSION", String, "The PE version to install")
-  opts.on("-t", "--type TYPE", String, "The AWS EC2 instance type to provision")
-  opts.on("-s", "--size SIZE", Integer, "The AWS EC2 volume size to specify")
-end.parse!(into: options)
+  opts.on("-o", "--output_dir DIR", String, "The directory where the Bolt files should be written") do |output_dir|
+    options[:output_dir] = output_dir
+  end
+
+  opts.on("-v", "--pe_version VERSION", String, "The PE version to install") do |pe_version|
+    options[:pe_version] = pe_version
+  end
+
+  opts.on("-t", "--type TYPE", String, "The AWS EC2 instance type to provision") do |type|
+    options[:type] = type
+  end
+
+  opts.on("-s", "--size SIZE", Integer, "The AWS EC2 volume size to specify") do |size|
+    options[:size] = size
+  end
+end.parse!
 
 ROLES_CORE = %w[master
                 puppet_db

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -299,6 +299,8 @@ def check_nodes_yaml(file)
   puts "Verifying YAML..."
   nodes = yaml["groups"][0]["nodes"]
 
+  raise "Invalid pe_xl inventory file; must contain non-empty `nodes` element" if nodes.nil? || nodes.empty?
+
   puts
   puts "Verified parameter 'nodes':"
   puts nodes
@@ -369,8 +371,15 @@ def check_params_json(file)
   puts "Verifying JSON..."
   install = json["install"]
 
+  unless [true, false].include? install
+    raise "Invalid pe_xl parameter file; must contain `install` parameter specifying either `true` or `false`"
+  end
+
   puts "Verified parameter 'install': #{install}"
   puts
 end
 
-provision_pe_xl_nodes
+# provision_pe_xl_nodes
+
+check_params_json("params.json")
+check_nodes_yaml("nodes.yaml")

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -377,7 +377,5 @@ def check_params_json(file)
   puts
 end
 
-# provision_pe_xl_nodes
+provision_pe_xl_nodes
 
-check_params_json("params.json")
-check_nodes_yaml("nodes.yaml")

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -8,6 +8,13 @@ require "json"
 require "./setup/helpers/abs_helper.rb"
 include AbsHelper # rubocop:disable Style/MixinUsage
 
+DEFAULT_HA = false
+DEFAULT_AWS_TAG_ID = "slv"
+DEFAULT_OUTPUT_DIR = "./"
+DEFAULT_PE_VERSION = "2019.1.0"
+DEFAULT_AWS_INSTANCE_TYPE = "c5.2xlarge"
+DEFAULT_AWS_VOLUME_SIZE = "80"
+
 DESCRIPTION = <<~DESCRIPTION
   This script was created to assist in working with the pe_xl module (https://github.com/reidmv/reidmv-pe_xl).
   It provisions the nodes used by the module and generates the Bolt inventory and parameter files populated with the provisioned hosts.
@@ -27,6 +34,18 @@ DESCRIPTION = <<~DESCRIPTION
 
 DESCRIPTION
 
+DEFAULTS = <<~DEFAULTS
+
+  The following defaults values are used if the options are not specified:
+  * HA (--ha): #{DEFAULT_HA}
+  * AWS_TAG_ID (-i, --id): #{DEFAULT_AWS_TAG_ID}
+  * OUTPUT_DIR (-o, --output_dir): #{DEFAULT_OUTPUT_DIR}
+  * PE_VERSION (-v, --pe_version): #{DEFAULT_PE_VERSION}
+  * AWS_INSTANCE_TYPE (-t, --type): #{DEFAULT_AWS_INSTANCE_TYPE}
+  * AWS_VOLUME_SIZE (-s, --size): #{DEFAULT_AWS_VOLUME_SIZE}
+
+DEFAULTS
+
 options = {}
 
 # Note: looks like 'Store options to a Hash' doesn't work in Ruby 2.3.0.
@@ -41,7 +60,7 @@ OptionParser.new do |opts|
   opts.on("-h", "--help", "Display the help text") do
     puts DESCRIPTION
     puts opts
-    puts
+    puts DEFAULTS
     exit
   end
 
@@ -90,7 +109,7 @@ if options[:ha]
   HA = true
   ROLES = ROLES_CORE + ROLES_HA
 else
-  HA = false
+  HA = DEFAULT_HA
   ROLES = ROLES_CORE
 end
 
@@ -98,13 +117,13 @@ NOOP = options[:noop] || false
 TEST = options[:test] || false
 PROVISIONING_TXT = NOOP || TEST ? "Would have provisioned" : "Provisioning"
 
-AWS_TAG_ID = options[:id] || "slv"
-OUTPUT_DIR = options[:output_dir] || "./"
-PE_VERSION = options[:pe_version] || "2019.1.0"
+AWS_TAG_ID = options[:id] || DEFAULT_AWS_TAG_ID
+OUTPUT_DIR = options[:output_dir] || DEFAULT_OUTPUT_DIR
+PE_VERSION = options[:pe_version] || DEFAULT_PE_VERSION
 
 # TODO: allow different type / size for each node?
-AWS_INSTANCE_TYPE = options[:type] || "c5.2xlarge"
-AWS_VOLUME_SIZE = options[:size] || "80"
+AWS_INSTANCE_TYPE = options[:type] || DEFAULT_AWS_INSTANCE_TYPE
+AWS_VOLUME_SIZE = options[:size] || DEFAULT_AWS_VOLUME_SIZE
 
 # TODO: move to spec when test cases are implemented
 # for now this allows testing of the create_pe_xl_bolt_files method without provisioning

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# TODO: make this a Bolt task once abs_helper is available as a gem
+
 require "optparse"
 require "yaml"
 require "json"

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -54,8 +54,7 @@ OptionParser.new do |opts|
   opts.on("--noop", "Run in no-op mode") { options[:noop] = true }
   opts.on("--test", "Use test data rather than provisioning hosts") { options[:test] = true }
 
-  # TODO: this description seems awkward; suggestions?
-  opts.on("--ha", "Specifies that the environment should be set up for HA") { options[:ha] = true }
+  opts.on("--ha", "Deploy HA environment") { options[:ha] = true }
 
   opts.on("-i", "--id ID", String, "The value for the AWS 'id' tag") do |id|
     options[:id] = id
@@ -135,7 +134,6 @@ NODES_YAML = <<~NODES_YAML
 NODES_YAML
 
 # TODO: update to use variables / symbols for all parameter values?
-# TODO: should this use `<<-` vs `<<~`?
 PARAMS_JSON = <<~PARAMS_JSON
   {
     "install": true,

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -378,4 +378,3 @@ def check_params_json(file)
 end
 
 provision_pe_xl_nodes
-


### PR DESCRIPTION
This update to the provision_pe_xl_nodes script adds the ability to specify options via OptionParser:
```
    -h, --help                       Display the help text
        --noop                       Run in no-op mode
        --test                       Use test data rather than provisioning hosts
        --ha                         Specifies that the environment should be set up for HA
    -i, --id ID                      The value for the AWS 'id' tag
    -o, --output_dir DIR             The directory where the Bolt files should be written
    -v, --pe_version VERSION         The PE version to install
    -t, --type TYPE                  The AWS EC2 instance type to provision
    -s, --size SIZE                  The AWS EC2 volume size to specify
```

Additional updates: 
- Updated `check_nodes_yaml` with more output
- Created `check_params_json`
- Updated `create_nodes_yaml` and `create_params_json` to call the corresponding 'check' method when running in test mode
 - Refactoring

Note:  Resolved the issue with OptionParser on Ruby 2.3.0 by not using the 'store options to a hash' feature:
https://ruby-doc.org/stdlib-2.6.3/libdoc/optparse/rdoc/OptionParser.html#class-OptionParser-label-Store+options+to+a+Hash
`end.parse!(into: options)`

~~TODO: Update abs_utils.md~~