### PR TITLE
(SLV-512) Update rakefile to validate environment variables before executing performance tasks

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -12,7 +12,7 @@ REF_ARCH_STD, REF_ARCH_LARGE = ["S","L"]
 task :default => :performance
 
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
-rototiller_task :performance do
+rototiller_task :performance => "validate:validate_performance_env_vars" do
   ENV['REF_ARCH'] ||= REF_ARCH_STD
   if ENV['PUPPET_GATLING_REPORTS_ONLY'] == 'true' && (!ENV['PUPPET_GATLING_REPORTS_TARGET'] || ENV['PUPPET_GATLING_REPORTS_TARGET'] == '')
     abort 'A valid result folder (i.e. PerfTestLarge-1524848074511) must be specified for PUPPET_GATLING_REPORTS_TARGET if PUPPET_GATLING_REPORTS_ONLY=true'
@@ -21,7 +21,7 @@ rototiller_task :performance do
   if ENV['REF_ARCH'] == REF_ARCH_LARGE
     Rake::Task["pe_xl:deploy"].invoke
   else
-    Rake::Task["performance_provision_with_abs"].execute unless ENV['ABS_RESOURCE_HOSTS'] ||
+    Rake::Task["performance_provision_with_abs"].invoke unless ENV['ABS_RESOURCE_HOSTS'] ||
       (ENV['BEAKER_HOSTS'] &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/pe-perf-test.cfg' &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg' &&
@@ -43,7 +43,7 @@ rototiller_task :opsworks_performance do
   raise "The test must be Opsworks.rb, or '' if you plan to execute tests later" unless
     ["", "tests/OpsWorks.rb"].include? ENV["BEAKER_TESTS"]
   configure_opsworks
-  Rake::Task["performance"].execute
+  Rake::Task["performance"].invoke
 end
 
 def configure_opsworks
@@ -74,9 +74,9 @@ def configure_opsworks
 end
 
 desc 'Provision systems for the performance task with ABS - included in the performance task'
-rototiller_task :performance_provision_with_abs do |t|
-  raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
-      ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
+rototiller_task :performance_provision_with_abs  => "validate:verify_beaker_install_type" do |t|
+  # raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
+  #     ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
   t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
@@ -102,7 +102,7 @@ rototiller_task :setup_recording_agent do
   ENV['ABS_RESOURCE_HOSTS'] = File.open("last_abs_resource_hosts.log").readlines[0] if File.exist? "last_abs_resource_hosts.log"
   ENV['BEAKER_PRE_SUITE'] = "setup/install_gatling/00_pre_install/05_initialize_helpers.rb,setup/install_gatling/setup_metrics_as_agent.rb"
   ENV['BEAKER_TESTS'] = ""
-  Rake::Task["performance_without_provision"].execute
+  Rake::Task["performance_without_provision"].invoke
 end
 
 desc 'Run Performance tests using previously provisioned hosts'
@@ -110,11 +110,11 @@ rototiller_task :performance_against_already_provisioned do
   ENV['BEAKER_HOSTS'] ||= "log/latest/hosts_preserved.yml"
   ENV['ABS_RESOURCE_HOSTS'] = File.open("last_abs_resource_hosts.log").readlines[0] if File.exist? "last_abs_resource_hosts.log"
   ENV['BEAKER_PRE_SUITE'] = ""
-  Rake::Task["performance_without_provision"].execute
+  Rake::Task["performance_without_provision"].invoke
 end
 
 desc 'Execute beaker performance setup and tests against existing hosts specified by ABS_RESOURCE_HOSTS env var, intended to be used in CI - use task "performance" for local/dev execution'
-rototiller_task :performance_without_provision do |t|
+rototiller_task :performance_without_provision => "validate:validate_performance_env_vars" do |t|
   ENV['REF_ARCH'] ||= REF_ARCH_STD
   if ENV['REF_ARCH'] == REF_ARCH_LARGE
     generated_hosts = "build/pe_xl/beaker.cfg"
@@ -272,13 +272,13 @@ end
 desc 'Run Performance setup for clamps'
 rototiller_task :performance_clamps do |t|
   ENV['ENVIRONMENT_TYPE'] = 'clamps'
-  Rake::Task["performance"].execute
+  Rake::Task["performance"].invoke
 end
 
 desc 'Run Performance setup for gatling'
 rototiller_task :performance_gatling do |t|
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
-  Rake::Task["performance"].execute
+  Rake::Task["performance"].invoke
 end
 
 desc 'Run Performance setup and a very short iteration of gatling tests'
@@ -290,14 +290,14 @@ rototiller_task :acceptance do |t|
   ENV['BEAKER_POST_SUITE'] = ''
   # Need to change this from an AWS OS image to a vmpooler OS image
   ENV['ABS_OS'] ||= 'centos-7-x86_64'
-  Rake::Task["performance"].execute
+  Rake::Task["performance"].invoke
 end
 
 desc 'Run Performance setup for gatling'
 rototiller_task :performance_setup do
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = ''
-  Rake::Task["performance"].execute
+  Rake::Task["performance"].invoke
 end
 
 desc 'Run Soak setup and test for gatling'
@@ -308,13 +308,13 @@ rototiller_task :soak do
   ENV['PUPPET_SCALE_CLASS'] = ENV['PUPPET_SCALE_CLASS'] || 'role::by_size::large'
   ENV['PUPPET_GATLING_SCALE_TUNE'] = ENV['PUPPET_GATLING_SCALE_TUNE'] || 'true'
   ENV['ABS_AWS_REAP_DAYS'] = ENV['ABS_AWS_REAP_DAYS'] || '30'
-  Rake::Task["performance"].execute
+  Rake::Task["performance"].invoke
 end
 
 desc 'Run Soak setup for gatling'
 rototiller_task :soak_setup do
   ENV['BEAKER_TESTS'] = ''
-  Rake::Task["soak"].execute
+  Rake::Task["soak"].invoke
 end
 
 desc 'Run Soak test for gatling on previously provisioned hosts'
@@ -323,7 +323,7 @@ rototiller_task :soak_provisioned do
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Soak.rb'
   ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
   ENV['PUPPET_SCALE_CLASS'] = ENV['PUPPET_SCALE_CLASS'] || 'role::by_size::large'
-  Rake::Task["performance_against_already_provisioned"].execute
+  Rake::Task["performance_against_already_provisioned"].invoke
 end
 
 desc 'Run Scale setup and test for gatling'
@@ -333,26 +333,26 @@ rototiller_task :autoscale do
   ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
   ENV['PUPPET_SCALE_CLASS'] = ENV['PUPPET_SCALE_CLASS'] || 'role::by_size::small'
   ENV['PUPPET_GATLING_SCALE_TUNE'] = ENV['PUPPET_GATLING_SCALE_TUNE'] || 'true'
-  Rake::Task["performance"].execute
-  Rake::Task["autoscale_handle_latest_results"].execute unless ENV['BEAKER_TESTS'] == ''
+  Rake::Task["performance"].invoke
+  Rake::Task["autoscale_handle_latest_results"].invoke unless ENV['BEAKER_TESTS'] == ''
 end
 
 desc 'Run Scale setup and test for gatling restarting pe-puppetserver with each iteration'
 rototiller_task :autoscale_cold do
   ENV['PUPPET_GATLING_SCALE_RESTART_PUPPETSERVER'] = 'true'
-  Rake::Task["autoscale"].execute
+  Rake::Task["autoscale"].invoke
 end
 
 desc 'Run Scale setup for gatling without restarting pe-puppetserver'
 rototiller_task :autoscale_warm do
   ENV['PUPPET_GATLING_SCALE_RESTART_PUPPETSERVER'] = 'false'
-  Rake::Task["autoscale"].execute
+  Rake::Task["autoscale"].invoke
 end
 
 desc 'Run Scale setup for gatling'
 rototiller_task :autoscale_setup do
   ENV['BEAKER_TESTS'] = ''
-  Rake::Task["autoscale"].execute
+  Rake::Task["autoscale"].invoke
 end
 
 desc 'Run puppet infrastructure tune setup for gatling on a previously provisioned master'
@@ -361,7 +361,7 @@ rototiller_task :autoscale_tune do
   ENV['BEAKER_TESTS'] = 'setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb'
   ENV['BEAKER_PRESERVE_HOSTS'] = 'always'
   ENV['PUPPET_GATLING_SCALE_TUNE'] = 'true'
-  Rake::Task["performance_against_already_provisioned"].execute
+  Rake::Task["performance_against_already_provisioned"].invoke
 end
 
 desc 'Run Scale test for gatling on previously provisioned hosts'
@@ -370,20 +370,20 @@ rototiller_task :autoscale_provisioned do
   ENV['BEAKER_TESTS'] = ENV['BEAKER_TESTS'] || 'tests/Scale.rb'
   ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
   ENV['PUPPET_SCALE_CLASS'] = ENV['PUPPET_SCALE_CLASS'] || 'role::by_size::small'
-  Rake::Task["performance_against_already_provisioned"].execute
-  Rake::Task["autoscale_handle_latest_results"].execute
+  Rake::Task["performance_against_already_provisioned"].invoke
+  Rake::Task["autoscale_handle_latest_results"].invoke
 end
 
 desc 'Run Scale setup for gatling'
 rototiller_task :autoscale_provisioned_cold do
   ENV['PUPPET_GATLING_SCALE_RESTART_PUPPETSERVER'] = 'true'
-  Rake::Task["autoscale_provisioned"].execute
+  Rake::Task["autoscale_provisioned"].invoke
 end
 
 desc 'Run Scale setup for gatling'
 rototiller_task :autoscale_provisioned_warm do
   ENV['PUPPET_GATLING_SCALE_RESTART_PUPPETSERVER'] = 'false'
-  Rake::Task["autoscale_provisioned"].execute
+  Rake::Task["autoscale_provisioned"].invoke
 end
 
 desc 'Run perf simulation for CD4PE testing on previously provisioned hosts'
@@ -404,7 +404,7 @@ rototiller_task :autoscale_provisioned_cd4pe do
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'cd4pe.json'
 
   # use the autoscale test type using previously provisioned hosts with no restart
-  Rake::Task["autoscale_provisioned_warm"].execute
+  Rake::Task["autoscale_provisioned_warm"].invoke
 end
 
 desc 'Run tiny Scale test for gatling on previously provisioned hosts'
@@ -412,7 +412,7 @@ rototiller_task :autoscale_provisioned_tiny do
   ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '3'
   ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '1'
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_tiny.json'
-  Rake::Task["autoscale_provisioned"].execute
+  Rake::Task["autoscale_provisioned"].invoke
 end
 
 desc 'Run small Scale test for gatling on previously provisioned hosts'
@@ -420,7 +420,7 @@ rototiller_task :autoscale_provisioned_sm do
   ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '10'
   ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '10'
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_sm.json'
-  Rake::Task["autoscale_provisioned"].execute
+  Rake::Task["autoscale_provisioned"].invoke
 end
 
 desc 'Run medium Scale test for gatling on previously provisioned hosts'
@@ -428,13 +428,13 @@ rototiller_task :autoscale_provisioned_med do |t|
   ENV['PUPPET_GATLING_SCALE_ITERATIONS'] = '10'
   ENV['PUPPET_GATLING_SCALE_INCREMENT'] = '100'
   ENV['PUPPET_GATLING_SCALE_SCENARIO'] = 'Scale_med.json'
-  Rake::Task["autoscale_provisioned"].execute
+  Rake::Task["autoscale_provisioned"].invoke
 end
 
 desc 'Handle the latest scale results after the run has completed'
 task :autoscale_handle_latest_results do
-  Rake::Task["autoscale_copy_log"].execute
-  Rake::Task["autoscale_csv2html"].execute
+  Rake::Task["autoscale_copy_log"].invoke
+  Rake::Task["autoscale_csv2html"].invoke
 end
 
 desc 'Copy latest log to latest scale results after the run has completed'
@@ -510,7 +510,7 @@ namespace :lint do
 end
 
 namespace :pr do
-  desc "Run the lint, and test tasks for pull requests"
+  desc "Run the lint and test tasks for pull requests"
   task :check do
     puts "Running GPLT PR checks"
     tasks = ["lint:rubocop", "test:spec"]
@@ -611,5 +611,45 @@ namespace :pe_xl do
   desc "Deploy pe_xl arch"
   task :deploy => [:clean, :provision, :run_plan] do
     puts "Deploying a pe_xl architecture"
+  end
+
+end
+
+namespace :validate do
+  desc "Validate the environment variables"
+  task :validate_performance_env_vars do
+    Rake::Task["bigquery:verify_baseline_version"].invoke
+  end
+
+  desc "Verifies that the BEAKER_INSTALL_TYPE environment variable and dependencies have been specified"
+  task :verify_beaker_install_type do
+    # TODO: extract to a helper and spec test
+    # TODO: validate the specified values
+    raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
+        ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
+
+    if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
+      raise "The BEAKER_PE_VER and BEAKER_PE_DIR environment variables must be specified when BEAKER_INSTALL_TYPE == 'pe'" if
+          ENV['BEAKER_PE_VER'].nil? || ENV['BEAKER_PE_DIR'].nil?
+    else
+      raise "The PACKAGE_BUILD_VERSION and PUPPET_AGENT_VERSION environment variables must be specified when BEAKER_INSTALL_TYPE == 'foss'" if
+          ENV['PACKAGE_BUILD_VERSION'].nil? || ENV['PUPPET_AGENT_VERSION'].nil?
+    end
+  end
+
+end
+
+namespace :bigquery do
+  desc "List the baseline versions in BigQuery"
+  task :baseline_versions do
+    versions = baseline_versions
+    puts "Baseline versions:"
+    puts versions
+  end
+
+  desc "Verify that the specified baseline PE version exists in BigQuery"
+  task :verify_baseline_version do
+    # if BASELINE_PE_VER is specified verify that it exists before proceeding
+    verify_baseline_version ENV["BASELINE_PE_VER"] if ENV["BASELINE_PE_VER"]
   end
 end

--- a/rakefile
+++ b/rakefile
@@ -12,7 +12,7 @@ REF_ARCH_STD, REF_ARCH_LARGE = ["S","L"]
 task :default => :performance
 
 desc 'Provision systems using ABS (or use already set ABS_RESOURCE_HOSTS) and then execute beaker performance setup and tests'
-rototiller_task :performance => "validate:validate_performance_env_vars" do
+rototiller_task :performance => "validate:performance_env_vars" do
   ENV['REF_ARCH'] ||= REF_ARCH_STD
   if ENV['PUPPET_GATLING_REPORTS_ONLY'] == 'true' && (!ENV['PUPPET_GATLING_REPORTS_TARGET'] || ENV['PUPPET_GATLING_REPORTS_TARGET'] == '')
     abort 'A valid result folder (i.e. PerfTestLarge-1524848074511) must be specified for PUPPET_GATLING_REPORTS_TARGET if PUPPET_GATLING_REPORTS_ONLY=true'
@@ -27,7 +27,7 @@ rototiller_task :performance => "validate:validate_performance_env_vars" do
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/foss-perf-test.cfg' &&
           ENV['BEAKER_HOSTS'] != 'config/beaker_hosts/opsworks-perf-test.cfg')
   end
