### PR TITLE
(SLV-670) Add final puppet run to pre-suite

### DIFF
--- a/setup/install_gatling/99_final/99_final_puppet_run.rb
+++ b/setup/install_gatling/99_final/99_final_puppet_run.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+test_name "final puppet run" do
+  step "Run puppet until all changes are applied" do
+    run_agent_until_no_change(hosts)
+  end
+end

--- a/setup/options/options_foss.rb
+++ b/setup/options/options_foss.rb
@@ -16,7 +16,8 @@
     "setup/install_gatling/40_post_install/60_restart_server.rb",
     "setup/install_gatling/40_post_install/70_disable_firewall.rb",
     "setup/install_gatling/40_post_install/80_install_deps.rb",
-    "setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb"
+    "setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb",
+    "setup/install_gatling/99_final/99_final_puppet_run.rb"
   ],
   "is_puppetserver"      => true,
   "use-service"          => true, # use service scripts to start/stop stuff

--- a/setup/options/options_pe.rb
+++ b/setup/options/options_pe.rb
@@ -22,7 +22,8 @@
     "setup/install_gatling/40_post_install/80_install_deps.rb",
     "setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb",
     # unique to pe
-    "setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb"
+    "setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb",
+    "setup/install_gatling/99_final/99_final_puppet_run.rb"
   ],
   "is_puppetserver"      => true,
   "use-service"          => true, # use service scripts to start/stop stuff

--- a/setup/options/options_pe_clamps.rb
+++ b/setup/options/options_pe_clamps.rb
@@ -27,7 +27,8 @@
     "setup/install_gatling/40_post_install/80_install_deps.rb",
     "setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb",
     # unique to pe
-    "setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb"
+    "setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb",
+    "setup/install_gatling/99_final/99_final_puppet_run.rb"
   ],
   "is_puppetserver"      => true,
   "use-service"          => true, # use service scripts to start/stop stuff

--- a/setup/options/options_pe_xl.rb
+++ b/setup/options/options_pe_xl.rb
@@ -18,7 +18,8 @@
     "setup/install_gatling/40_post_install/70_disable_firewall.rb",
     "setup/install_gatling/40_post_install/80_install_deps.rb",
     "setup/install_gatling/40_post_install/99_setup_gatling_proxy.rb",
-    "setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb"
+    "setup/install_gatling/50_tune/10_puppet_infrastructure_tune.rb",
+    "setup/install_gatling/99_final/99_final_puppet_run.rb"
   ],
   "is_puppetserver"      => true,
   "use-service"          => true, # use service scripts to start/stop stuff


### PR DESCRIPTION
This commit adds a pre-suite to run puppet until all changes have been
applied on all hosts.  This is intended to get the SUTs into a desired
state prior to executing tests.

This pre-suite is also added to the options files.