### PR TITLE
(SLV-588) Fix deprecated rspec stubs

### DIFF
--- a/rakefile
+++ b/rakefile
@@ -495,8 +495,7 @@ namespace :test do
     require "rspec/core/rake_task"
     desc "Run unit tests"
     RSpec::Core::RakeTask.new do |t|
-      # TODO: remove '--deprecation-out ...' when SLV-588 has been resolved
-      t.rspec_opts = ["--color --deprecation-out rspec_deprecation_warnings.log"]
+      t.rspec_opts = ["--color"]
       t.pattern = 'spec/**/*_spec.rb'
     end
       # if rspec isn't available, we can still use this Rakefile

--- a/spec/setup/helpers/perf_helper_spec.rb
+++ b/spec/setup/helpers/perf_helper_spec.rb
@@ -543,7 +543,7 @@ describe PerfHelperClass do
 
       classifier = double("classifier").as_null_object
       allow(classifier).to receive(:get_node_group_by_name).and_return("id" => master_group_id)
-      subject.stub(:classifier) { classifier }
+      allow(subject).to receive(:classifier).and_return(classifier)
 
       expect(classifier).to receive(:update_node_group).with(master_group_id, class_opts)
       subject.configure_code_manager
@@ -553,7 +553,7 @@ describe PerfHelperClass do
   describe "#cm_deploy_all_envs" do
     it "calls deploy_all_environments on classifier" do
       classifier = double("classifier").as_null_object
-      subject.stub(:classifier) { classifier }
+      allow(subject).to receive(:classifier).and_return(classifier)
 
       expect(classifier).to receive(:deploy_all_environments)
       subject.cm_deploy_all_envs
@@ -587,7 +587,7 @@ describe PerfHelperClass do
       classifier = double("classifier",
                           get_node_group_by_name: { "id" => pe_infra_uuid },
                           find_or_create_node_group_model: true)
-      subject.stub(:classifier) { classifier }
+      allow(subject).to receive(:classifier).and_return(classifier)
 
       expect(classifier).to receive(:find_or_create_node_group_model).with(expected_lb_group)
       expect(classifier).to receive(:find_or_create_node_group_model).with(expected_lb_exports_group)


### PR DESCRIPTION
This commit replaces deprecated rspec stubs with `allow(Obj).to
receive(:message).and_return(obj)` syntax.  The Rakefile option to
create a deprecations log has been removed.