-  Rake::Task["performance_without_provision"].execute
+  Rake::Task["performance_without_provision"].invoke
   Rake::Task["performance_deprovision_with_abs"].execute unless ENV['BEAKER_PRESERVE_HOSTS'] == 'always' ||
       ((@beaker_cmd.nil? || @beaker_cmd.result.exit_code != 0)&&
           ENV['BEAKER_PRESERVE_HOSTS'] == 'onfail')
@@ -74,9 +74,8 @@ def configure_opsworks
 end
 
 desc 'Provision systems for the performance task with ABS - included in the performance task'
-rototiller_task :performance_provision_with_abs  => "validate:verify_beaker_install_type" do |t|
-  # raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
-  #     ENV['BEAKER_INSTALL_TYPE'] == 'pe' || ENV['BEAKER_INSTALL_TYPE'] == 'foss'
+# validate the BEAKER_INSTALL_TYPE (and dependent env vars) to prevent provisioning if incorrectly specified
+rototiller_task :performance_provision_with_abs  => "validate:beaker_install_type" do |t|
   t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
@@ -114,7 +113,7 @@ rototiller_task :performance_against_already_provisioned do
 end
 
 desc 'Execute beaker performance setup and tests against existing hosts specified by ABS_RESOURCE_HOSTS env var, intended to be used in CI - use task "performance" for local/dev execution'
