### PR TITLE
(SLV-466) Add util/tune/current_settings.rb script

### DIFF
--- a/docs/tune_utils.md
+++ b/docs/tune_utils.md
@@ -1,0 +1,117 @@
+# Utility scripts for use in tuning PE
+
+## Background
+The [`pe_tune`](https://github.com/tkishel/pe_tune) module "provides a Puppet subcommand puppet pe tune that outputs optimized settings for Puppet Enterprise services based upon available system resources.
+Puppet Enterprise 2018.1.3 and newer includes the functionality of this module via the puppet infrastructure tune subcommand. "
+
+## Scripts
+The following Ruby scripts have been added to the `utils/tune` directory to assist in tuning PE:
+
+### current_settings.rb
+This script returns a JSON array of the current values for the settings adjusted by the 'pe_tune' module:
+  https://github.com/tkishel/pe_tune
+
+The list of settings can be found here:
+  https://github.com/tkishel/pe_tune/blob/79d5db4ddc7bbf3b1c9aefcdfab7f1dc9b3c3f4e/lib/puppet_x/puppetlabs/tune.rb#L19
+
+#### Usage
+
+##### Running locally on the master
+The script can be copied to the master and run there:
+```
+[root@ip-10-227-0-141 ~]# ruby current_settings.rb
+[
+  {
+    "puppet_enterprise::master::puppetserver::jruby_max_active_instances": "5"
+  },
+  {
+    "puppet_enterprise::master::puppetserver::reserved_code_cache": "640m"
+  },
+  {
+    "puppet_enterprise::profile::console::java_args": "-Xmx768m -Xms768m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/console-services/console-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+  },
+  {
+    "puppet_enterprise::profile::database::shared_buffers": "3571MB"
+  },
+  {
+    "puppet_enterprise::profile::database::autovacuum_max_workers": "3"
+  },
+  {
+    "puppet_enterprise::profile::database::autovacuum_work_mem": "637MB"
+  },
+  {
+    "puppet_enterprise::profile::database::maintenance_work_mem": "1913MB"
+  },
+  {
+    "puppet_enterprise::profile::database::max_connections": "400"
+  },
+  {
+    "puppet_enterprise::profile::database::work_mem": "4MB"
+  },
+  {
+    "puppet_enterprise::profile::master::java_args": "-Xms3840m -Xmx3840m -Djava.io.tmpdir=/opt/puppetlabs/server/apps/puppetserver/tmp -XX:ReservedCodeCacheSize=640m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetserver/puppetserver_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+  },
+  {
+    "puppet_enterprise::profile::orchestrator::java_args": "-Xmx768m -Xms768m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/orchestration-services/orchestration-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+  },
+  {
+    "puppet_enterprise::profile::puppetdb::java_args": "-Xmx1071m -Xms1071m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetdb/puppetdb_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+  },
+  {
+    "puppet_enterprise::puppetdb::command_processing_threads": "2"
+  }
+]
+
+```
+
+##### Running via Bolt
+The script can also be run via Bolt:
+```
+test.user:~/gatling-puppet-load-test> bolt script run util/tune/current_settings.rb --user root --nodes 10.227.0.141
+Started on 10.227.0.141...
+Finished on 10.227.0.141:
+  STDOUT:
+    [
+      {
+        "puppet_enterprise::master::puppetserver::jruby_max_active_instances": "5"
+      },
+      {
+        "puppet_enterprise::master::puppetserver::reserved_code_cache": "640m"
+      },
+      {
+        "puppet_enterprise::profile::console::java_args": "-Xmx768m -Xms768m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/console-services/console-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+      },
+      {
+        "puppet_enterprise::profile::database::shared_buffers": "3571MB"
+      },
+      {
+        "puppet_enterprise::profile::database::autovacuum_max_workers": "3"
+      },
+      {
+        "puppet_enterprise::profile::database::autovacuum_work_mem": "637MB"
+      },
+      {
+        "puppet_enterprise::profile::database::maintenance_work_mem": "1913MB"
+      },
+      {
+        "puppet_enterprise::profile::database::max_connections": "400"
+      },
+      {
+        "puppet_enterprise::profile::database::work_mem": "4MB"
+      },
+      {
+        "puppet_enterprise::profile::master::java_args": "-Xms3840m -Xmx3840m -Djava.io.tmpdir=/opt/puppetlabs/server/apps/puppetserver/tmp -XX:ReservedCodeCacheSize=640m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetserver/puppetserver_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+      },
+      {
+        "puppet_enterprise::profile::orchestrator::java_args": "-Xmx768m -Xms768m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/orchestration-services/orchestration-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+      },
+      {
+        "puppet_enterprise::profile::puppetdb::java_args": "-Xmx1071m -Xms1071m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetdb/puppetdb_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
+      },
+      {
+        "puppet_enterprise::puppetdb::command_processing_threads": "2"
+      }
+    ]
+Successful on 1 node: 10.227.0.141
+Ran on 1 node in 2.89 seconds
+```

--- a/util/tune/current_settings.rb
+++ b/util/tune/current_settings.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "json"
+
+NA = "N/A"
+PE_PUPPET_SERVER_CONF = "/etc/puppetlabs/puppetserver/conf.d/pe-puppet-server.conf"
+POSTGRES_CONF = "/opt/puppetlabs/server/data/postgresql/9.6/data/postgresql.conf"
+PUPPET_DB_CONF = "/etc/puppetlabs/puppetdb/conf.d/config.ini"
+
+def puppetserver_jruby_max_active_instances
+  if File.exist? PE_PUPPET_SERVER_CONF
+    command = "cat #{PE_PUPPET_SERVER_CONF} | grep max-active-instances | egrep -v '^#' | cut -d ':' -f 2"
+    output = `#{command}`.strip!
+    value = output.to_i unless output.nil? || output.empty?
+  end
+
+  unless value
+    command = "facter processorcount"
+    output = `#{command}`
+
+    if output
+      num_cores = output.to_i
+      minimum = 1
+      maximum = 4
+      value = [[num_cores, minimum].max, maximum].min
+    else
+      value = NA
+    end
+
+  end
+
+  value
+end
+
+def get_java_args(file)
+  path = if File.exist? "/etc/debian_version"
+           "/etc/defaults/#{file}"
+         else
+           "/etc/sysconfig/#{file}"
+         end
+
+  if File.exist? path
+    command = "cat #{path} | grep Xmx | grep Xmx"
+    output = `#{command}`
+    value = output.split('"')[1] if output
+  else
+    value = NA
+  end
+
+  value
+end
+
+def puppetserver_reserved_code_cache
+  path = if File.exist? "/etc/debian_version"
+           "/etc/defaults/pe-puppetserver"
+         else
+           "/etc/sysconfig/pe-puppetserver"
+         end
+
+  if File.exist? path
+    command = "cat #{path} | grep Xmx | grep Xmx"
+    res_param = nil
+
+    output = `#{command}`
+    output.split(" ").each do |param|
+      if param.include? "ReservedCodeCacheSize"
+        res_param = param
+        break
+      end
+    end
+
+    value = res_param.split("=")[1] if res_param
+  else
+    value = NA
+  end
+
+  value
+end
+
+def console_java_args
+  get_java_args("pe-console-services")
+end
+
+def master_java_args
+  get_java_args("pe-puppetserver")
+end
+
+def orchestrator_java_args
+  get_java_args("pe-orchestration-services")
+end
+
+def puppetdb_java_args
+  get_java_args("pe-puppetdb")
+end
+
+# TODO: add exclude arg
+def get_postgres_parameter(parameter)
+  command = "cat #{POSTGRES_CONF} | grep #{parameter} | egrep -v '^#' | cut -d '=' -f 2 | cut -d '#' -f 1"
+  `#{command}`.strip!
+end
+
+def database_shared_buffers
+  get_postgres_parameter("shared_buffers")
+end
+
+def database_autovacuum_max_workers
+  get_postgres_parameter("autovacuum_max_workers")
+end
+
+def database_autovacuum_work_mem
+  get_postgres_parameter("autovacuum_work_mem")
+end
+
+def database_maintenance_work_mem
+  get_postgres_parameter("maintenance_work_mem")
+end
+
+def database_max_connections
+  get_postgres_parameter("max_connections")
+end
+
+# TODO: use get_postgres_parameter once updated to take exlude arg
+def database_work_mem
+  exclusion = "grep -v -e 'maintenance' -e 'autovacuum'"
+  command = "cat #{POSTGRES_CONF} | grep work_mem | #{exclusion} | egrep -v '^#' | cut -d '=' -f 2 | cut -d '#' -f 1"
+  `#{command}`.strip!
+end
+
+def puppetdb_command_processing_threads
+  command = "cat #{PUPPET_DB_CONF} | grep threads | egrep -v '^#' | cut -d '=' -f 2"
+  `#{command}`.strip!
+end
+
+# rubocop:disable Metrics/LineLength
+def current_settings
+  params = []
+  params << { "puppet_enterprise::master::puppetserver::jruby_max_active_instances" => puppetserver_jruby_max_active_instances }
+  params << { "puppet_enterprise::master::puppetserver::reserved_code_cache" => puppetserver_reserved_code_cache }
+  params << { "puppet_enterprise::profile::console::java_args" => console_java_args }
+  params << { "puppet_enterprise::profile::database::shared_buffers" => database_shared_buffers }
+  params << { "puppet_enterprise::profile::database::autovacuum_max_workers" => database_autovacuum_max_workers }
+  params << { "puppet_enterprise::profile::database::autovacuum_work_mem" => database_autovacuum_work_mem }
+  params << { "puppet_enterprise::profile::database::maintenance_work_mem" => database_maintenance_work_mem }
+  params << { "puppet_enterprise::profile::database::max_connections" => database_max_connections }
+  params << { "puppet_enterprise::profile::database::maintenance_work_mem" => database_maintenance_work_mem }
+  params << { "puppet_enterprise::profile::database::max_connections" => database_max_connections }
+  params << { "puppet_enterprise::profile::database::work_mem" => database_work_mem }
+  params << { "puppet_enterprise::profile::master::java_args" => master_java_args }
+  params << { "puppet_enterprise::profile::orchestrator::java_args" => orchestrator_java_args }
+  params << { "puppet_enterprise::profile::puppetdb::java_args" => puppetdb_java_args }
+  params << { "puppet_enterprise::puppetdb::command_processing_threads" => puppetdb_command_processing_threads }
+
+  # TODO: pretty or not?
+  # json = params.to_json
+  json = JSON.pretty_generate params
+
+  # TODO: remove?
+  puts json
+
+  json
+end
+# rubocop:enable Metrics/LineLength
+
+current_settings

--- a/util/tune/current_settings.rb
+++ b/util/tune/current_settings.rb
@@ -2,7 +2,12 @@
 
 # frozen_string_literal: true
 
-# TODO: docs
+# This script returns a JSON array of the current values for the settings adjusted by the 'pe_tune' module:
+#   https://github.com/tkishel/pe_tune
+#
+# The list of settings can be found here:
+#   https://github.com/tkishel/pe_tune/blob/79d5db4ddc7bbf3b1c9aefcdfab7f1dc9b3c3f4e/lib/puppet_x/puppetlabs/tune.rb#L19
+#
 # TODO: spec
 
 require "json"
@@ -15,6 +20,18 @@ PUPPET_DB_CONF = "/etc/puppetlabs/puppetdb/conf.d/config.ini"
 MIN_DEFAULT_JRUBIES = 1
 MAX_DEFAULT_JRUBIES = 4
 
+# Returns the value for the 'max-active-instances' parameter if found, otherwise the default value
+#
+# See the following documentation:
+#   https://puppet.com/docs/pe/2019.1/config_puppetserver.html#tune-the-maximum-number-of-jruby-instances
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the max-active-instances setting if set, otherwise the default (see link above)
+#
+# @example
+#   value = puppetserver_jruby_max_active_instances
+#
 def puppetserver_jruby_max_active_instances
   if File.exist? PE_PUPPET_SERVER_CONF
     line = File.open(PE_PUPPET_SERVER_CONF).grep(/max-active-instances/)[0]
@@ -28,7 +45,7 @@ def puppetserver_jruby_max_active_instances
 
     if output
       num_cores = output.to_i
-      value = [[num_cores, MIN_DEFAULT_JRUBIES].max, MAX_DEFAULT_JRUBIES].min.to_s
+      value = [[(num_cores - 1), MIN_DEFAULT_JRUBIES].max, MAX_DEFAULT_JRUBIES].min.to_s
     else
       value = NA
     end
@@ -38,6 +55,17 @@ def puppetserver_jruby_max_active_instances
   value
 end
 
+# Returns the java args for the specified file
+#
+# @author Bill Claytor
+#
+# @param [String] file The file to search for java args
+#
+# @return [string] The java args
+#
+# @example
+#   args = get_java_args(file)
+#
 # TODO: grep for java args
 def get_java_args(file)
   path = if File.exist? "/etc/debian_version"
@@ -55,26 +83,102 @@ def get_java_args(file)
   value
 end
 
+# Returns the value for the following setting:
+# "puppet_enterprise::master::puppetserver::reserved_code_cache"
+#
+# Uses the 'ReservedCodeCacheSize' parameter in the 'pe-puppetserver' file
+#
+# @author Bill Claytor
+#
+# @return [string] The reserved_code_cache value
+#
+# @example
+#   value = puppetserver_reserved_code_cache
+#
+#
 def puppetserver_reserved_code_cache
   get_java_args("pe-puppetserver").match(/XX:ReservedCodeCacheSize=\K[^\s]+/) || NA
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::console::java_args'
+#
+# Uses the 'pe-console-services' file
+#
+# @author Bill Claytor
+#
+# @return [string] The java args
+#
+# @example
+#   value = console_java_args
+#
 def console_java_args
   get_java_args("pe-console-services")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::master::java_args'
+#
+# Uses the 'pe-puppetserver' file
+#
+# @author Bill Claytor
+#
+# @return [string] The java args
+#
+# @example
+#   value = master_java_args
+#
 def master_java_args
   get_java_args("pe-puppetserver")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::orchestrator::java_args'
+#
+# Uses the 'pe-orchestration-services' file
+#
+# @author Bill Claytor
+#
+# @return [string] The java args
+#
+# @example
+#   value = zzz
+#
 def orchestrator_java_args
   get_java_args("pe-orchestration-services")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::puppetdb::java_args'
+#
+# Uses the 'pe-puppetdb' file
+#
+# @author Bill Claytor
+#
+# @return [string] The java args
+#
+# @example
+#   value = puppetdb_java_args
+#
 def puppetdb_java_args
   get_java_args("pe-puppetdb")
 end
 
+# Returns the value for the specified parameter in the specified config file
+# Optionally accepts a list of exclusions to avoid collisions (i.e. 'work_mem' matching 'autovacuum_work_mem', etc)
+#
+# @author Bill Claytor
+#
+# @param [String] file The config file to search
+# @param [String] parameter The parameter to search for
+# @param [RegEx]  exclusions The regular expression used to exclude words from the search
+#
+# @return [string] The parameter value if found, otherwise "N/A"
+#
+# @example
+#   value = get_conf_parameter(file, parameter)
+#   value = get_conf_parameter(file, parameter, /(example_a|example_b)/)
+#
 def get_conf_parameter(file, parameter, exclusions = NA)
   value = if File.exist? file
             match_val = /#{parameter} = \K[^\s]+/
@@ -85,43 +189,151 @@ def get_conf_parameter(file, parameter, exclusions = NA)
   value
 end
 
+# Returns the value for the specified parameter in the postgres config file
+#
+# Note: see get_conf_parameter for a description of optional exclusions
+#
+# @author Bill Claytor
+#
+# @param [String] parameter   The parameter to search for
+# @param [RegEx]  exclusions  The regular expression used to exclude words from the search
+#
+# @return [string] The parameter value if found, otherwise "N/A"
+#
+# @example
+#   value = get_postgres_parameter(parameter)
+#   value = get_postgres_parameter(parameter, /(example_a|example_b)/)
+#
 def get_postgres_parameter(parameter, exclusions = NA)
   get_conf_parameter(POSTGRES_CONF, parameter, exclusions)
 end
 
+# Returns the value for the specified parameter in the puppetdb config file
+#
+# Note: see get_conf_parameter for a description of optional exclusions
+#
+# @author Bill Claytor
+#
+# @param [String] parameter   The parameter to search for
+# @param [RegEx]  exclusions  The regular expression used to exclude words from the search
+#
+# @return [string] The parameter value if found, otherwise "N/A"
+#
+# @example
+#   value = get_puppetdb_parameter(parameter)
+#   value = get_puppetdb_parameter(parameter, /(example_a|example_b)/)
+#
 def get_puppetdb_parameter(parameter, exclusions = NA)
   get_conf_parameter(PUPPET_DB_CONF, parameter, exclusions)
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::database::shared_buffers'
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the 'shared_buffers' parameter
+#
+# @example
+#   value = database_shared_buffers
+#
 def database_shared_buffers
   get_postgres_parameter("shared_buffers")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::database::autovacuum_max_workers'
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the 'autovacuum_max_workers' parameter
+#
+# @example
+#   value = database_autovacuum_max_workers
+#
 def database_autovacuum_max_workers
   get_postgres_parameter("autovacuum_max_workers")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::database::autovacuum_work_mem'
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the 'autovacuum_work_mem' parameter
+#
+# @example
+#   value = database_autovacuum_work_mem
+#
 def database_autovacuum_work_mem
   get_postgres_parameter("autovacuum_work_mem")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::database::maintenance_work_mem'
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the 'maintenance_work_mem' parameter
+#
+# @example
+#   value = database_maintenance_work_mem
+#
 def database_maintenance_work_mem
   get_postgres_parameter("maintenance_work_mem")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::database::max_connections'
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the 'max_connections' parameter
+#
+# @example
+#   value = database_max_connections
+#
 def database_max_connections
   get_postgres_parameter("max_connections")
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::profile::database::work_mem'
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the 'work_mem' parameter
+#
+# @example
+#   value = database_work_mem
+#
 def database_work_mem
   exclusions = /(maintenance|autovacuum)/
   get_postgres_parameter("work_mem", exclusions)
 end
 
+# Returns the value for the following setting:
+# 'puppet_enterprise::puppetdb::command_processing_threads'
+#
+# @author Bill Claytor
+#
+# @return [string] The value for the 'threads' parameter
+#
+# @example
+#   value = puppetdb_command_processing_threads
+#
 def puppetdb_command_processing_threads
   get_puppetdb_parameter("threads")
 end
 
+# Returns a JSON array of the current values for the settings that can be adjusted using the 'pe_tune' module
+# @author Bill Claytor
+#
+# @return [JSON] The current_settings array
+#
+# @example
+#   settings = current_settings
+#
 # rubocop:disable Metrics/LineLength
 def current_settings
   params = []
@@ -141,7 +353,7 @@ def current_settings
 
   json = JSON.pretty_generate params
 
-  # TODO: optional?
+  # TODO: make this optional?
   puts json
 
   json

--- a/util/tune/current_settings.rb
+++ b/util/tune/current_settings.rb
@@ -44,6 +44,9 @@ def puppetserver_jruby_max_active_instances
     output = `#{command}`
 
     if output
+      # See the docs link in the description above
+      # The default used in PE is the number of CPUs - 1, expressed as $::processorcount - 1.
+      # One instance is the minimum value and four instances is the maximum value.
       num_cores = output.to_i
       value = [[(num_cores - 1), MIN_DEFAULT_JRUBIES].max, MAX_DEFAULT_JRUBIES].min.to_s
     else

--- a/util/tune/current_settings.rb
+++ b/util/tune/current_settings.rb
@@ -86,6 +86,27 @@ def get_java_args(file)
   value
 end
 
+# Parses the specified java args into a hash with the following keys:
+#  "Xms": the value for the 'Xms' parameter
+#  "Xmx": the value for the 'Xmx' parameter
+#  "Misc": the remaining args
+#
+# @author Bill Claytor
+#
+# @return [Hash] The parsed java args
+#
+# @example
+#   result = parse_java_aggs(args)
+#
+def parse_java_aggs(args)
+  xmx = args.match(/-Xmx\K[^\s]+/)
+  xms = args.match(/-Xms\K[^\s]+/)
+  misc = args.gsub("-Xmx#{xmx} ", "").gsub("-Xms#{xms} ", "")
+
+  result = { "Xms" => xms, "Xmx" => xmx, "Misc" => misc }
+  result
+end
+
 # Returns the value for the following setting:
 # "puppet_enterprise::master::puppetserver::reserved_code_cache"
 #
@@ -116,7 +137,7 @@ end
 #   value = console_java_args
 #
 def console_java_args
-  get_java_args("pe-console-services")
+  parse_java_aggs(get_java_args("pe-console-services"))
 end
 
 # Returns the value for the following setting:
@@ -132,7 +153,7 @@ end
 #   value = master_java_args
 #
 def master_java_args
-  get_java_args("pe-puppetserver")
+  parse_java_aggs(get_java_args("pe-puppetserver"))
 end
 
 # Returns the value for the following setting:
@@ -148,7 +169,7 @@ end
 #   value = zzz
 #
 def orchestrator_java_args
-  get_java_args("pe-orchestration-services")
+  parse_java_aggs(get_java_args("pe-orchestration-services"))
 end
 
 # Returns the value for the following setting:
@@ -164,7 +185,7 @@ end
 #   value = puppetdb_java_args
 #
 def puppetdb_java_args
-  get_java_args("pe-puppetdb")
+  parse_java_aggs(get_java_args("pe-puppetdb"))
 end
 
 # Returns the value for the specified parameter in the specified config file


### PR DESCRIPTION
This update adds the `util/tune/current_settings.rb` script which gets the current values for the settings updated by `pe_tune`:
```
puppet_enterprise::master::puppetserver::jruby_max_active_instances
puppet_enterprise::master::puppetserver::reserved_code_cache
puppet_enterprise::profile::console::java_args
puppet_enterprise::profile::database::shared_buffers
puppet_enterprise::profile::database::autovacuum_max_workers
puppet_enterprise::profile::database::autovacuum_work_mem
puppet_enterprise::profile::database::maintenance_work_mem
puppet_enterprise::profile::database::max_connections
puppet_enterprise::profile::database::work_mem
puppet_enterprise::profile::master::java_args
puppet_enterprise::profile::orchestrator::java_args
puppet_enterprise::profile::puppetdb::java_args
puppet_enterprise::puppetdb::command_processing_threads
```
The unformatted JSON output is dense and somewhat hard to read in a terminal:
```
[root@ip-10-227-2-128 ~]# ruby current_settings.rb
[{"puppet_enterprise::master::puppetserver::jruby_max_active_instances":4},{"puppet_enterprise::master::puppetserver::reserved_code_cache":"512m"},{"puppet_enterprise::profile::console::java_args":"-Xmx256m -Xms256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/console-services/console-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"},{"puppet_enterprise::profile::database::shared_buffers":"3699MB"},{"puppet_enterprise::profile::database::autovacuum_max_workers":"3"},{"puppet_enterprise::profile::database::autovacuum_work_mem":"637MB"},{"puppet_enterprise::profile::database::maintenance_work_mem":"1913MB"},{"puppet_enterprise::profile::database::max_connections":"400"},{"puppet_enterprise::profile::database::maintenance_work_mem":"1913MB"},{"puppet_enterprise::profile::database::max_connections":"400"},{"puppet_enterprise::profile::database::work_mem":"4MB"},{"puppet_enterprise::profile::master::java_args":"-Xms2048m -Xmx2048m -Djava.io.tmpdir=/opt/puppetlabs/server/apps/puppetserver/tmp -XX:ReservedCodeCacheSize=512m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetserver/puppetserver_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"},{"puppet_enterprise::profile::orchestrator::java_args":"-Xmx704m -Xms704m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/orchestration-services/orchestration-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"},{"puppet_enterprise::profile::puppetdb::java_args":"-Xmx256m -Xms256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetdb/puppetdb_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"},{"puppet_enterprise::puppetdb::command_processing_threads":"4"}]
```

The script currently uses `JSON.pretty_generate` to present more readable output:
```
[root@ip-10-227-2-128 ~]# ruby current_settings.rb
[
  {
    "puppet_enterprise::master::puppetserver::jruby_max_active_instances": 4
  },
  {
    "puppet_enterprise::master::puppetserver::reserved_code_cache": "512m"
  },
  {
    "puppet_enterprise::profile::console::java_args": "-Xmx256m -Xms256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/console-services/console-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
  },
  {
    "puppet_enterprise::profile::database::shared_buffers": "3699MB"
  },
  {
    "puppet_enterprise::profile::database::autovacuum_max_workers": "3"
  },
  {
    "puppet_enterprise::profile::database::autovacuum_work_mem": "637MB"
  },
  {
    "puppet_enterprise::profile::database::maintenance_work_mem": "1913MB"
  },
  {
    "puppet_enterprise::profile::database::max_connections": "400"
  },
  {
    "puppet_enterprise::profile::database::maintenance_work_mem": "1913MB"
  },
  {
    "puppet_enterprise::profile::database::max_connections": "400"
  },
  {
    "puppet_enterprise::profile::database::work_mem": "4MB"
  },
  {
    "puppet_enterprise::profile::master::java_args": "-Xms2048m -Xmx2048m -Djava.io.tmpdir=/opt/puppetlabs/server/apps/puppetserver/tmp -XX:ReservedCodeCacheSize=512m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetserver/puppetserver_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
  },
  {
    "puppet_enterprise::profile::orchestrator::java_args": "-Xmx704m -Xms704m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/orchestration-services/orchestration-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
  },
  {
    "puppet_enterprise::profile::puppetdb::java_args": "-Xmx256m -Xms256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetdb/puppetdb_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
  },
  {
    "puppet_enterprise::puppetdb::command_processing_threads": "4"
  }
]
```

Note: To simplify this script `puppet_enterprise::profile::amq::broker::heap_mb` has been omitted as it appears to not be used in versions 2019 or greater:
https://github.com/tkishel/pe_tune/blob/79d5db4ddc7bbf3b1c9aefcdfab7f1dc9b3c3f4e/lib/puppet_x/puppetlabs/tune.rb#L37

I will apply the same logic used in the `pe_tune` example above if we want to use this for versions prior to 2019.

---

The script can be executed remotely via Bolt by adding the following shebang:
```
#!/opt/puppetlabs/puppet/bin/ruby
```

For example:
```
bill.claytor:~/RubymineProjects/_forks/gatling-puppet-load-test> bolt script run util/tune/current_settings.rb --user root --nodes 10.227.2.128
Started on 10.227.2.128...
Finished on 10.227.2.128:
  STDOUT:
    [
      {
        "puppet_enterprise::master::puppetserver::jruby_max_active_instances": 4
      },
      {
        "puppet_enterprise::master::puppetserver::reserved_code_cache": "512m"
      },
      {
        "puppet_enterprise::profile::console::java_args": "-Xmx256m -Xms256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/console-services/console-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
      },
      {
        "puppet_enterprise::profile::database::shared_buffers": "3699MB"
      },
      {
        "puppet_enterprise::profile::database::autovacuum_max_workers": "3"
      },
      {
        "puppet_enterprise::profile::database::autovacuum_work_mem": "637MB"
      },
      {
        "puppet_enterprise::profile::database::maintenance_work_mem": "1913MB"
      },
      {
        "puppet_enterprise::profile::database::max_connections": "400"
      },
      {
        "puppet_enterprise::profile::database::maintenance_work_mem": "1913MB"
      },
      {
        "puppet_enterprise::profile::database::max_connections": "400"
      },
      {
        "puppet_enterprise::profile::database::work_mem": "4MB"
      },
      {
        "puppet_enterprise::profile::master::java_args": "-Xms2048m -Xmx2048m -Djava.io.tmpdir=/opt/puppetlabs/server/apps/puppetserver/tmp -XX:ReservedCodeCacheSize=512m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetserver/puppetserver_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
      },
      {
        "puppet_enterprise::profile::orchestrator::java_args": "-Xmx704m -Xms704m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/orchestration-services/orchestration-services_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
      },
      {
        "puppet_enterprise::profile::puppetdb::java_args": "-Xmx256m -Xms256m -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/puppetlabs/puppetdb/puppetdb_gc.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=16 -XX:GCLogFileSize=64m"
      },
      {
        "puppet_enterprise::puppetdb::command_processing_threads": "4"
      }
    ]
Successful on 1 node: 10.227.2.128
Ran on 1 node in 3.02 seconds
```

If this is desirable I will add it to the script.

---

TODO:
* include the shebang?  (see note above)
* include amq::broker::heap_mb? (see note above)
* TODO items in the code
* spec
