### PR TITLE
(SLV-647) Ensure all puppet changes in post inst

### DIFF
--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -725,6 +725,7 @@ module PerfHelper
   end
 
   def run_agent_until_no_change(hosts, max_retries = 5, retry_interval = 2)
+    hosts = Array(hosts)
     retry_params = { max_retries: max_retries,
                      retry_interval: retry_interval,
                      desired_exit_codes: [0] }

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -723,5 +723,14 @@ module PerfHelper
     }
     classifier.find_or_create_node_group_model(loadbalancer_exports_group)
   end
+
+  def run_agent_until_no_change(hosts, max_retries = 5, retry_interval = 2)
+    retry_params = { max_retries: max_retries,
+                     retry_interval: retry_interval,
+                     desired_exit_codes: [0] }
+    hosts.each do |host|
+      retry_on(host, puppet("agent", "-t"), retry_params)
+    end
+  end
 end
 # rubocop:enable Style/SpecialGlobalVars

--- a/setup/install_gatling/40_post_install/30_final_puppet_run.rb
+++ b/setup/install_gatling/40_post_install/30_final_puppet_run.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 test_name "final puppet run" do
-  step "run puppet on all nodes" do
+  step "Set server to master on hosts" do
     on hosts, "puppet config set --section agent server #{master.hostname}"
-    on hosts, "puppet agent -t", acceptable_exit_codes: [0, 2, 6]
+  end
+  step "Run puppet until all changes are applied" do
+    run_agent_until_no_change(hosts)
   end
 end

--- a/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
+++ b/setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-MAX_AGENT_RUNS = 5
-
-test_name "Run puppet infrastructure tune" do # rubocop:disable Metrics/BlockLength
+test_name "Run puppet infrastructure tune" do
   def puppet_infrastructure_tune
     base_tune_command = "puppet infrastructure tune"
     common_yaml_path = "/etc/puppetlabs/code-staging/environments/production/data/common.yaml"
@@ -45,12 +43,7 @@ test_name "Run puppet infrastructure tune" do # rubocop:disable Metrics/BlockLen
     ].join(" ")
     on master, commit
 
-    # re-run the agent up to MAX_AGENT_RUNS attempts
-    retry_params = { max_retries: MAX_AGENT_RUNS,
-                     retry_interval: 2,
-                     desired_exit_codes: [0] }
-
-    retry_on(master, puppet("agent", "-t"), retry_params)
+    run_agent_until_no_change(master)
 
     # output current tune
     puts "Checking current tune:"

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -595,5 +595,22 @@ describe PerfHelperClass do
       subject.add_loadbalancer_groups(loadbalancer, compile_master)
     end
   end
+  describe "#run_agent_until_no_change" do
+    it "calls retry_on on puppet for given host" do
+      expect(subject).to receive(:puppet).with("agent", "-t")
+      expect(subject).to receive(:retry_on).with(hosts[0], any_args)
+      expect(subject.run_agent_until_no_change(hosts)).to eq(hosts)
+    end
+    it "updates retry params based on given parameters" do
+      retries = 42
+      interval = 7
+      expected_retry_params = { max_retries: retries,
+                                retry_interval: interval,
+                                desired_exit_codes: [0] }
+      expect(subject).to receive(:puppet).with("agent", "-t")
+      expect(subject).to receive(:retry_on).with(hosts[0], nil, expected_retry_params)
+      expect(subject.run_agent_until_no_change(hosts, retries, interval)).to eq(hosts)
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -609,7 +609,7 @@ describe PerfHelperClass do
                                 desired_exit_codes: [0] }
       expect(subject).to receive(:puppet).with("agent", "-t")
       expect(subject).to receive(:retry_on).with(hosts[0], nil, expected_retry_params)
-      expect(subject.run_agent_until_no_change(hosts, retries, interval)).to eq(hosts)
+      subject.run_agent_until_no_change(hosts, retries, interval)
     end
   end
 end


### PR DESCRIPTION
This commit updates the `30_final_puppet_run` pre-suite to ensure that
the puppet agent is run repeatedly until all changes are applied and the
exit code is `0`.