### PR TITLE
(SLV-656) Add save_average_compile_time helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
     - 'Boltdir/site-modules/metrics/spec/fixtures/**/*'
     - 'Boltdir/site-modules/pe_xl/**/*'
     - 'vendor/**/*'
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -5,7 +5,7 @@ require "./tests/helpers/perf_run_helper"
 # Add pry support when available
 begin
   require "pry"
-rescue LoadError # rubocop: disable Lint/HandleExceptions
+rescue LoadError # rubocop: disable Lint/SuppressedException
   # do nothing
 end
 

--- a/spec/tests/helpers/perf_run_helper_spec.rb
+++ b/spec/tests/helpers/perf_run_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# vim: set foldmethod=marker
+# vim: foldmethod=marker
 
 require "spec_helper"
 require "minitest/assertions"
@@ -831,6 +831,65 @@ current_tune_settings.json"
       it "raises an exception" do
         expect { subject.find_file(path, pattern) }.to \
           raise_error("Single file matching pattern '#{pattern}' not found in path #{path}.")
+      end
+    end
+  end
+  describe "#save_average_compile_time" do
+    let(:host) do
+      Beaker::Host.create("localhost", { role: "database" }, logger: @logger)
+    end
+    before { subject.instance_variable_set(:@start_epoch, 0) }
+    before { subject.instance_variable_set(:@end_epoch, 946_684_799) }
+    let(:file) { Tempfile.new(described_class.to_s) }
+    let(:result) { Beaker::Result.new(host, "") }
+    let(:curl) do
+      curl = <<~CURL
+        curl
+          -X GET
+          http://localhost:8080/pdb/query/v4
+          -d 'query=["from", "reports",
+                      ["extract", "metrics",
+                        ["and",
+                          [">=", "start_time", "1970-01-01 00:00:00"],
+                          ["<=", "end_time", "1999-12-31 23:59:59"]]]]'
+      CURL
+      curl = curl.strip.gsub(/\n+/, " ")
+      curl.gsub(/\s+/, " ")
+    end
+    context "when puppet query returns json data with config_retreival times" do
+      it "writes average compile time to the given file" do
+        compile_time = 41.534695086999933
+        result.stdout = <<~JSON_DATA # {{{
+          [
+            {
+              "metrics": {
+                "data": [
+                  {
+                    "name": "config_retrieval",
+                    "value": #{compile_time},
+                    "category": "time"
+                  }
+                ]
+              }
+            }
+          ]
+        JSON_DATA
+        # }}}
+        expect(subject).to receive(:on).with(host, curl).and_return(result)
+        subject.save_average_compile_time(file.path, host)
+
+        file.open
+        expect(file.read.chomp).to eq(compile_time.ceil.to_s)
+      end
+    end
+    context "when puppet query returns no data" do
+      it "writes nothing to the given file" do
+        result.stdout = ""
+        expect(subject).to receive(:on).with(host, curl).and_return(result)
+        subject.save_average_compile_time(file.path, host)
+
+        file.open
+        expect(file.read.chomp).to eq("")
       end
     end
   end


### PR DESCRIPTION
This commit adds the `save_average_compile_time` helper to to the
PerfRunHelper module.  This helper queries puppetdb for the
"config_retrieval" and "total" values associated with metrics data from
the reports endpoint.  This query is constrained to a time range bound
by the start_epoch and end_epoch instance values associated with the
code at runtime.

Spec tests for this helper are added as well.