-rototiller_task :performance_without_provision => "validate:validate_performance_env_vars" do |t|
+rototiller_task :performance_without_provision => "validate:performance_env_vars" do |t|
   ENV['REF_ARCH'] ||= REF_ARCH_STD
   if ENV['REF_ARCH'] == REF_ARCH_LARGE
     generated_hosts = "build/pe_xl/beaker.cfg"
@@ -616,13 +615,13 @@ namespace :pe_xl do
 end
 
 namespace :validate do
-  desc "Validate the environment variables"
-  task :validate_performance_env_vars do
-    Rake::Task["bigquery:verify_baseline_version"].invoke
+  desc "Validate the environment variables for the 'performance' rake tasks"
+  task :performance_env_vars do
+    Rake::Task["validate:baseline_pe_version"].invoke if ENV["BASELINE_PE_VER"]
   end
 
   desc "Verifies that the BEAKER_INSTALL_TYPE environment variable and dependencies have been specified"
-  task :verify_beaker_install_type do
+  task :beaker_install_type do
     # TODO: extract to a helper and spec test
     # TODO: validate the specified values
     raise "The BEAKER_INSTALL_TYPE env var must be set to either 'pe' or 'foss' to continue" unless
@@ -637,19 +636,20 @@ namespace :validate do
     end
   end
 
