### PR TITLE
(SLV-738) Ensure puppet agent disabled on infra

### DIFF
--- a/setup/install_gatling/30_classification/60_classify_use_loadbalancer.rb
+++ b/setup/install_gatling/30_classification/60_classify_use_loadbalancer.rb
@@ -55,6 +55,7 @@ test_name "classify and use loadbalancer" do # rubocop:disable Metrics/BlockLeng
     # Infra agents would otherwise inherit the config above, so explicitly override it to defaults.
     pe_infra_agent_group = {
       "name"    => "PE Infrastructure Agent",
+      "rule"    => ["and", ["not", ["~", %w[fact clientcert], ".*agent.*"]]],
       "classes" => {
         "puppet_enterprise::profile::agent" => {
           "manage_puppet_conf" => true,

--- a/setup/install_gatling/99_final/99_final_puppet_run.rb
+++ b/setup/install_gatling/99_final/99_final_puppet_run.rb
@@ -8,8 +8,9 @@ test_name "final puppet run" do
     # If deployed via install_pe this is part of the install.
     #   Ref: https://github.com/puppetlabs/beaker-pe/blob/master/lib/beaker-pe/install/pe_utils.rb
     # This is added to ensure that the puppet agent service is
-    # disabled prior to a gatling run regardless of how the hosts
-    # were deployed.
-    stop_agent_on(hosts)
+    # disabled on hosts with a role other than agent prior to a
+    # gatling run regardless of how the hosts were deployed.
+    infra_hosts = hosts.reject { |host| (host[:roles] == ["agent"]) }
+    stop_agent_on(infra_hosts)
   end
 end

--- a/setup/install_gatling/99_final/99_final_puppet_run.rb
+++ b/setup/install_gatling/99_final/99_final_puppet_run.rb
@@ -4,4 +4,12 @@ test_name "final puppet run" do
   step "Run puppet until all changes are applied" do
     run_agent_until_no_change(hosts)
   end
+  step "Ensure puppet agent disabled" do
+    # If deployed via install_pe this is part of the install.
+    #   Ref: https://github.com/puppetlabs/beaker-pe/blob/master/lib/beaker-pe/install/pe_utils.rb
+    # This is added to ensure that the puppet agent service is
+    # disabled prior to a gatling run regardless of how the hosts
+    # were deployed.
+    stop_agent_on(hosts)
+  end
 end


### PR DESCRIPTION
This commit adds a pre-suite step after the final puppet run to ensure
that the puppet agent service is disabled on all hosts prior to any
gatling tests.