### PR TITLE
(SLV-609) Download pe tarballs for pe_xl

### DIFF
--- a/lib/beaker_dsl.rb
+++ b/lib/beaker_dsl.rb
@@ -4,7 +4,7 @@ require "beaker"
 require "beaker-pe"
 
 # BeakerHelper class to get Beaker helpers outside of a Beaker run
-class BeakerHelper
+class BeakerDSL
   include Beaker::DSL::Helpers
   include Beaker::DSL::Wrappers
   include Beaker::DSL::Roles

--- a/lib/beakerhelper.rb
+++ b/lib/beakerhelper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "beaker"
+require "beaker-pe"
+
+# BeakerHelper class to get Beaker helpers outside of a Beaker run
+class BeakerHelper
+  include Beaker::DSL::Helpers
+  include Beaker::DSL::Wrappers
+  include Beaker::DSL::Roles
+  include Beaker::DSL::Patterns
+
+  def options
+    { cache_files_locally: true }
+  end
+
+  def logger
+    Beaker::Logger.new
+  end
+end

--- a/rakefile
+++ b/rakefile
@@ -631,8 +631,10 @@ namespace :pe_xl do
     raise KeyError, 'key not found: "BEAKER_PE_VER"' unless ENV["BEAKER_PE_VER"].is_a? String
 
     # validate that BEAKER_PE_VER looks like a PE version
-    match_data = ENV["BEAKER_PE_VER"].match(/(^\d{4}\.\d+)\.(\d+)(.*$)/i)
-    raise Error, "BEAKER_PE_VER: #{ENV['BEAKER_PE_VER']} does not look like a valid version string" unless match_data
+    pe_pattern = /(^\d{4}\.\d+)\.(\d+)(.*$)/i
+    err_msg = "BEAKER_PE_VER: #{ENV['BEAKER_PE_VER']} does not match the pattern '#{pe_pattern}'"
+    match_data = ENV["BEAKER_PE_VER"].match(pe_pattern)
+    raise Error, err_msg unless match_data
 
     pe_dir = if !match_data[3]&.empty?
                "http://enterprise.delivery.puppetlabs.net/#{match_data[1]}/ci-ready/"

--- a/rakefile
+++ b/rakefile
@@ -1,3 +1,5 @@
+require "beaker"
+require "beaker-pe"
 require 'rototiller'
 require 'rubocop/rake_task'
 
@@ -8,6 +10,56 @@ require './tests/helpers/perf_results_helper'
 include PerfResultsHelper
 
 REF_ARCH_STD, REF_ARCH_LARGE = ["S","L"]
+
+# Create a trumped up class to get a Beaker helpers outside of a Beaker run
+class ClassMixedWithDSLHelpers
+  include Beaker::DSL::Helpers
+  include Beaker::DSL::Wrappers
+  include Beaker::DSL::Roles
+  include Beaker::DSL::Patterns
+
+  def options
+    { cache_files_locally: true }
+  end
+
+  def logger
+    Beaker::Logger.new
+  end
+end
+
+def master_from_beaker_hosts_hash(hosts)
+  master = nil
+  hosts.each_key do |name|
+    host = hosts[name]
+    master = host if host[:roles].include?("master")
+  end
+  master
+end
+
+def fetch_pe_for_master(beaker_proxy, master, ver, dir, dest = "/tmp")
+  local = File.directory?(dir)
+  filename = "puppet-enterprise-#{ver}-#{master['packaging_platform']}"
+  if local
+    extension = File.exist?("#{dir}/#{filename}.tar.gz") ? ".tar.gz" : ".tar"
+    non_exist_msg = "PE #{dir}/#{filename}#{extension} does not exist"
+    raise non_exist_msg unless File.exist?("#{dir}/#{filename}#{extension}")
+
+  else
+    extension = beaker_proxy.link_exists?("#{dir}/#{filename}.tar.gz") ? ".tar.gz" : ".tar"
+    non_exist_msg = "PE #{dir}/#{filename}#{extension} does not exist"
+    raise non_exist_msg unless beaker_proxy.link_exists?("#{dir}/#{filename}#{extension}")
+
+    beaker_proxy.fetch_http_file(dir, "#{filename}#{extension}", dest)
+  end
+  local_file = File.join(dest, filename) + extension
+  raise "failed to retrieve #{filename}#{extenstion}" unless File.exist?(local_file)
+
+  return if extension == ".tar.gz" || File.exist?("#{local_file}.gz")
+
+  Zlib::GzipWriter.open("#{local_file}.gz") do |gz|
+    gz.write IO.binread(local_file)
+  end
+end
 
 task :default => :performance
 
@@ -577,8 +629,24 @@ namespace :pe_xl do
   file "#{BUILD_DIR}/params.json" do
     puts "Provisioning nodes for pe_xl"
     raise KeyError, 'key not found: "BEAKER_PE_VER"' unless ENV["BEAKER_PE_VER"].is_a? String