+  desc "Verify that the specified baseline PE version exists in BigQuery"
+  task :baseline_pe_version do
+    # if BASELINE_PE_VER is specified verify that it exists before proceeding
+    verify_baseline_pe_version ENV["BASELINE_PE_VER"]
+  end
+
 end
 
 namespace :bigquery do
-  desc "List the baseline versions in BigQuery"
-  task :baseline_versions do
-    versions = baseline_versions
+  desc "List the baseline PE versions in BigQuery"
+  task :list_baseline_pe_versions do
+    versions = baseline_pe_versions
     puts "Baseline versions:"
     puts versions
   end
 
-  desc "Verify that the specified baseline PE version exists in BigQuery"
-  task :verify_baseline_version do
-    # if BASELINE_PE_VER is specified verify that it exists before proceeding
-    verify_baseline_version ENV["BASELINE_PE_VER"] if ENV["BASELINE_PE_VER"]
-  end
 end

--- a/spec/tests/helpers/perf_results_helper_spec.rb
+++ b/spec/tests/helpers/perf_results_helper_spec.rb
@@ -532,7 +532,7 @@ describe PerfResultsHelper do
 
     context "when the GOOGLE_APPLICATION_CREDENTIALS environment variable is empty" do
       it "raises an error" do
-        ENV["GOOGLE_APPLICATION_CREDENTIALS"] = nil
+        ENV["GOOGLE_APPLICATION_CREDENTIALS"] = ""
         expect { subject.query_bigquery(TEST_BIGQUERY_SQL) }
           .to raise_error(/GOOGLE_APPLICATION_CREDENTIALS/)
       end
