### PR TITLE
(SLV-652) Update abs_helper to retry request on invalid response code

### DIFF
--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -221,12 +221,12 @@ module AbsHelper
 
       next unless ct < ABS_MAX_REQUEST_ATTEMPTS
 
-      puts "Unable to provision host for role: #{role} with request #{ct} of #{ABS_MAX_REQUEST_ATTEMPTS}"
+      puts "Unable to provision host for role '#{role}' with request #{ct} of #{ABS_MAX_REQUEST_ATTEMPTS}"
       puts "Retrying request..."
       puts
     end
 
-    error_msg = "Unable to provision host for role: #{role} after #{ABS_MAX_REQUEST_ATTEMPTS} attempts"
+    error_msg = "Unable to provision host for role '#{role}' after #{ABS_MAX_REQUEST_ATTEMPTS} attempts"
     raise error_msg if result.nil?
 
     result

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -35,6 +35,7 @@ module AbsHelper
   ABS_ID = "slv"
 
   ABS_MAX_REQUEST_ATTEMPTS = 3
+  ABS_RETRY_DELAY = 30
 
   # Checks whether the user has a valid token and if so initializes the instance variables
   #
@@ -222,6 +223,9 @@ module AbsHelper
       next unless ct < ABS_MAX_REQUEST_ATTEMPTS
 
       puts "Unable to provision host for role '#{role}' with request #{ct} of #{ABS_MAX_REQUEST_ATTEMPTS}"
+      puts "Waiting for #{ABS_RETRY_DELAY} seconds before retrying request..."
+      sleep ABS_RETRY_DELAY
+
       puts "Retrying request..."
       puts
     end

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -395,7 +395,7 @@ describe AbsHelperClass do
     end
 
     context "when the response is not valid" do
-      it "retries the request up to the max number of attempts before raising an error" do
+      it "retries the request up to the max number of attempts (with a delay between each) before raising an error" do
         max_attempts = AbsHelper::ABS_MAX_REQUEST_ATTEMPTS
         unable_message = "Unable to provision host for role '#{TEST_A2A_MASTER[:role]}'"
         error_message = "#{unable_message} after #{max_attempts} attempts"
@@ -416,6 +416,8 @@ describe AbsHelperClass do
           expect(subject).to receive(:puts).with(retry_message)
         end
 
+        expect(subject).to receive(:puts).with(/Waiting/).exactly(max_attempts - 1).times
+        expect(subject).to receive(:sleep).with(AbsHelper::ABS_RETRY_DELAY).exactly(max_attempts - 1).times
         expect(subject).to receive(:puts).with(/Retry/).exactly(max_attempts - 1).times
 
         expect(test_http_response).not_to receive(:body)

--- a/spec/setup/helpers/abs_helper_spec.rb
+++ b/spec/setup/helpers/abs_helper_spec.rb
@@ -397,7 +397,7 @@ describe AbsHelperClass do
     context "when the response is not valid" do
       it "retries the request up to the max number of attempts before raising an error" do
         max_attempts = AbsHelper::ABS_MAX_REQUEST_ATTEMPTS
-        unable_message = "Unable to provision host for role: #{TEST_A2A_MASTER[:role]}"
+        unable_message = "Unable to provision host for role '#{TEST_A2A_MASTER[:role]}'"
         error_message = "#{unable_message} after #{max_attempts} attempts"
 
         expect(subject).to receive(:puts).with("Host_to_request: #{TEST_A2A_MASTER}")


### PR DESCRIPTION
This update modifies the 'get_abs_resource_host' method to retry the request up to a max number of attempts (currently set to 3) before failing.
