### PR TITLE
(SLV-599) Preserve hosts in performance_setup

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -294,6 +294,7 @@ end
 
 desc 'Run Performance setup for gatling'
 rototiller_task :performance_setup do
+  ENV['BEAKER_PRESERVE_HOSTS'] = ENV['BEAKER_PRESERVE_HOSTS'] || 'always'
   ENV['ENVIRONMENT_TYPE'] = 'gatling'
   ENV['BEAKER_TESTS'] = ''
   Rake::Task["performance"].invoke


### PR DESCRIPTION
This commit configures the `performance_setup` rake task to preserve
hosts by default.