### PR TITLE
(SLV-280) Copy system logs from suts

### DIFF
--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -798,7 +798,6 @@ module PerfRunHelper
       # Write summary results to log so it can be archived
       perf.log_csv
 
-      # TODO: tar archive file before copying to avoid timeouts with soak results
       begin
         copy_archive_files
         hosts.each do |host|


### PR DESCRIPTION
This commit adds a helper to copy puppet system logs from suts to the
test runner.