+
+    m = ENV["BEAKER_PE_VER"].match(/(^\d{4}\.\d+)\.(\d+)(.*$)/i)
+    raise Error, "BEAKER_PE_VER: #{ENV['BEAKER_PE_VER']} does not look like a valid version string" unless m
+
+    pe_dir = if !m[3]&.empty?
+               "http://enterprise.delivery.puppetlabs.net/#{m[1]}/ci-ready/"
+             else
+               "http://enterprise.delivery.puppetlabs.net/archives/releases/#{m[1]}.#{m[2]}/"
+             end
+
     mkdir_p BUILD_DIR
     system "bundle exec ruby util/abs/provision_pe_xl_nodes.rb --output_dir #{BUILD_DIR} --pe_version #{ENV['BEAKER_PE_VER']}"
+
+    puts "Retrieving PE package"
+    cfg_hash = Beaker::Options::HostsFileParser.parse_hosts_file "#{BUILD_DIR}/beaker.cfg"
+    master = master_from_beaker_hosts_hash(cfg_hash[:HOSTS])
+    bhp = ClassMixedWithDSLHelpers.new
+    fetch_pe_for_master(bhp, master, ENV["BEAKER_PE_VER"], pe_dir)
   end
 
   desc "Provision pe_xl nodes"

--- a/rakefile
+++ b/rakefile
@@ -39,14 +39,13 @@ end
 def fetch_pe_for_master(beaker_proxy, master, ver, dir, dest = "/tmp")
   local = File.directory?(dir)
   filename = "puppet-enterprise-#{ver}-#{master['packaging_platform']}"
+  non_exist_msg = "PE #{filename} does not exist at #{dir}"
   if local
     extension = File.exist?("#{dir}/#{filename}.tar.gz") ? ".tar.gz" : ".tar"
-    non_exist_msg = "PE #{dir}/#{filename}#{extension} does not exist"
     raise non_exist_msg unless File.exist?("#{dir}/#{filename}#{extension}")
 
   else
     extension = beaker_proxy.link_exists?("#{dir}/#{filename}.tar.gz") ? ".tar.gz" : ".tar"
-    non_exist_msg = "PE #{dir}/#{filename}#{extension} does not exist"
     raise non_exist_msg unless beaker_proxy.link_exists?("#{dir}/#{filename}#{extension}")
 
     beaker_proxy.fetch_http_file(dir, "#{filename}#{extension}", dest)

--- a/rakefile
+++ b/rakefile
@@ -1,5 +1,3 @@
-require "beaker"
-require "beaker-pe"
 require 'rototiller'
 require 'rubocop/rake_task'
 
@@ -9,23 +7,9 @@ include AbsHelper
 require './tests/helpers/perf_results_helper'
 include PerfResultsHelper
 
+require "./lib/beakerhelper"
+
 REF_ARCH_STD, REF_ARCH_LARGE = ["S","L"]
-
-# Create a trumped up class to get a Beaker helpers outside of a Beaker run
-class ClassMixedWithDSLHelpers
-  include Beaker::DSL::Helpers
-  include Beaker::DSL::Wrappers
-  include Beaker::DSL::Roles
-  include Beaker::DSL::Patterns
-
-  def options
-    { cache_files_locally: true }
-  end
-
-  def logger
-    Beaker::Logger.new
-  end
-end
 
 def master_from_beaker_hosts_hash(hosts)
   master = nil
@@ -634,7 +618,7 @@ namespace :pe_xl do
     pe_pattern = /(^\d{4}\.\d+)\.(\d+)(.*$)/i
     err_msg = "BEAKER_PE_VER: #{ENV['BEAKER_PE_VER']} does not match the pattern '#{pe_pattern}'"
     match_data = ENV["BEAKER_PE_VER"].match(pe_pattern)
-    raise Error, err_msg unless match_data
+    raise err_msg unless match_data
 
     pe_dir = if !match_data[3]&.empty?
                "http://enterprise.delivery.puppetlabs.net/#{match_data[1]}/ci-ready/"
@@ -648,7 +632,7 @@ namespace :pe_xl do
     puts "Retrieving PE package"
     cfg_hash = Beaker::Options::HostsFileParser.parse_hosts_file "#{BUILD_DIR}/beaker.cfg"
     master = master_from_beaker_hosts_hash(cfg_hash[:HOSTS])
-    bkr = ClassMixedWithDSLHelpers.new
+    bkr = BeakerHelper.new
     fetch_pe_for_master(bkr, master, ENV["BEAKER_PE_VER"], pe_dir)
   end
 

--- a/rakefile
+++ b/rakefile
@@ -630,13 +630,14 @@ namespace :pe_xl do
     puts "Provisioning nodes for pe_xl"
     raise KeyError, 'key not found: "BEAKER_PE_VER"' unless ENV["BEAKER_PE_VER"].is_a? String
 
