### PR TITLE
(SLV-708) Skip better performance for memory

### DIFF
--- a/spec/tests/helpers/perf_run_helper_spec.rb
+++ b/spec/tests/helpers/perf_run_helper_spec.rb
@@ -763,12 +763,38 @@ current_tune_settings.json"
                                               "pass_thing2" => [100, 102])).to eq(false)
       end
     end
+    context "when any delta is > MAX_BASELINE_VARIANCE other direction" do
+      it "returns false" do
+        expect(subject.validate_baseline_data("fail_thing"  => [2, 1],
+                                              "pass_thing2" => [100, 102])).to eq(false)
+      end
+    end
     context "when MAX_BASELINE_VARIANCE < 'orchestration_service memory delta' > MAX_BASELINE_VARIANCE_ORCH_REL_MEM" do
       it "returns true" do
         expect(
           subject.validate_baseline_data(
             "pass_thing1"                                    => [1.00, 0.98],
             "process_orchestration_services_release_avg_mem" => [100, 112]
+          )
+        ).to eq(true)
+      end
+    end
+    context "when 'orchestration_service memory delta' < MAX_BASELINE_VARIANCE_ORCH_REL_MEM AND worse" do
+      it "returns false" do
+        expect(
+          subject.validate_baseline_data(
+            "pass_thing1"                                    => [1.00, 0.98],
+            "process_orchestration_services_release_avg_mem" => [100, 150]
+          )
+        ).to eq(false)
+      end
+    end
+    context "when 'orchestration_service memory delta' < MAX_BASELINE_VARIANCE_ORCH_REL_MEM AND better" do
+      it "returns true" do
+        expect(
+          subject.validate_baseline_data(
+            "pass_thing1"                                    => [1.00, 0.98],
+            "process_orchestration_services_release_avg_mem" => [100, 50]
           )
         ).to eq(true)
       end

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -1085,10 +1085,11 @@ module PerfRunHelper
   # @return [Boolean]
   def validate_baseline_data(data)
     failures = find_failing_variances(data)
-    # FIXME: The following line removes any failures where the performance is
-    # better than expected.  Strictly speaking, this should trigger a failure,
-    # but we have not gated on this condition in the past.
-    failures = failures.select { |_k, v| v.last > 1 }
+    # FIXME: (SLV-716) Revert the commit associated with the following line.
+    # The following line removes any failures where the performance is better
+    # than expected for memory consumption.  Strictly speaking, this should
+    # trigger a failure, but we have not gated on this condition in the past.
+    failures = failures.reject { |k, v| v.last < 1 && k.to_s.match(/mem$/) }
     return true if failures.empty?
 
     failures.each do |k, v|


### PR DESCRIPTION
This commit updates the logic for squelching failures that are positive.
These should only be throttled for memory values, in the sense that less
is better than more.  Other relationships do not require suppression at
this time.  This logic should be removed when SLV-716 is resolved.