### PR TITLE
(SLV-573) supress new lines in csv file

### DIFF
--- a/tests/helpers/perf_results_helper.rb
+++ b/tests/helpers/perf_results_helper.rb
@@ -441,6 +441,8 @@ module PerfResultsHelper
       line_ct += 1
 
       output_path = output_path_detail if line_ct > 3
+      line.rstrip!
+      next if line.empty?
 
       File.open(output_path, "a") do |f|
         f.puts line


### PR DESCRIPTION
split_atop_csv_results splits the file into 2 files.  1 for the top section and one for the bottom.
But it was sending the empty line to the first file, and then csv lint failed on that blank line.
So I added code to supress the printing of blank lines in split_atop_csv_results