### PR TITLE
(SLV-589) Update collect_metrics_files to use replace underscores with hyphens in staging dir

### DIFF
--- a/setup/install/00_pre_install/00_configuration_check.rb
+++ b/setup/install/00_pre_install/00_configuration_check.rb
@@ -6,9 +6,10 @@ test_name "check configuration" do
   end
 
   step "fail on presence of scale: logic: setting" do
-    if options[:scale] && options[:scale][:logic]
-      fail_test "The 'logic' setting in the 'scale' configuration section is obsolete." \
-        "Please use 'static_files' and 'dynamic_files' instead."
-    end
+    fail_msg = %w[
+      The logic setting in the scale configuration section is obsolete.
+      Please use static_files and dynamic_files instead.
+    ].join(" ")
+    fail_test fail_msg if options.dig(:scale, :logic)
   end
 end

--- a/setup/install/00_pre_install/00_configuration_check.rb
+++ b/setup/install/00_pre_install/00_configuration_check.rb
@@ -6,6 +6,9 @@ test_name "check configuration" do
   end
 
   step "fail on presence of scale: logic: setting" do
-    fail_test "The 'logic' setting in the 'scale' configuration section is obsolete. Please use 'static_files' and 'dynamic_files' instead." if options[:scale] && options[:scale][:logic] # rubocop:disable Metrics/LineLength
+    if options[:scale] && options[:scale][:logic]
+      fail_test "The 'logic' setting in the 'scale' configuration section is obsolete." \
+        "Please use 'static_files' and 'dynamic_files' instead."
+    end
   end
 end

--- a/tests/helpers/perf_results_helper.rb
+++ b/tests/helpers/perf_results_helper.rb
@@ -66,8 +66,7 @@ module PerfResultsHelper
                            "catalog",
                            "report"].freeze
 
-  # TODO: update to 'puppet-metrics-collector' (SLV-589)
-  PUPPET_METRICS_COLLECTOR_DIR_NAME = "puppet_metrics_collector"
+  PUPPET_METRICS_COLLECTOR_DIR_NAME = "puppet-metrics-collector"
 
   # Extract Gatling JSON data into a CSV file in the format used in our release test reports
   # and convert the CSV file to an HTML file for easy viewing

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -517,8 +517,8 @@ module PerfRunHelper
 
     # copy puppet-metrics-collector to scale results dir (this iteration) and parent dir (entire scale run)
     src = File.join(@archive_root, PUPPET_METRICS_COLLECTOR_DIR_NAME)
-    FileUtils.copy_entry src, "#{scale_result_dir}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
-    FileUtils.copy_entry src, "#{scale_results_parent_dir}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
+    FileUtils.copy_entry src, File.join(scale_result_dir, PUPPET_METRICS_COLLECTOR_DIR_NAME)
+    FileUtils.copy_entry src, File.join(scale_results_parent_dir, PUPPET_METRICS_COLLECTOR_DIR_NAME)
 
     # copy epoch files
     # TODO: update to include in the bulk copy below when these have an extension
@@ -528,7 +528,7 @@ module PerfRunHelper
     # copy any csv/html/json/tar.gz/txt files
     res_files = Dir.glob("#{@archive_root}/*.{csv,html,json,tar.gz,txt}")
     res_files.each do |file|
-      FileUtils.copy_file file, "#{scale_result_dir}/#{File.basename(file)}"
+      FileUtils.copy_file file, File.join(scale_result_dir, File.basename(file))
     end
   end
 

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -23,7 +23,6 @@ module PerfRunHelper
                                       else
                                         ["puppetserver"]
                                       end
-  PUPPET_METRICS_COLLECTOR_DIR_NAME = "puppet-metrics-collector"
 
   PERF_RESULTS_DIR = "results/perf"
   SCALE_RESULTS_DIR = "results/scale"
@@ -492,10 +491,6 @@ module PerfRunHelper
     scale_result_dir = "#{scale_results_parent_dir}/#{scenario.gsub('.json', '')}"
     FileUtils.mkdir_p scale_result_dir
 
-    # copy entire results to scale results dir (TODO: remove this?)
-    # perf_result_dir = File.basename(@archive_root)
-    # FileUtils.copy_entry @archive_root, "#{scale_result_dir}/#{perf_result_dir}"
-
     # copy metric
     remote_result_dir = "root/gatling-puppet-load-test/simulation-runner/results"
     metric_results = "#{@archive_root}/#{metric.hostname}/#{remote_result_dir}/#{@dir_name}"
