### PR TITLE
(SLV-719) Disable save_average_transaction_time

### DIFF
--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -917,7 +917,8 @@ module PerfRunHelper
       puts
     end
 
-    save_average_transaction_time("#{@archive_root}/avg_transaction_time.json", database)
+    # TODO:  The save_average_transaction_time should be re-enabled as part of SLV-724
+    # save_average_transaction_time("#{@archive_root}/avg_transaction_time.json", database)
 
     [perf, GatlingResult.new(gatling_assertions, mean_response_time)]
   end


### PR DESCRIPTION
This commit disables the call to save_average_transaction_time.  This
method appears to be causing beaker to crash due to the puppetdb data
causing beaker to run out of memory.  This commit should be reverted as
part of SLV-724.