@@ -561,11 +561,11 @@ describe PerfResultsHelper do
     end
   end
 
-  describe "#baseline_versions" do
+  describe "#baseline_pe_versions" do
     context "when the query execution returns empty data" do
       it "raises an error" do
         expect(subject).to receive(:query_bigquery).and_return([])
-        expect { subject.baseline_versions }
+        expect { subject.baseline_pe_versions }
           .to raise_error(/Error/)
       end
     end
@@ -576,29 +576,28 @@ describe PerfResultsHelper do
         test_expected_versions = ["2142.2.1"]
 
         expect(subject).to receive(:query_bigquery).and_return(test_result)
-        expect(subject.baseline_versions).to eq(test_expected_versions)
+        expect(subject.baseline_pe_versions).to eq(test_expected_versions)
       end
     end
   end
 
-  # TODO: implement
-  describe "#verify_baseline_version" do
+  describe "#verify_baseline_pe_version" do
     test_baseline_versions = ["2142.2.1"]
 
     context "when the specified version is found" do
       it "returns true" do
         test_version = "2142.2.1"
 
-        expect(subject).to receive(:baseline_versions).and_return(test_baseline_versions)
-        expect(subject.verify_baseline_version(test_version)).to eq(true)
+        expect(subject).to receive(:baseline_pe_versions).and_return(test_baseline_versions)
+        expect(subject.verify_baseline_pe_version(test_version)).to eq(true)
       end
     end
 
     context "when the specified version is not found" do
       it "raises an error" do
         test_version = "1942.2.1"