@@ -521,8 +516,7 @@ module PerfRunHelper
     FileUtils.copy_file stats_path, "#{json_dir}/#{scenario.gsub('.json', 'stats.json')}"
 
     # copy puppet-metrics-collector to scale results dir (this iteration) and parent dir (entire scale run)
-    # TODO: rename dir to 'puppet-metrics-collector'
-    src = "#{@archive_root}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
+    src = File.join(@archive_root, PUPPET_METRICS_COLLECTOR_DIR_NAME)
     FileUtils.copy_entry src, "#{scale_result_dir}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
     FileUtils.copy_entry src, "#{scale_results_parent_dir}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
 

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -23,6 +23,7 @@ module PerfRunHelper
                                       else
                                         ["puppetserver"]
                                       end
+  PUPPET_METRICS_COLLECTOR_DIR_NAME = "puppet-metrics-collector"
 
   PERF_RESULTS_DIR = "results/perf"
   SCALE_RESULTS_DIR = "results/scale"
@@ -352,34 +353,6 @@ module PerfRunHelper
     output
   end
 
-  # Copy the puppet-metrics-collector log files for each service
-  #
-  # @author Bill Claytor
-  #
-  # @param [String] destination_dir The destination directory
-  #
-  # @return [void]
-  #
-  # @example
-  #   copy_puppet_metrics_collector(destination_dir)
-  #
-  # TODO: update for SLV-430
-  #
-  def copy_puppet_metrics_collector(destination_dir)
-    puts "Copying 'puppet-metrics-collector' to #{destination_dir}"
-    puts
-
-    dest_pmc_dir = "#{destination_dir}/puppet-metrics-collector"
-    FileUtils.mkdir_p dest_pmc_dir
-
-    PUPPET_METRICS_COLLECTOR_SERVICES.each do |service|
-      source_dir = "/opt/puppetlabs/puppet-metrics-collector/#{service}"
-      scp_from(master, source_dir.to_s, dest_pmc_dir.to_s)
-    end
-
-    extract_puppet_metrics_collector_data(dest_pmc_dir)
-  end
-
   # Generate a name for the scenario that includes the iteration and number of instances
   #
   # @author Bill Claytor
@@ -549,9 +522,9 @@ module PerfRunHelper
 
     # copy puppet-metrics-collector to scale results dir (this iteration) and parent dir (entire scale run)
     # TODO: rename dir to 'puppet-metrics-collector'
-    src = "#{@archive_root}/puppet_metrics_collector"
-    FileUtils.copy_entry src, "#{scale_result_dir}/puppet_metrics_collector"
-    FileUtils.copy_entry src, "#{scale_results_parent_dir}/puppet_metrics_collector"
+    src = "#{@archive_root}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
+    FileUtils.copy_entry src, "#{scale_result_dir}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
+    FileUtils.copy_entry src, "#{scale_results_parent_dir}/#{PUPPET_METRICS_COLLECTOR_DIR_NAME}"
 
     # copy epoch files
     # TODO: update to include in the bulk copy below when these have an extension
@@ -1033,4 +1006,4 @@ module PerfRunHelper
   # rubocop: enable Naming/AccessorMethodName
 end
 
-Beaker::TestCase.send(:include, PerfRunHelper)
+Beaker::TestCase.include PerfRunHelper

--- a/util/metrics/collect_metrics_files.rb
+++ b/util/metrics/collect_metrics_files.rb
@@ -62,7 +62,7 @@ module Metrics
       @verbose = verbose
 
       @parent_staging_dir = Dir.mktmpdir
-      @staging_dir = @parent_staging_dir + "/puppet_metrics_collector"
+      @staging_dir = @parent_staging_dir + "/puppet-metrics-collector"
       FileUtils.mkdir_p(@staging_dir)
       puts "staging dir is #{@staging_dir}" if @verbose
     end


### PR DESCRIPTION
This update changes the name of the staging directory in the collect_metrics_files script from `puppet_metrics_collector` to `puppet-metrics-collector` for consistency. The methods that handle the metrics collector data in `perf_run_helper` and `perf_results_helper` have also been updated.