### PR TITLE
(SLV-733) Fix perf-agent-group classes

### DIFF
--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -395,7 +395,7 @@ module PerfHelper
       "parent"  => "00000000-0000-4000-8000-000000000000",
       "name"    => "perf-agent-group",
       "rule"    => ["~", %w[fact clientcert], ".*agent.*"],
-      "classes" => { ENV["PUPPET_SCALE_CLASS"] => nil }
+      "classes" => { ENV["PUPPET_SCALE_CLASS"] => {} }
     )
   end
 

--- a/setup/helpers/perf_helper.rb
+++ b/setup/helpers/perf_helper.rb
@@ -660,7 +660,7 @@ module PerfHelper
       "parent"  => "00000000-0000-4000-8000-000000000000",
       "name"    => "master-group",
       "rule"    => ["~", %w[fact clientcert], master_cert_name],
-      "classes" => { "role::puppet_master" => nil }
+      "classes" => { "role::puppet_master" => {} }
     )
   end
 


### PR DESCRIPTION
This commit replaces the `nil` value with and empty hash value for the
interpolated PUPPET_SCALE_CLASS applied to the `perf-agent-group`.
Prior to this commit the nil value unset the class assignment causing
the desired class not to be applied when installing on top of a pe_xl
deployment.