### PR TITLE
(SLV-575) Add loadbalancer when Large arch

### DIFF
--- a/setup/install_gatling/30_classification/60_classify_use_loadbalancer.rb
+++ b/setup/install_gatling/30_classification/60_classify_use_loadbalancer.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require File.expand_path("../../../setup/helpers/perf_helper", __dir__)
+Beaker::TestCase.class_eval { include PerfHelper }
+
+test_name "classify and use loadbalancer" do # rubocop:disable Metrics/BlockLength
+  skip_test "Not a PE Large/XL Architecture" unless any_hosts_as?(:loadbalancer) && any_hosts_as?(:compile_master)
+
+  step "install puppet on loadbalancer" do
+    cmd = frictionless_agent_installer_cmd(loadbalancer, {}, "foobar")
+    on(loadbalancer, cmd)
+  end
+
+  step "create loadbalancer groups" do
+    add_loadbalancer_groups(loadbalancer, compile_master)
+  end
+
+  step "add loadbalancer to PE Infra Agent group" do
+    group_id = classifier.get_node_group_id_by_name("PE Infrastructure Agent")
+    classifier.pin_nodes(group_id, { nodes: [loadbalancer] }.to_json)
+  end
+
+  step "export haproxy balancer member resources" do
+    on(compile_master,
+       puppet_agent("-t --no-use_cached_catalog"),
+       acceptable_exit_codes: [0, 2])
+  end
+
+  step "setup loadbalancer" do
+    step "disable selinux on loadbalancer server" do
+      on loadbalancer, "setenforce 0 || true"
+    end
+
+    step "install haproxy on loadbalancer" do
+      on(loadbalancer, puppet_agent("-t --no-use_cached_catalog"),
+         acceptable_exit_codes: [2])
+    end
+  end
+
+  step "set PE Agent group to use loadbalancer" do
+    pe_agent_uuid = classifier.get_node_group_by_name("PE Agent")["id"]
+    pe_infra_agent_uuid = classifier.get_node_group_by_name("PE Infrastructure Agent")["id"]
+
+    pe_agent_group = {
+      "name"    => "PE Agent",
+      "classes" => {
+        "puppet_enterprise::profile::agent" => {
+          "manage_puppet_conf" => true,
+          "server_list"        => ["#{loadbalancer}:8140"],
+          "pcp_broker_list"    => ["#{loadbalancer}:8142"]
+        }
+      }
+    }
+
+    # Infra agents would otherwise inherit the config above, so explicitly override it to defaults.
+    pe_infra_agent_group = {
+      "name"    => "PE Infrastructure Agent",
+      "classes" => {
+        "puppet_enterprise::profile::agent" => {
+          "manage_puppet_conf" => true,
+          "server_list"        => ["#{master}:8140"],
+          "pcp_broker_list"    => ["#{master}:8142"]
+        }
+      }
+    }
+
+    classifier.update_node_group(pe_agent_uuid, pe_agent_group)
+    classifier.update_node_group(pe_infra_agent_uuid, pe_infra_agent_group)
+  end
+end

--- a/setup/options/options_pe_xl.rb
+++ b/setup/options/options_pe_xl.rb
@@ -10,6 +10,7 @@
     "setup/install_gatling/30_classification/00_configure_code_manager.rb",
     "setup/install_gatling/30_classification/40_classify_nodes_via_nc.rb",
     "setup/install_gatling/30_classification/45_classify_master_via_nc.rb",
+    "setup/install_gatling/30_classification/60_classify_use_loadbalancer.rb",
     "setup/install_gatling/40_post_install/30_final_puppet_run.rb",
     "setup/install_gatling/40_post_install/40_configure_gatling_auth.rb",
     "setup/install_gatling/40_post_install/50_configure_permissive_server_auth.rb",

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -559,5 +559,41 @@ describe PerfHelperClass do
       subject.cm_deploy_all_envs
     end
   end
+
+  describe "#add_loadbalancer_groups" do
+    pe_infra_uuid = 42
+    loadbalancer = "foo"
+    compile_master = "bar"
+
+    it "creates Loadbalancer groups" do
+      expected_lb_group = {
+        "name"    => "HAProxy Loadbalancer",
+        "rule"    => ["or", ["=", "name", loadbalancer]],
+        "parent"  => pe_infra_uuid,
+        "classes" => {
+          "profile::loadbalancer" => {}
+        }
+      }
+
+      expected_lb_exports_group = {
+        "name"    => "Loadbalancer Exports(Compile Masters)",
+        "rule"    => ["or", ["=", "name", compile_master]],
+        "parent"  => pe_infra_uuid,
+        "classes" => {
+          "profile::loadbalancer_exports" => {}
+        }
+      }
+
+      classifier = double("classifier",
+                          get_node_group_by_name: { "id" => pe_infra_uuid },
+                          find_or_create_node_group_model: true)
+      subject.stub(:classifier) { classifier }
+
+      expect(classifier).to receive(:find_or_create_node_group_model).with(expected_lb_group)
+      expect(classifier).to receive(:find_or_create_node_group_model).with(expected_lb_exports_group)
+
+      subject.add_loadbalancer_groups(loadbalancer, compile_master)
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -27,6 +27,7 @@ DESCRIPTION = <<~DESCRIPTION
   EC2 hosts are provisioned for the following roles:
   * Core roles:
    - metrics
+   - loadbalancer
    - master
    - puppet_db (for xl)
    - compiler_a
@@ -113,6 +114,7 @@ end.parse!
 raise "Large ref_arch doesn't currently support HA" if options[:ref_arch] == REF_ARCH_TYPES[:large] && options[:ha]
 
 ROLES_CORE = %w[metrics
+                loadbalancer
                 master
                 compiler_a
                 compiler_b].freeze
@@ -398,6 +400,7 @@ def create_beaker_config(hosts, output_dir)
                       "puppet_db_replica" => "database",
                       "compiler_a"        => "compile_master",
                       "compiler_b"        => "compile_master",
+                      "loadbalancer"      => "loadbalancer",
                       "metrics"           => "metric" }
 
   beaker_roles = beaker_role_map.keys


### PR DESCRIPTION
This PR adds a loadbalancer node in front of the compile masters when using a Large Architecture setup.  This includes:
* Create host, and roles via provision_pe_xl
* Add pre-suite to configure loadbalancer and PE infrastructure to use it
