### PR TITLE
(SLV-661) Add env_setup_2019.2.1

### DIFF
--- a/config/env/env_setup_2019.2.1
+++ b/config/env/env_setup_2019.2.1
@@ -1,0 +1,3 @@
+export BEAKER_INSTALL_TYPE=pe
+export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.2.1
+export BEAKER_PE_VER=2019.2.1


### PR DESCRIPTION
This update adds the `config/env/env_setup_2019.2.1` file for Lovejoy testing.