-        expect(subject).to receive(:baseline_versions).and_return(test_baseline_versions)
-        expect { subject.verify_baseline_version(test_version) }
+        expect(subject).to receive(:baseline_pe_versions).and_return(test_baseline_versions)
+        expect { subject.verify_baseline_pe_version(test_version) }
           .to raise_error(/#{test_version}/)
       end
     end

--- a/spec/tests/helpers/perf_results_helper_spec.rb
+++ b/spec/tests/helpers/perf_results_helper_spec.rb
@@ -40,6 +40,8 @@ TEST_JSON_NO_CATALOG = <<~TEST_JSON
   }
 TEST_JSON
 
+TEST_BIGQUERY_SQL = "SELECT DISTINCT pe_build_number FROM `perf-metrics.perf_metrics.atop_metrics`"
+
 # rubocop:disable Metrics/BlockLength
 describe PerfResultsHelper do
   before do
@@ -505,6 +507,99 @@ describe PerfResultsHelper do
     # TODO
     context "when the specified file contains catalog metrics" do
       it "returns the metrics" do
+      end
+    end
+  end
+
+  describe "#query_bigquery" do
+    let(:logger) { double }
+    let(:test_google_bigquery) { Class.new }
+    let(:test_bigquery_instance) { Class.new }
+    test_data = [{ "field" => "value" }]
+
+    before do
+      allow(subject).to receive(:logger).and_return(logger)
+      stub_const("Google::Cloud::Bigquery", test_google_bigquery)
+    end
+
+    context "when the GOOGLE_APPLICATION_CREDENTIALS environment variable is nil" do
+      it "raises an error" do
+        ENV["GOOGLE_APPLICATION_CREDENTIALS"] = nil
+        expect { subject.query_bigquery(TEST_BIGQUERY_SQL) }
+          .to raise_error(/GOOGLE_APPLICATION_CREDENTIALS/)
+      end
+    end
+
+    context "when the GOOGLE_APPLICATION_CREDENTIALS environment variable is empty" do
+      it "raises an error" do
+        ENV["GOOGLE_APPLICATION_CREDENTIALS"] = nil
+        expect { subject.query_bigquery(TEST_BIGQUERY_SQL) }
+          .to raise_error(/GOOGLE_APPLICATION_CREDENTIALS/)
+      end
+    end
+
+    context "when the GOOGLE_APPLICATION_CREDENTIALS environment variable is set" do
+      it "queries BigQuery with the specified sql and returns the data" do
+        ENV["GOOGLE_APPLICATION_CREDENTIALS"] = "test"
+        expect(test_google_bigquery).to receive(:new).and_return(test_bigquery_instance)
+        expect(test_bigquery_instance).to receive(:query).and_return(test_data)
+
+        expect(subject.query_bigquery(TEST_BIGQUERY_SQL)).to eq(test_data)
+      end
+    end
+
+    context "when the query execution returns empty data" do
+      it "logs the error and returns the data" do
+        ENV["GOOGLE_APPLICATION_CREDENTIALS"] = "test"
+        empty_data = []
+        expect(test_google_bigquery).to receive(:new).and_return(test_bigquery_instance)
+        expect(test_bigquery_instance).to receive(:query).and_return(empty_data)
+        expect(logger).to receive(:error)
+
+        expect(subject.query_bigquery(TEST_BIGQUERY_SQL)).to eq(empty_data)
+      end
+    end
+  end
+
+  describe "#baseline_versions" do
+    context "when the query execution returns empty data" do
+      it "raises an error" do
+        expect(subject).to receive(:query_bigquery).and_return([])
+        expect { subject.baseline_versions }
+          .to raise_error(/Error/)
+      end
+    end
+
+    context "when the query execution returns non-empty data" do
+      it "returns an array of the baseline versions" do
+        test_result = [pe_build_number: "2142.2.1"]
+        test_expected_versions = ["2142.2.1"]
+
+        expect(subject).to receive(:query_bigquery).and_return(test_result)
+        expect(subject.baseline_versions).to eq(test_expected_versions)
+      end
+    end
+  end
+
+  # TODO: implement
+  describe "#verify_baseline_version" do
+    test_baseline_versions = ["2142.2.1"]
+
+    context "when the specified version is found" do
+      it "returns true" do
+        test_version = "2142.2.1"
+
+        expect(subject).to receive(:baseline_versions).and_return(test_baseline_versions)
+        expect(subject.verify_baseline_version(test_version)).to eq(true)
+      end
+    end
+
+    context "when the specified version is not found" do
+      it "raises an error" do
+        test_version = "1942.2.1"
+        expect(subject).to receive(:baseline_versions).and_return(test_baseline_versions)
+        expect { subject.verify_baseline_version(test_version) }
+          .to raise_error(/#{test_version}/)
       end
     end
   end

--- a/tests/helpers/perf_results_helper.rb
+++ b/tests/helpers/perf_results_helper.rb
@@ -778,7 +778,7 @@ module PerfResultsHelper
 
     bigquery = Google::Cloud::Bigquery.new project: BIGQUERY_PROJECT
     data = bigquery.query sql
-    logger.error("Cannot find result that matches query: #{sql}") if data.empty?
+    logger.error("Cannot find result in BigQuery project '#{BIGQUERY_PROJECT}' matching query: #{sql}") if data.empty?
     data
   end
 
@@ -791,14 +791,15 @@ module PerfResultsHelper
   # @return [Array] The array of versions
   #
   # @example
-  #   versions_array = baseline_versions
+  #   versions_array = baseline_pe_versions
   #
-  def baseline_versions
+  def baseline_pe_versions
     sql = "SELECT DISTINCT pe_build_number FROM `perf-metrics.perf_metrics.atop_metrics` " \
           "WHERE pe_build_number IS NOT NULL " \
           "ORDER BY pe_build_number"
     data = query_bigquery(sql)
-    raise "Error: cannot find result that matches query: #{sql}" if data.empty?
+    error = "Error: cannot find baseline PE versions in BigQuery project '#{BIGQUERY_PROJECT}' with query: #{sql}"
+    raise error if data.empty?
 
     versions = []
     data.each do |row|
@@ -819,11 +820,11 @@ module PerfResultsHelper
   # @return [Boolean] true if the specified baseline PE version is found
   #
   # @example
-  #   is_verified = verify_baseline_version(baseline_pe_ver)
+  #   is_verified = verify_baseline_pe_version(baseline_pe_ver)
   #
-  def verify_baseline_version(baseline_pe_ver)
-    versions = baseline_versions
-    raise "Invalid baseline version: #{baseline_pe_ver}" unless versions.include?(baseline_pe_ver)
+  def verify_baseline_pe_version(baseline_pe_ver)
+    versions = baseline_pe_versions
+    raise "Invalid baseline PE version: #{baseline_pe_ver}" unless versions.include?(baseline_pe_ver)
 
     true
   end

--- a/tests/helpers/perf_results_helper.rb
+++ b/tests/helpers/perf_results_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "csv"
+require "google/cloud/bigquery"
 require "json"
 require "minitar"
 require "zlib"
@@ -67,6 +68,8 @@ module PerfResultsHelper
                            "report"].freeze
 
   PUPPET_METRICS_COLLECTOR_DIR_NAME = "puppet-metrics-collector"
