### PR TITLE
(SLV-551) Update rake tasks to accomodate pe_xl

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -7,19 +7,26 @@ include AbsHelper
 require './tests/helpers/perf_results_helper'
 include PerfResultsHelper
 
+REF_ARCH_STD, REF_ARCH_LARGE = ["S","L"]
+
 task :default => :performance
 
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
 rototiller_task :performance do
+  ENV['REF_ARCH'] ||= REF_ARCH_STD
   if ENV['PUPPET_GATLING_REPORTS_ONLY'] == 'true' && (!ENV['PUPPET_GATLING_REPORTS_TARGET'] || ENV['PUPPET_GATLING_REPORTS_TARGET'] == '')
     abort 'A valid result folder (i.e. PerfTestLarge-1524848074511) must be specified for PUPPET_GATLING_REPORTS_TARGET if PUPPET_GATLING_REPORTS_ONLY=true'
   end
 
-  Rake::Task["performance_provision_with_abs"].execute unless ENV['ABS_RESOURCE_HOSTS'] ||
+  if ENV['REF_ARCH'] == REF_ARCH_LARGE
+    Rake::Task["pe_xl:deploy"].invoke
+  else
+    Rake::Task["performance_provision_with_abs"].execute unless ENV['ABS_RESOURCE_HOSTS'] ||
       (ENV['BEAKER_HOSTS'] &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg' &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/opsworks-perf-test.cfg')
+  end
   Rake::Task["performance_without_provision"].execute
   Rake::Task["performance_deprovision_with_abs"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' ||
       ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0)&&
@@ -108,6 +115,17 @@ end
 
 desc 'Execute beaker performance setup and tests against existing hosts specified by ABS_RESOURCE_HOSTS env var, intended to be used in CI - use task "performance" for local/dev execution'
 rototiller_task :performance_without_provision do |t|
+  ENV['REF_ARCH'] ||= REF_ARCH_STD
+  if ENV['REF_ARCH'] == REF_ARCH_LARGE
+    generated_hosts = "build/pe_xl/beaker.cfg"
+    unless File.file? ENV['BEAKER_HOSTS'].to_s
+      raise "No valid BEAKER_HOSTS file available" unless File.file? generated_hosts
+      ENV['BEAKER_HOSTS'] = generated_hosts
+    end
+    ENV['BEAKER_INSTALL_TYPE'] = "pe"
+    ENV['BEAKER_OPTIONS_FILE'] = "setup/options/options_pe_xl.rb"
+  end
+
   t.add_env({:name => 'ABS_RESOURCE_HOSTS', :message => 'The string returned from the ABS service describing your hosts'}) if ENV['BEAKER_HOSTS'] == 'config/beaker_hosts/pe-perf-test.cfg' ||
       ENV['BEAKER_HOSTS'] == 'config/beaker_hosts/foss-perf-test.cfg'
   t.add_env({:name => 'ENVIRONMENT_TYPE', :message => 'Either gatling or clamps', :default => 'gatling'})


### PR DESCRIPTION
This commit updates the `performance_without_provision` and `performance` rake tasks
to accomodate a Large Architecture.  This is accomplished with the
addition of a new ENV var `REF_ARCH`.  If this is set to `L` the
`performance`, `performance_without_provision`, and
`performance_against_already_provisioned` rake tasks will utilize the
`pe_xl:deploy` task or attempt to use the infrastructure deployed by
said task.

Example workflows:

* Performance (provision, deploy, setup performance, run tests)
```
export BEAKER_PE_VER=2019.1.1
REF_ARCH=L bundle exec rake performance
```

* Separate stages
  * Setup Large Architecture with PE installed
  ```
  export BEAKER_PE_VER=2019.1.1
  bundle exec rake pe_xl:deploy
  ```
  * Setup performance and run tests on existing Large Architecture
  ```
  REF_ARCH=L be rake performance_without_provision
  ```
  * Run run tests on existing Large Architecture
  ```
  REF_ARCH=L be rake performance_against_already_provisioned
  ```
