### PR TITLE
(SLV-547) Deploy metrics node with provision_pe_xl

### DIFF
--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -97,7 +97,8 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-ROLES_CORE = %w[master
+ROLES_CORE = %w[metrics
+                master
                 puppet_db
                 compiler_a
                 compiler_b].freeze


### PR DESCRIPTION
This commit adds a `metrics` role to the nodes deployed in the
`provision_pe_xl.rb` script.