### PR TITLE
(SLV-566) Update provision_hosts_for_roles to update abs resource log

### DIFF
--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -754,26 +754,31 @@ module AbsHelper
   #
   # @raise [RuntimeError] If provisioning is not successful
   #
-  # @return [String] The hostname of the provisioned host
+  # @return [Hash] The provisioned host
   #
   # @example
-  #   hostname = provision_host_for_role(role)
+  #   host = provision_host_for_role(role)
   #     or
-  #   hostname = provision_host_for_role(role, "c5.xlarge", "40")
+  #   host = provision_host_for_role(role, "c5.xlarge", "40")
   #
-  # TODO: spec test(s)
   def provision_host_for_role(role, size = AWS_SIZE, volume_size = AWS_VOLUME_SIZE)
     host_to_provision = get_host_to_provision(role, size, volume_size)
     abs_resource_hosts = get_abs_resource_hosts(host_to_provision)
     raise "Unable to provision host via ABS" unless abs_resource_hosts
 
+    # parse the JSON
     hosts = parse_abs_resource_hosts(abs_resource_hosts)
-    hostname = hosts[0]["hostname"]
 
-    puts "Successfully provisioned host - role: #{role}, hostname: #{hostname}"
+    # convert keys from strings to symbols (provision_pe_xl_nodes.rb expects symbols)
+    host = Hash[hosts[0].map { |key, value| [key.to_sym, value] }]
+
+    # add the role so the host can be identified by role
+    host[:role] = role
+
+    puts "Successfully provisioned host - role: #{host[:role]}, hostname: #{host[:hostname]}"
     puts
 
-    hostname
+    host
   end
 
   # Provisions a set of hosts for the specified roles
@@ -807,13 +812,15 @@ module AbsHelper
 
     # uses in_threads to allow variable modification
     Parallel.map(roles.each, in_threads: num_threads) do |role|
-      hostname = provision_host_for_role(role, size, volume_size)
-      hosts << { role: role, hostname: hostname }
+      host = provision_host_for_role(role, size, volume_size)
+      hosts << host
     end
 
     puts "The following hosts were successfully provisioned:"
     puts hosts
     puts
+
+    update_last_abs_resource_hosts(hosts.to_json)
 
     hosts
   end

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -8,7 +8,7 @@ require "json"
 require "yaml"
 require "parallel"
 
-# Provides functionality to provision and deprovision hosts via ABS
+# Provides functionality to provision and de-provision hosts via ABS
 # rubocop:disable Naming/AccessorMethodName
 module AbsHelper
   ABS_BASE_URL = "https://cinext-abs.delivery.puppetlabs.net/api/v2"

--- a/setup/helpers/abs_helper.rb
+++ b/setup/helpers/abs_helper.rb
@@ -770,6 +770,7 @@ module AbsHelper
     hosts = parse_abs_resource_hosts(abs_resource_hosts)
 
     # convert keys from strings to symbols (provision_pe_xl_nodes.rb expects symbols)
+    # TODO: remove once SLV-676 (standardize on symbols) has been implemented
     host = Hash[hosts[0].map { |key, value| [key.to_sym, value] }]
 
     # add the role so the host can be identified by role


### PR DESCRIPTION
With this update all hosts provisioned via `provision_hosts_for_roles` are written to the last_abs_resource_hosts.log file. This allows the `performance_deprovision_with_abs` rake task to be used to de-provision hosts that have been provisioned via the `util/abs/provision_pe_xl_nodes.rb` script which is used to provision hosts for the Large and XL reference architectures:
* `provision_hosts_for_role` has been updated to return the host hash rather than the hostname. It converts the keys in the `abs_resource_hosts` hash to symbols and adds the role to the hash. This provides compatibility with the `util/abs/provision_pe_xl_nodes.rb` script which expects the keys to be symbols and the role to be included.
* `provision_hosts_for_roles` has been updated to call `update_last_abs_resource_hosts` with the hosts array (converted to JSON). 
* The spec tests have been updated accordingly.
