### PR TITLE
(SLV-434) Use code manager for PE installs

### DIFF
--- a/setup/install_gatling/30_classification/00_configure_code_manager.rb
+++ b/setup/install_gatling/30_classification/00_configure_code_manager.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+test_name "Configure code manager" do
+  configure_code_manager
+  on(master, puppet("agent", "-t"), acceptable_exit_codes: [0, 2])
+  on(compile_master, puppet("agent", "-t"), acceptable_exit_codes: [0, 2]) if any_hosts_as?("compile_master")
+  cm_deploy_all_envs
+end

--- a/setup/options/options_pe.rb
+++ b/setup/options/options_pe.rb
@@ -9,11 +9,8 @@
     "setup/install_gatling/00_pre_install/30_r10k_git_setup.rb",
     # unique to pe
     "setup/install_gatling/10_pe_install/10_install_pe.rb",
-    # common between foss, pe
-    "setup/install_gatling/30_classification/10_r10k_deploy.rb",
     # unique to pe
-    "setup/install_gatling/30_classification/20_enable_file_sync.rb",
-    "setup/install_gatling/30_classification/30_sync_codedir.rb",
+    "setup/install_gatling/30_classification/00_configure_code_manager.rb",
     "setup/install_gatling/30_classification/40_classify_nodes_via_nc.rb",
     "setup/install_gatling/30_classification/45_classify_master_via_nc.rb",
     # common between foss, pe

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -527,5 +527,37 @@ describe PerfHelperClass do
       end
     end
   end
+
+  describe "#configure_code_manager" do
+    ENV["PUPPET_GATLING_R10K_CONTROL_REPO"] = "foobar"
+    ENV["PUPPET_GATLING_R10K_BASEDIR"] = "foobar"
+    ENV["PUPPET_GATLING_R10K_ENVIRONMENTS"] = "foobar"
+    master_group_id = "pe_master_group_id"
+
+    it "calls update_node_group on classifier to setup code_manager on puppet_enterprise::profile::master class" do
+      class_opts = { "classes" =>
+                                  { "puppet_enterprise::profile::master" =>
+                                                                            { code_manager_auto_configure: true,
+                                                                              r10k_private_key: "",
+                                                                              r10k_remote: "foobar" } } }
+
+      classifier = double("classifier").as_null_object
+      allow(classifier).to receive(:get_node_group_by_name).and_return("id" => master_group_id)
+      subject.stub(:classifier) { classifier }
+
+      expect(classifier).to receive(:update_node_group).with(master_group_id, class_opts)
+      subject.configure_code_manager
+    end
+  end
+
+  describe "#cm_deploy_all_envs" do
+    it "calls deploy_all_environments on classifier" do
+      classifier = double("classifier").as_null_object
+      subject.stub(:classifier) { classifier }
+
+      expect(classifier).to receive(:deploy_all_environments)
+      subject.cm_deploy_all_envs
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
This PR updates the beaker pre-suite and options files to use code manager rather than r10k when installing PE.