### PR TITLE
(SLV-526) Update spec tests to use simplecov for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ results
 
 # Bolt
 .rerun.json
+
+# simplecov
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ gem "rspec", "~>3.0"
 gem "rubocop", "~> 0.67"
 gem "scooter", "~>4.3"
 
+group :test do
+  gem "simplecov", "~> 0.17.0", require: false
+end
+
 eval(File.read("#{__FILE__}.local"), binding) if File.exist? "#{__FILE__}.local" # rubocop:disable Security/Eval
 
 gem "google-api-client", "~> 0.19.0"

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 
-require "./setup/helpers/abs_helper"
+require "spec_helper"
 require "net/ssh/errors"
 
 class AbsHelperClass

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -2,8 +2,7 @@
 
 # rubocop:disable Metrics/BlockLength
 
-require "rspec"
-require File.expand_path("../../../setup/helpers/perf_helper", __dir__)
+require "spec_helper"
 
 class PerfHelperClass
   include PerfHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,17 +15,6 @@ Dir["./setup/helpers/*.rb"].each { |file| require file }
 # test helpers
 Dir["./tests/helpers/*.rb"].each { |file| require file }
 
-RSpec.configure do |c|
-end
-
-RSpec.shared_context "case_info_lets" do
-  let(:something) { "some value" }
-end
-
-def do_something_helpful(value)
-  puts "Do something with #{value}"
-end
-
 SimpleCov.at_exit do
   SimpleCov.result.format!
   SimpleCov.minimum_coverage 40

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "simplecov"
+require "rspec"
+
+SimpleCov.start do
+  add_filter "/spec/"
+  add_group "Setup helpers", "setup/helpers"
+  add_group "Test helpers", "tests/helpers"
+end
+
+# setup helpers
+Dir["./setup/helpers/*.rb"].each { |file| require file }
+
+# test helpers
+Dir["./tests/helpers/*.rb"].each { |file| require file }
+
+RSpec.configure do |c|
+end
+
+RSpec.shared_context "case_info_lets" do
+  let(:something) { "some value" }
+end
+
+def do_something_helpful(value)
+  puts "Do something with #{value}"
+end
+
+SimpleCov.at_exit do
+  SimpleCov.result.format!
+  SimpleCov.minimum_coverage 40
+end

--- a/spec/tests/helpers/perf_run_helper_spec.rb
+++ b/spec/tests/helpers/perf_run_helper_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "rspec"
-require File.expand_path("../../../tests/helpers/perf_run_helper", __dir__)
+require "spec_helper"
 require "minitest/assertions"
 
 class PerfRunHelperClass


### PR DESCRIPTION
This update adds simplecov for spec test code coverage. A `spec_helper.rb` file has been added which configures simplecov and requires the files that should be covered by the spec tests. This currently includes `setup/helpers` and `tests/helpers`. The spec test files have been updated to require `spec_helper` instead of the files under test. 

After running the spec tests via `bundle exec rake spec` the coverage report will be displayed in the results:
```
Coverage report generated for Unit Tests to /Users/test.user/gatling-puppet-load-test/coverage. 515 / 1185 LOC (43.46%) covered.
```
An HTML report is generated at `./coverage/index.html`. Based on the current code coverage the threshold has been set to 40%.
