### PR TITLE
(SLV-549) Add pre-suite install puppet on metric

### DIFF
--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -626,7 +626,12 @@ module PerfHelper
       metric.mkdir_p "gatling-puppet-load-test/proxy-recorder"
       scp_to(metric, "proxy-recorder", "gatling-puppet-load-test")
 
+      # ensure puppet installed on metric
+      cmd = frictionless_agent_installer_cmd(metric, {}, "foobar")
+      on(metric, cmd, accept_all_exit_codes: true)
+
       classify_metrics_node_via_nc
+      on(metric, puppet("agent", "-t"), accept_all_exit_codes: true)
     end
   end
 

--- a/setup/install_gatling/10_pe_install/20_autosign_hosts.rb
+++ b/setup/install_gatling/10_pe_install/20_autosign_hosts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+test_name "configure autosign for hosts" do
+  skip_test "Installing FOSS, not PE" unless ENV["BEAKER_INSTALL_TYPE"] == "pe"
+  confdir = master.puppet["confdir"]
+  hostnames = hosts.map(&:hostname)
+  on master, puppet_apply, stdin: <<~MANIFEST
+    file { "#{confdir}/autosign.conf":
+      ensure => file,
+      mode => "0644",
+      owner => "pe-puppet",
+      group => "pe-puppet",
+      content => "#{hostnames.join("\n")}",
+    }
+  MANIFEST
+end


### PR DESCRIPTION
This commit adds pre-suites to ensure that the puppet agent is installed
on the metric node and that its certificate is autosigned by the master.