### PR TITLE
Revert "(SLV-580) Change travis ruby version to 2.5.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
 notifications:
   email: false
 rvm:
-  - 2.5.1
+  - 2.6.2


### PR DESCRIPTION
This reverts commit 9466894dab16354d5758e0a0128db581205105a2.

Ruby 2.5.1 is incompatible with the csvlint code currently used by
the repo.  This is causing CI tests to fail.  This update can be
re-applied when the csvlint code is removed by SLV-576.