+
+  BIGQUERY_PROJECT = "perf-metrics"
 
   # Extract Gatling JSON data into a CSV file in the format used in our release test reports
   # and convert the CSV file to an HTML file for easy viewing
@@ -757,5 +760,73 @@ module PerfResultsHelper
 
     row
   end
+
+  # Execute the specified SQL query via BigQuery
+  #
+  # @author Bill Claytor
+  #
+  # @raise [StandardError] If the GOOGLE_APPLICATION_CREDENTIALS environment variable is not set
+  #
+  # @return [Array] The array of versions
+  #
+  # @example
+  #   versions_array = baseline_versions
+  #
+  def query_bigquery(sql)
+    error = "The GOOGLE_APPLICATION_CREDENTIALS environment variable must be set with the location of the JSON key file"
+    raise error if ENV["GOOGLE_APPLICATION_CREDENTIALS"].nil? || ENV["GOOGLE_APPLICATION_CREDENTIALS"].empty?
+
+    bigquery = Google::Cloud::Bigquery.new project: BIGQUERY_PROJECT
+    data = bigquery.query sql
+    logger.error("Cannot find result that matches query: #{sql}") if data.empty?
+    data
+  end
+
+  # Retrieve the list of baseline PE versions from BigQuery
+  #
+  # @author Bill Claytor
+  #
+  # @raise [StandardError] If the query returns no data
+  #
+  # @return [Array] The array of versions
+  #
+  # @example
+  #   versions_array = baseline_versions
+  #
+  def baseline_versions
+    sql = "SELECT DISTINCT pe_build_number FROM `perf-metrics.perf_metrics.atop_metrics` " \
+          "WHERE pe_build_number IS NOT NULL " \
+          "ORDER BY pe_build_number"
+    data = query_bigquery(sql)
+    raise "Error: cannot find result that matches query: #{sql}" if data.empty?
+
+    versions = []
+    data.each do |row|
+      versions << row[:pe_build_number]
+    end
+
+    versions
+  end
+
+  # Verify that the specified baseline PE version exists in BigQuery
+  #
+  # @author Bill Claytor
+  #
+  # @param [String] baseline_pe_ver The baseline PE version to verify
+  #
+  # @raise [StandardError] If the specified baseline PE version is not found
+  #
+  # @return [Boolean] true if the specified baseline PE version is found
+  #
+  # @example
+  #   is_verified = verify_baseline_version(baseline_pe_ver)
+  #
+  def verify_baseline_version(baseline_pe_ver)
+    versions = baseline_versions
+    raise "Invalid baseline version: #{baseline_pe_ver}" unless versions.include?(baseline_pe_ver)
+
+    true
+  end
+
   # rubocop:enable Metrics/LineLength
 end

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -2,7 +2,6 @@
 
 require "beaker"
 require "beaker-benchmark"
