### PR TITLE
(SLV-467) Update perf_setup to capture current tune settings

### DIFF
--- a/util/tune/current_settings.rb
+++ b/util/tune/current_settings.rb
@@ -19,7 +19,7 @@ PUPPET_DB_CONF = "/etc/puppetlabs/puppetdb/conf.d/config.ini"
 MIN_DEFAULT_JRUBIES = 1
 MAX_DEFAULT_JRUBIES = 4
 DEFAULT_EXCLUSION = ""
-DEFAULT_WORKING_DIRECTORY = "~/tmp"
+DEFAULT_WORKING_DIRECTORY = "/root/tmp"
 DEFAULT_OUTPUT_FILE = "current_tune_settings.json"
 
 # Returns the value for the 'max-active-instances' parameter if found, otherwise the default value


### PR DESCRIPTION
This PR includes the following updates:
* update current_settings.rb to output the correct JSON format and write the result to ~/tmp/current_tune_settings.rb on the master
* add the following new methods to `perf_run_helper.rb`:
-- `create_perf_archive_root`
-- `capture_current_tune_settings`
* update `perf_setup` to create the archive root and capture the current settings using the new methods
* add spec tests
