### PR TITLE
(maint) Use require_relative in utils for helpers

### DIFF
--- a/util/abs/provision_pe_xl_nodes.rb
+++ b/util/abs/provision_pe_xl_nodes.rb
@@ -6,7 +6,7 @@ require "optparse"
 require "yaml"
 require "json"
 require "beaker-hostgenerator"
-require "./setup/helpers/abs_helper.rb"
+require_relative "../../setup/helpers/abs_helper.rb"
 include AbsHelper # rubocop:disable Style/MixinUsage
 
 REF_ARCH_TYPES = { large: "l", extra_large: "xl" }.freeze

--- a/util/report_utils/build_perf_comparison.rb
+++ b/util/report_utils/build_perf_comparison.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 TEMPLATE_PATH = "templates/perf_comparison_template.html"

--- a/util/report_utils/build_perf_report.rb
+++ b/util/report_utils/build_perf_report.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 # TODO: move to perf_results_helper

--- a/util/report_utils/build_scale_csv_summary.rb
+++ b/util/report_utils/build_scale_csv_summary.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 raise Exception, "you must provide a results directory" unless ARGV[0]

--- a/util/report_utils/build_soak_report.rb
+++ b/util/report_utils/build_soak_report.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 # TODO: include this functionality in every performance run

--- a/util/report_utils/compare_atop.rb
+++ b/util/report_utils/compare_atop.rb
@@ -4,7 +4,7 @@
 # TODO: accept release names as optional arguments for A / B
 
 require "csv"
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 SUMMARY_NAME = "summary"

--- a/util/report_utils/compare_results.rb
+++ b/util/report_utils/compare_results.rb
@@ -4,7 +4,7 @@
 # TODO: accept release names as optional arguments for A / B
 
 require "csv"
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 raise Exception, "you must provide two csv files to compare" unless ARGV[0] && ARGV[1]

--- a/util/report_utils/csv2html.rb
+++ b/util/report_utils/csv2html.rb
@@ -6,7 +6,7 @@
 require "json"
 require "csv"
 
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 raise Exception, "you must provide a directory" unless ARGV[0]

--- a/util/report_utils/extract_csv.rb
+++ b/util/report_utils/extract_csv.rb
@@ -2,7 +2,7 @@
 
 require "json"
 require "csv"
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 raise Exception, "you must provide a results directory" unless ARGV[0]

--- a/util/report_utils/split_atop_csv.rb
+++ b/util/report_utils/split_atop_csv.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "../../tests/helpers/perf_results_helper.rb"
+require_relative "../../tests/helpers/perf_results_helper.rb"
 include PerfResultsHelper # rubocop:disable Style/MixinUsage
 
 raise Exception, "you must provide a csv file" unless ARGV[0]


### PR DESCRIPTION
This commit replaces `require` statements with `require_relative` when
requiring helper paths relative to the path location of the utility
script.  This change allows the utilities to be called outside of the
directory in which they reside while still allowing the required helper
to be found.