### PR TITLE
(SLV-447) Add pe-trial performance test

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 #### Table of Contents
 
 1. [Setup](#setup)
+1. [PE trial performance test](#pe-trial-performance-test)
 1. [Apples to Apples performance tests](#apples-to-apples-performance-tests)
 1. [Opsworks performance tests](#opsworks-performance-tests)
 1. [Soak performance tests](#soak-performance-tests)
@@ -159,6 +160,24 @@ curl -u jdoe --url https://vmpooler.example.com/api/v1/token
 For more detailed information, please refer to the
 [vmpooler documentation](https://github.com/puppetlabs/vmpooler/blob/master/docs)
 
+
+## PE trial performance test
+
+This repo includes a `pe-trial.rb` test to validate that an AWS m5.large can
+easily accommodate the 10 nodes allowed for a trial installation of Puppet
+Enterprise.  To run this test use the following command.  Please ensure that
+you set the `BEAKER_PE_VER` and the `BEAKER_PE_DIR` to match the PE version
+that you are testing.  The other environment variables should remain as defined
+below.
+```
+    BEAKER_TESTS=tests/pe-trial.rb \
+    PUPPET_GATLING_SCENARIO=pe-trial.json \
+    ABS_AWS_MASTER_SIZE=m5.large \
+    BEAKER_PE_VER=2019.1.0 \
+    BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.1.0 \
+    BEAKER_INSTALL_TYPE=pe \
+    bundle exec rake performance
+```
 
 ## Apples to Apples performance tests
 

--- a/simulation-runner/config/scenarios/pe-trial.json
+++ b/simulation-runner/config/scenarios/pe-trial.json
@@ -1,0 +1,12 @@
+{
+    "run_description": "PE trial: 'role::by_size_large' role from perf control repo, 100 agents, 2 repetitions",
+    "nodes": [
+        {
+            "node_config": "PerfTestLarge.json",
+            "num_instances": 100,
+            "ramp_up_duration_seconds": 1800,
+            "num_repetitions": 2,
+            "sleep_duration_seconds": 1800
+        }
+    ]
+}

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -787,13 +787,13 @@ module PerfRunHelper
       base_url = "https://#{pup}:8140"
       sim_config = "config/scenarios/#{gatling_scenario} "
       reports_target_path = "#{sim_runner_dir}/results/#{reports_target}"
-      command = "cd #{sim_runner_dir} && " \
-                "PUPPET_GATLING_MASTER_BASE_URL=#{base_url} " \
-                "PUPPET_GATLING_SIMULATION_CONFIG=#{sim_config} " +
-                gatling_assertions +
-                "PUPPET_GATLING_REPORTS_ONLY=#{reports_only} " \
-                "PUPPET_GATLING_REPORTS_TARGET=#{reports_target_path} " \
-                "PUPPET_GATLING_SIMULATION_ID=#{simulation_id} sbt run"
+      command = %W[cd #{sim_runner_dir} &&
+                   PUPPET_GATLING_MASTER_BASE_URL=#{base_url}
+                   PUPPET_GATLING_SIMULATION_CONFIG=#{sim_config}
+                   #{gatling_assertions}
+                   PUPPET_GATLING_REPORTS_ONLY=#{reports_only}
+                   PUPPET_GATLING_REPORTS_TARGET=#{reports_target_path}
+                   PUPPET_GATLING_SIMULATION_ID=#{simulation_id} sbt run].join " "
 
       on(metric, command, accept_all_exit_codes: true) do |result|
         fail_test "Gatling execution failed with: #{result.formatted_output(20)}" if result.exit_code != 0

--- a/tests/pe-trial.rb
+++ b/tests/pe-trial.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "helpers/perf_run_helper"
+
+test_name "pe trial"
+
+teardown do
+  perf_teardown
+end
+
+# Setup
+## Create variables
+atop_result, gatling_result = nil
+
+## Set scenario file for test
+scenario_file = "pe-trial.json"
+
+## Get scenario data from scenario config file
+scenario_dir = File.expand_path("../simulation-runner/config/scenarios", __dir__)
+scenario = JSON.parse(File.read(File.join(scenario_dir, scenario_file)))
+
+## Get sim name and hit count from simulation config file identified in scenario data
+sim_dir = File.expand_path("../simulation-runner/src/main/scala/com/puppetlabs/gatling/node_simulations", __dir__)
+sim = File.basename(scenario["nodes"][0]["node_config"], ".json")
+sim_file = File.join(sim_dir, "#{sim}.scala")
+sim_hits = File.read(sim_file).scan(/exec\(http/).count
+
+## Set assertions
+## This is where changes should be made
+max_avg_mem = 3_000_000
+min_success_request_perc = 100
+max_response_time = 20_000 # magic
+total_request_count = scenario["nodes"][0]["num_instances"] * scenario["nodes"][0]["num_repetitions"] * sim_hits
+gatlingassertions = %W[SUCCESSFUL_REQUESTS=#{min_success_request_perc}
+                       MAX_RESPONSE_TIME_AGENT=#{max_response_time}
+                       TOTAL_REQUEST_COUNT=#{total_request_count}].join " "
+## End setup
+
+# Execute agent runs to warm up the JIT before starting our monitoring.
+step "warm up" do
+  perf_setup("WarmUpJit.json", "PerfTestLarge", "")
+  stop_monitoring(master, "/opt/puppetlabs")
+end
+
+# pass in gatling scenario file name and simulation id
+step "run simulation" do
+  perf_setup(scenario_file, sim, gatlingassertions)
+  atop_result, gatling_result = perf_result
+end
+
+step "max response" do
+  assert_later(gatling_result.max_response_time_agent <= max_response_time,
+               %W[Max response time per agent run was: #{gatling_result.max_response_time_agent},
+                  expected <= #{max_response_time}].join(" "))
+end
+
+step "successful request percentage" do
+  assert_later(gatling_result.successful_requests >= min_success_request_perc,
+               %W[Total successful request percentage was: #{gatling_result.successful_requests}%,
+                  expected #{min_success_request_perc}%].join(" "))
+end
+
+step "average memory" do
+  assert_later(atop_result.avg_mem < max_avg_mem,
+               "Average memory was: #{atop_result.avg_mem}, expected < #{max_avg_mem}")
+end
+
+if ENV["BASELINE_PE_VER"]
+  step "baseline assertions" do
+    baseline_assert(atop_result, gatling_result)
+  end
+end
+
+assert_all

--- a/tests/pe-trial.rb
+++ b/tests/pe-trial.rb
@@ -36,12 +36,6 @@ gatlingassertions = %W[SUCCESSFUL_REQUESTS=#{min_success_request_perc}
                        TOTAL_REQUEST_COUNT=#{total_request_count}].join " "
 ## End setup
 
-# Execute agent runs to warm up the JIT before starting our monitoring.
-step "warm up" do
-  perf_setup("WarmUpJit.json", "PerfTestLarge", "")
-  stop_monitoring(master, "/opt/puppetlabs")
-end
-
 # pass in gatling scenario file name and simulation id
 step "run simulation" do
   perf_setup(scenario_file, sim, gatlingassertions)


### PR DESCRIPTION
This commit adds a pe-trial performance test and a simulation scenario
configuration of the same name.  These files facilitate the testing of a
small standard installation when provided the following command:

The PE version and directory can be customized as needed, but the other
environment variables are tailored specifically for the purposes of this
test.
```
BEAKER_TESTS=tests/pe-trial.rb \
PUPPET_GATLING_SCENARIO=pe-trial.json \
PUPPET_GATLING_SCALE_TUNE_FORCE=true \
ABS_AWS_MASTER_SIZE=m5.large \
BEAKER_PE_VER=2019.1.0 \
BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.1.0 \
BEAKER_INSTALL_TYPE=pe \
bundle exec rake performance
```