### PR TITLE
(SLV-584) provision_pe_xl use roles as alias

### DIFF
--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -266,8 +266,7 @@ def create_nodes_yaml(hosts, output_dir)
 
   output_path = "#{File.expand_path(output_dir)}/nodes.yaml"
 
-  data["groups"][0]["nodes"] = hosts.map { |h| h[:hostname] }
-  data["groups"][0]["roles"] = hosts.map { |h| h[:role].ljust(15) + h[:hostname] }
+  data["groups"][0]["nodes"] = hosts.map { |h| { "name" => h[:hostname], "alias" => h[:role] } }
 
   puts "Writing #{output_path}"
   puts


### PR DESCRIPTION
This commit modifies the generated bolt inventory created by
provision_pe_xl to use the roles as aliases for the nodes.  This
allows the user to simply use the node role when running bolt
commands on the inventory.