### PR TITLE
(SLV-661) Update gatling2csv and compare_results to add min column

### DIFF
--- a/tests/helpers/perf_results_helper.rb
+++ b/tests/helpers/perf_results_helper.rb
@@ -12,12 +12,13 @@ require "zlib"
 # TODO: consolidate scale results code here
 module PerfResultsHelper
   # stats used in gatling2csv
+  MIN = "minResponseTime"
   MAX = "maxResponseTime"
   MEAN = "meanResponseTime"
   STD = "standardDeviation"
   TOTAL = "total"
 
-  PERF_CSV_COLUMN_HEADINGS = ["Duration", "max ms", "mean ms", "std dev"].freeze
+  PERF_CSV_COLUMN_HEADINGS = ["Duration (ms)", "min", "max", "mean", "std dev"].freeze
 
   # these must be in the same order as the Gatling data
   PERF_CSV_ROW_LABELS = ["overall response time",
@@ -118,7 +119,7 @@ module PerfResultsHelper
                      contents[contents.keys[index - 1]]["stats"]
                    end
 
-        csv << [item, row_data[MAX][TOTAL], row_data[MEAN][TOTAL], row_data[STD][TOTAL]]
+        csv << [item, row_data[MIN][TOTAL], row_data[MAX][TOTAL], row_data[MEAN][TOTAL], row_data[STD][TOTAL]]
       end
     end
 

--- a/util/report_utils/compare_results.rb
+++ b/util/report_utils/compare_results.rb
@@ -19,16 +19,16 @@ def write_csv(output_path, result_a, result_b)
 
   # TODO: use release names
   CSV.open(output_path.to_s, "wb") do |csv|
-    csv << ["", "$RELEASE_A_NAME ($RELEASE_A_NUMBER)", "", "",
-            "$RELEASE_B_NAME ($RELEASE_B_NUMBER)", "", ""]
-    csv << ["Duration", "max ms", "mean ms", "std dev", "max ms", "mean ms",
+    csv << ["", "$RELEASE_A_NAME ($RELEASE_A_NUMBER)", "", "", "",
+            "$RELEASE_B_NAME ($RELEASE_B_NUMBER)", "", "", "", ""]
+    csv << ["Duration (ms)", "min", "max", "mean", "std dev", "min", "max", "mean",
             "std dev", "% (mean) diff"]
 
     row_labels.each_with_index do |item, index|
       res_index = index + 1
-      csv << [item, result_a[res_index][1], result_a[res_index][2], result_a[res_index][3],
-              result_b[res_index][1], result_b[res_index][2], result_b[res_index][3],
-              percent_diff_string(result_a[res_index][2], result_b[res_index][2])]
+      csv << [item, result_a[res_index][1], result_a[res_index][2], result_a[res_index][3], result_a[res_index][4],
+              result_b[res_index][1], result_b[res_index][2], result_b[res_index][3], result_b[res_index][4],
+              percent_diff_string(result_a[res_index][3], result_b[res_index][3])]
     end
   end
 end

--- a/util/report_utils/compare_results.rb
+++ b/util/report_utils/compare_results.rb
@@ -17,6 +17,12 @@ output_path = (ARGV[2])
 def write_csv(output_path, result_a, result_b)
   row_labels = PerfResultsHelper::PERF_CSV_ROW_LABELS
 
+  # columns
+  min = 1
+  max = 2
+  mean = 3
+  std_dev = 4
+
   # TODO: use release names
   CSV.open(output_path.to_s, "wb") do |csv|
     csv << ["", "$RELEASE_A_NAME ($RELEASE_A_NUMBER)", "", "", "",
@@ -25,10 +31,11 @@ def write_csv(output_path, result_a, result_b)
             "std dev", "% (mean) diff"]
 
     row_labels.each_with_index do |item, index|
-      res_index = index + 1
-      csv << [item, result_a[res_index][1], result_a[res_index][2], result_a[res_index][3], result_a[res_index][4],
-              result_b[res_index][1], result_b[res_index][2], result_b[res_index][3], result_b[res_index][4],
-              percent_diff_string(result_a[res_index][3], result_b[res_index][3])]
+      row = index + 1
+      csv << [item,
+              result_a[row][min], result_a[row][max], result_a[row][mean], result_a[row][std_dev],
+              result_b[row][min], result_b[row][max], result_b[row][mean], result_b[row][std_dev],
+              percent_diff_string(result_a[row][mean], result_b[row][mean])]
     end
   end
 end


### PR DESCRIPTION
The A2A comparison in the perf report should include the min response time. This update adds the column to the CSV file extracted via `gatling2csv` and the comparison report generated via `util/report_utils/compare_results.rb`.