### PR TITLE
(SLV-691) Delete left over puppet logdir

### DIFF
--- a/spec/tests/helpers/perf_run_helper_spec.rb
+++ b/spec/tests/helpers/perf_run_helper_spec.rb
@@ -444,15 +444,14 @@ describe PerfRunHelperClass do # rubocop:disable Metrics/BlockLength
                            { platform: Beaker::Platform.new("centos-6.5-x86_64"),
                              role: "master" }, logger: @logger)]
     end
-    it "calls archive_file_from with given host and parent dir of puppet_logdir" do
+    it "calls scp_from to copy puppet logdir to archive root" do
       # test variables
-      build_id = gplt_timestamp = nil
-      puppet_logdir = "/foo/bar/baz"
-      archive_root = "/test/archive"
-      job_name = "foobar"
-      archive_name = "#{job_name}__#{build_id}__#{gplt_timestamp}__system_logs.tgz"
-      ENV["JOB_NAME"] = job_name
+      logdir_root = "foo"
+      puppet_logdir = File.join(logdir_root, "bar", "baz")
+      archive_root = "/tmp/test/archive"
       myhost = hosts.first
+      expected_dest = File.join(archive_root, myhost, logdir_root)
+
       # mock out @archive_root instance variable
       subject.instance_variable_set(:@archive_root, archive_root)
       # mock out beaker result
@@ -461,9 +460,9 @@ describe PerfRunHelperClass do # rubocop:disable Metrics/BlockLength
 
       allow(subject).to receive(:on).with(myhost, any_args).and_return(result)
       expect(subject).to receive(:puppet).with("config", "print", "logdir")
-      expect(subject).to receive(:archive_file_from).with(myhost,
-                                                          File.dirname(puppet_logdir),
-                                                          {}, archive_root, archive_name)
+      expect(subject).to receive(:scp_from).with(myhost,
+                                                 File.dirname(puppet_logdir),
+                                                 expected_dest)
       subject.copy_system_logs(myhost)
     end
   end

--- a/spec/tests/helpers/perf_run_helper_spec.rb
+++ b/spec/tests/helpers/perf_run_helper_spec.rb
@@ -438,6 +438,7 @@ describe PerfRunHelperClass do # rubocop:disable Metrics/BlockLength
       end
     end
   end
+
   describe "#copy_system_logs" do
     let(:host) { double.as_null_object }
     let(:archive_root) { "/tmp/test/archive" }
@@ -450,28 +451,34 @@ describe PerfRunHelperClass do # rubocop:disable Metrics/BlockLength
       before { allow(subject).to receive(:archive_system_logs).with(host).and_return(archive_path) }
       before { allow(subject).to receive(:scp_from) }
       before { allow(FileUtils).to receive(:mkdir_p) }
+
       it "calls scp_from to copy archive path to archive root" do
         expected_dest = File.join(archive_root, host)
         expect(subject).to receive(:scp_from).with(host, archive_path, expected_dest)
         subject.copy_system_logs(host)
       end
+
       it "calls mkdir_p to create the local destination path" do
         expect(FileUtils).to receive(:mkdir_p)
         subject.copy_system_logs(host)
       end
     end
+
     context "when archiving fails" do
       before { allow(subject).to receive(:archive_system_logs).with(host).and_return(nil) }
-      it "scp_from is not called" do
+
+      it "does not call scp_from" do
         expect(subject).not_to receive(:scp_from)
         subject.copy_system_logs(host)
       end
-      it "mkdir_p is not called" do
+
+      it "does not call mkdir_p" do
         expect(FileUtils).not_to receive(:mkdir_p)
         subject.copy_system_logs(host)
       end
     end
   end
+
   describe "#archive_system_logs" do
     let(:host) { double.as_null_object }
     let(:puppet_logdir) { "/var/log/puppetlabs/puppet" }

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -687,11 +687,10 @@ module PerfRunHelper
     # create archive
     command = "cd #{File.dirname(puppetlabs_dir)} && " \
               "tar -czf #{archive_name} #{File.basename(puppetlabs_dir)}"
-    on(host, command, accept_all_exit_codes: true) do |result|
-      unless result.exit_code.zero?
-        logger.warn("Unable to to create archive of system logs")
-        archive_path = nil
-      end
+    result = on(host, command, accept_all_exit_codes: true)
+    unless result.exit_code.zero?
+      logger.warn("Unable to to create archive of system logs")
+      archive_path = nil
     end
 
     return archive_path

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -687,6 +687,10 @@ module PerfRunHelper
     puppet_logdir = File.dirname on(host, puppet("config", "print", "logdir")).stdout.strip
     archive_file_from(host, puppet_logdir,
                       {}, @archive_root, archive_name)
+
+    # the archive_file_from leaves the unpacked tree in place and we need to clean it up
+    logdir_root = puppet_logdir.split(File::SEPARATOR).select { |s| s.length >= 1 }.shift
+    FileUtils.rm_rf(File.join(@archive_root, host, logdir_root), secure: true)
   end
 
   private

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -676,14 +676,16 @@ module PerfRunHelper
 
   def copy_system_logs(host)
     puppet_logdir = File.dirname on(host, puppet("config", "print", "logdir")).stdout.strip
+    # Get the first path segment from puppet_logdir
     logdir_root = puppet_logdir.split(File::SEPARATOR).select { |s| s.length >= 1 }.shift
 
     dest = File.join(@archive_root, host, File.dirname(puppet_logdir))
     tar_root = File.join(@archive_root, host, logdir_root)
+    archive_name = File.join(@archive_root, host, "puppet_logdir.tgz")
 
     FileUtils.mkdir_p(dest)
     scp_from(host, puppet_logdir, dest)
-    tgz = Zlib::GzipWriter.new(File.open("#{tar_root}.tgz", "wb"))
+    tgz = Zlib::GzipWriter.new(File.open(archive_name, "wb"))
     Minitar.pack(dest, tgz)
     FileUtils.rm_rf(tar_root, secure: true)
   end


### PR DESCRIPTION
This commit updates the `copy_system_logs` helper to delete the system
log file tree left over by the beaker archive_file_from helper.