### PR TITLE
(SLV-706) Guard baseline_assert step

### DIFF
--- a/tests/ApplesToApples.rb
+++ b/tests/ApplesToApples.rb
@@ -34,9 +34,10 @@ step "average memory" do
   assert_later(atop_result.avg_mem < 3_000_000, "Average memory was: #{atop_result.avg_mem}, expected < 3000000")
 end
 
-# This step will only be run if BASELINE_PE_VER has been set.
-step "baseline assertions" do
-  baseline_assert(atop_result, gatling_result)
+if ENV["BASELINE_PE_VER"]
+  step "baseline assertions" do
+    baseline_assert(atop_result, gatling_result)
+  end
 end
 
 assert_all

--- a/tests/acceptance.rb
+++ b/tests/acceptance.rb
@@ -30,9 +30,10 @@ step "average memory" do
                "Average memory was: #{atop_result.avg_mem}, expected < 3000000")
 end
 
-# This step will only be run if BASELINE_PE_VER has been set.
-step "baseline assertions" do
-  baseline_assert(atop_result, gatling_result)
+if ENV["BASELINE_PE_VER"]
+  step "baseline assertions" do
+    baseline_assert(atop_result, gatling_result)
+  end
 end
 
 assert_all


### PR DESCRIPTION
This commit adds conditional guards around the baseline_assert step
because it will fail if a baseline has not been set.