### PR TITLE
(SLV-574) Enable gatling to use loadbalancer

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -588,8 +588,16 @@ namespace :pe_xl do
 
   file "#{BUILD_DIR}/pe_xl_plan_result" do
     puts "Running bolt plan"
-    system "bolt plan run pe_xl --debug --inventory #{BUILD_DIR}/nodes.yaml --params @#{BUILD_DIR}/params.json"
-    File.write("#{BUILD_DIR}/pe_xl_plan_result", $?)
+    cmd = %W[
+      bolt plan run pe_xl
+      --debug
+      --inventory #{BUILD_DIR}/nodes.yaml
+      --params @#{BUILD_DIR}/params.json
+    ].join(" ")
+    res = system cmd
+    res_str = "#{$?.to_i}\n#{res}\n"
+    File.write("#{BUILD_DIR}/pe_xl_plan_result", res_str)
+    raise "Plan for pe_xl failed: #{res_str}" if $?.to_i != 0
   end
 
   desc "Run pe_xl plan"

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -510,9 +510,9 @@ module PerfHelper
   end
 
   def configure_permissive_server_auth
-    step "Configure permissive auth.conf on master" do
+    step "Configure permissive auth.conf on master(s)" do
       auth_conf = "/etc/puppetlabs/puppetserver/conf.d/auth.conf"
-      create_remote_file(master, auth_conf, <<~AUTHCONF)
+      content = <<~AUTHCONF
         authorization: {
           version: 1
           rules: [
@@ -528,6 +528,12 @@ module PerfHelper
           ]
         }
       AUTHCONF
+      create_remote_file(master, auth_conf, content)
+      on(master, "puppetserver reload")
+      if any_hosts_as?("compile_master")
+        create_remote_file(compile_master, auth_conf, content)
+        on(compile_master, "puppetserver reload")
+      end
     end
   end
 

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -722,7 +722,8 @@ module PerfRunHelper
       end
 
       sim_runner_dir = "/root/gatling-puppet-load-test/simulation-runner/"
-      base_url = "https://#{master.hostname}:8140"
+      pup = any_hosts_as?("loadbalancer") ? loadbalancer : master
+      base_url = "https://#{pup}:8140"
       sim_config = "config/scenarios/#{gatling_scenario} "
       reports_target_path = "#{sim_runner_dir}/results/#{reports_target}"
       command = "cd #{sim_runner_dir} && " \

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -845,6 +845,13 @@ module PerfRunHelper
     scp_to(master, "util/metrics/collect_metrics_files.rb", "/root/collect_metrics_files.rb")
     start_epoch = File.read("#{@archive_root}/start_epoch")
     end_epoch = File.read("#{@archive_root}/end_epoch")
+
+    # privatebindir is not available if beaker did not install puppet.
+    # So, we introspect it from the host based on the installed puppet.
+    unless master["privatebindir"]
+      res = on(master, "readlink -f $(which puppet)")
+      master["privatebindir"] = File.dirname(res.stdout.chomp)
+    end
     cmf_output = on(master,
                     "env PATH=\"#{master['privatebindir']}:${PATH}\" \
                     ruby /root/collect_metrics_files.rb --start_epoch #{start_epoch} --end_epoch #{end_epoch}")


### PR DESCRIPTION
This PR enabled gatling to target a load balancer if it is present and to set the puppetserver auth.conf files on compile masters to allow for gatling submissions to be allowed.