-    m = ENV["BEAKER_PE_VER"].match(/(^\d{4}\.\d+)\.(\d+)(.*$)/i)
-    raise Error, "BEAKER_PE_VER: #{ENV['BEAKER_PE_VER']} does not look like a valid version string" unless m
+    # validate that BEAKER_PE_VER looks like a PE version
+    match_data = ENV["BEAKER_PE_VER"].match(/(^\d{4}\.\d+)\.(\d+)(.*$)/i)
+    raise Error, "BEAKER_PE_VER: #{ENV['BEAKER_PE_VER']} does not look like a valid version string" unless match_data
 
-    pe_dir = if !m[3]&.empty?
-               "http://enterprise.delivery.puppetlabs.net/#{m[1]}/ci-ready/"
+    pe_dir = if !match_data[3]&.empty?
+               "http://enterprise.delivery.puppetlabs.net/#{match_data[1]}/ci-ready/"
              else
-               "http://enterprise.delivery.puppetlabs.net/archives/releases/#{m[1]}.#{m[2]}/"
+               "http://enterprise.delivery.puppetlabs.net/archives/releases/#{match_data[1]}.#{match_data[2]}/"
              end
 
     mkdir_p BUILD_DIR

--- a/rakefile
+++ b/rakefile
@@ -7,7 +7,7 @@ include AbsHelper
 require './tests/helpers/perf_results_helper'
 include PerfResultsHelper
 
-require "./lib/beakerhelper"
+require "./lib/beaker_dsl"
 
 REF_ARCH_STD, REF_ARCH_LARGE = ["S","L"]
 
@@ -632,7 +632,7 @@ namespace :pe_xl do
     puts "Retrieving PE package"
     cfg_hash = Beaker::Options::HostsFileParser.parse_hosts_file "#{BUILD_DIR}/beaker.cfg"
     master = master_from_beaker_hosts_hash(cfg_hash[:HOSTS])
-    bkr = BeakerHelper.new
+    bkr = BeakerDSL.new
     fetch_pe_for_master(bkr, master, ENV["BEAKER_PE_VER"], pe_dir)
   end
 

--- a/rakefile
+++ b/rakefile
@@ -36,7 +36,7 @@ def master_from_beaker_hosts_hash(hosts)
   master
 end
 
-def fetch_pe_for_master(beaker_proxy, master, ver, dir, dest = "/tmp")
+def fetch_pe_for_master(beaker_obj, master, ver, dir, dest = "/tmp")
   local = File.directory?(dir)
   filename = "puppet-enterprise-#{ver}-#{master['packaging_platform']}"
   non_exist_msg = "PE #{filename} does not exist at #{dir}"
@@ -45,10 +45,11 @@ def fetch_pe_for_master(beaker_proxy, master, ver, dir, dest = "/tmp")
     raise non_exist_msg unless File.exist?("#{dir}/#{filename}#{extension}")
 
   else
-    extension = beaker_proxy.link_exists?("#{dir}/#{filename}.tar.gz") ? ".tar.gz" : ".tar"
-    raise non_exist_msg unless beaker_proxy.link_exists?("#{dir}/#{filename}#{extension}")
+    # ensure that package exists at remote location
+    extension = beaker_obj.link_exists?("#{dir}/#{filename}.tar.gz") ? ".tar.gz" : ".tar"
+    raise non_exist_msg unless beaker_obj.link_exists?("#{dir}/#{filename}#{extension}")
 
-    beaker_proxy.fetch_http_file(dir, "#{filename}#{extension}", dest)
+    beaker_obj.fetch_http_file(dir, "#{filename}#{extension}", dest)
   end
   local_file = File.join(dest, filename) + extension
   raise "failed to retrieve #{filename}#{extenstion}" unless File.exist?(local_file)
@@ -644,8 +645,8 @@ namespace :pe_xl do
     puts "Retrieving PE package"
     cfg_hash = Beaker::Options::HostsFileParser.parse_hosts_file "#{BUILD_DIR}/beaker.cfg"
     master = master_from_beaker_hosts_hash(cfg_hash[:HOSTS])
-    bhp = ClassMixedWithDSLHelpers.new
-    fetch_pe_for_master(bhp, master, ENV["BEAKER_PE_VER"], pe_dir)
+    bkr = ClassMixedWithDSLHelpers.new
+    fetch_pe_for_master(bkr, master, ENV["BEAKER_PE_VER"], pe_dir)
   end
 
   desc "Provision pe_xl nodes"


### PR DESCRIPTION
This commit adds logic to the `pe_xl:provision` rake task to download the
package for the given BEAKER_PE_VER.  The pe_xl plans will use a local
`tar.gz` file for the given version from the `/tmp` directory if it is
available.  This change determines whether the given version is a
release or development version, downloads the tar file, and gzips it if
necessary in order to provide it to pe_xl.