-require "google/cloud/bigquery"
 require "master_manipulator"
 require "beaker-puppet"
 
@@ -948,8 +947,7 @@ module PerfRunHelper
         "WHERE pe_build_number = '#{BASELINE_PE_VER}' AND test_scenario = '#{current_test_name}' " \
            "GROUP BY pe_build_number, test_scenario)"
 
-      bigquery = Google::Cloud::Bigquery.new project: "perf-metrics"
-      data = bigquery.query sql
+      data = query_bigquery sql
       if !data.empty?
         logger.info("Baseline result returned from BigQuery: #{data}")
       else


### PR DESCRIPTION
This update adds the `validate:performance_env_vars` as a pre-requisite for the `performance` and `performance_without_provision` tasks, and the `validate:beaker_install_type` as a pre-requisite for the `performance_provision_with_abs` task.

The `validate:validate_performance_env_vars` task currently invokes the `validate:baseline_pe_version` task which verifies the `BASELINE_PE_VER` environment variable if specified. Additional validations can be added here.

The `validate:beaker_install_type` task extracts the existing verification of `BEAKER_INSTALL_TYPE` and also verifies `BEAKER_PE_VER` and `BEAKER_PE_DIR` for 'pe', `PACKAGE_BUILD_VERSION` and `PUPPET_AGENT_VERSION` for 'foss'.

To avoid duplication the code to perform the BigQuery query has been extracted to `perf_results_helper.rb`; spec tests have been added.