### PR TITLE
(SLV-470) Update common.yaml path in 10_puppet_infrastructure_tune

### DIFF
--- a/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
+++ b/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
@@ -3,7 +3,7 @@
 test_name "Run puppet infrastructure tune" do # rubocop:disable Metrics/BlockLength
   def puppet_infrastructure_tune
     base_tune_command = "puppet infrastructure tune"
-    common_yaml_path = "/etc/puppetlabs/code-staging/environments/production/hieradata/common.yaml"
+    common_yaml_path = "/etc/puppetlabs/code-staging/environments/production/data/common.yaml"
     tune_output_dir = "tune_output"
     tune_output_path = "#{tune_output_dir}/nodes/#{master.hostname}.yaml"
 


### PR DESCRIPTION
This update replaces `heiradata` with `data` in the common.yaml path (`common_yaml_path = "/etc/puppetlabs/code-staging/environments/production/data/common.yaml"`) per the following control repo update:
https://github.com/puppetlabs/puppetlabs-pe_perf_control_repo/pull/9
