### PR TITLE
(SLV-703) Use artifactory URIs for BEAKER_PE_DIR

### DIFF
--- a/CD4PE.md
+++ b/CD4PE.md
@@ -43,7 +43,7 @@ You can set the values manually:
 
 ```
 export BEAKER_INSTALL_TYPE=pe
-export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.0.1
+export BEAKER_PE_DIR=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2019.0.1
 export BEAKER_PE_VER=2019.0.1
 ```
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ below.
     PUPPET_GATLING_SCENARIO=pe-trial.json \
     ABS_AWS_MASTER_SIZE=m5.large \
     BEAKER_PE_VER=2019.1.0 \
-    BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.1.0 \
+    BEAKER_PE_DIR=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2019.1.0 \
     BEAKER_INSTALL_TYPE=pe \
     bundle exec rake performance
 ```
@@ -204,7 +204,7 @@ Example run
 ```
 export BEAKER_INSTALL_TYPE=pe
 export BEAKER_PE_VER=2019.1.0
-export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.1.0
+export BEAKER_PE_DIR=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2019.1.0
 export BASELINE_PE_VER=2018.1.9
 export GOOGLE_APPLICATION_CREDENTIALS=mysecret.json  # location of your google json key file
 

--- a/config/env/env_setup_2019.0.1
+++ b/config/env/env_setup_2019.0.1
@@ -5,5 +5,5 @@
 # export PUPPET_GATLING_SCALE_SIMULATION_ID="PerfAutoScaleSmall"
 
 export BEAKER_INSTALL_TYPE=pe
-export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.0.1
+export BEAKER_PE_DIR=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2019.0.1
 export BEAKER_PE_VER=2019.0.1

--- a/config/env/env_setup_2019.0.2
+++ b/config/env/env_setup_2019.0.2
@@ -5,5 +5,5 @@
 # export PUPPET_GATLING_SCALE_SIMULATION_ID="PerfAutoScaleSmall"
 
 export BEAKER_INSTALL_TYPE=pe
-export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.0.2
+export BEAKER_PE_DIR=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2019.0.2
 export BEAKER_PE_VER=2019.0.2

--- a/config/env/env_setup_2019.1.0
+++ b/config/env/env_setup_2019.1.0
@@ -5,5 +5,5 @@
 # export PUPPET_GATLING_SCALE_SIMULATION_ID="PerfAutoScaleSmall"
 
 export BEAKER_INSTALL_TYPE=pe
-export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.1.0
+export BEAKER_PE_DIR=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2019.1.0
 export BEAKER_PE_VER=2019.1.0

--- a/config/env/env_setup_2019.2.1
+++ b/config/env/env_setup_2019.2.1
@@ -1,3 +1,3 @@
 export BEAKER_INSTALL_TYPE=pe
-export BEAKER_PE_DIR=http://enterprise.delivery.puppetlabs.net/archives/releases/2019.2.1
+export BEAKER_PE_DIR=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2019.2.1
 export BEAKER_PE_VER=2019.2.1

--- a/jenkins-integration/beaker/install/pe/10_install_pe.rb
+++ b/jenkins-integration/beaker/install/pe/10_install_pe.rb
@@ -3,7 +3,7 @@
 test_name "Install PE"
 
 # Environment variables:
-#   (required) pe_dir="http://enterprise.delivery.puppetlabs.net/2016.2/ci-ready/"
+#   (required) pe_dir="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/2016.2/ci-ready/"
 #   (optional) pe_ver="2016.2.0-rc0"
 #
 # The environment variables need to be specified on the CLI when invoking beaker,

--- a/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
+++ b/jenkins-integration/jenkins-jobs/common/scripts/jenkins/pipeline.groovy
@@ -166,7 +166,7 @@ def step010_setup_beaker(script_dir, server_version) {
     if (server_version["type"] == "pe") {
         if (server_version["find_latest"] == true) {
             withEnv(["SUT_HOST=${SUT_HOST}",
-                     "pe_dir=http://enterprise.delivery.puppetlabs.net/${server_version["pe_version"]}/ci-ready/",
+                     "pe_dir=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${server_version["pe_version"]}/ci-ready/",
                      "pe_family=${server_version["pe_version"]}"]) {
                 sh "${script_dir}/010_setup_beaker.sh"
             }

--- a/rakefile
+++ b/rakefile
@@ -112,7 +112,7 @@ end
 desc 'Provision systems for the performance task with ABS - included in the performance task'
 # validate the BEAKER_INSTALL_TYPE (and dependent env vars) to prevent provisioning if incorrectly specified
 rototiller_task :performance_provision_with_abs  => "validate:beaker_install_type" do |t|
-  t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: http://enterprise.delivery.puppetlabs.net/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
+  t.add_env({:name => 'BEAKER_PE_DIR', :message => 'The PE download directory, example: https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'BEAKER_PE_VER', :message => 'The PE version to install on hosts, example: 2017.2.4'}) if ENV['BEAKER_INSTALL_TYPE'] == 'pe'
   t.add_env({:name => 'ABS_OS', :default => 'centos-7-x86-64-west', :message => 'The OS to provision with ABS: centos-7-x86-64-west (for AWS), or centos-7-x86_64 (for vmpooler)'})
   t.add_env({:name => 'ABS_AWS_METRICS_SIZE', :default => 'c5.2xlarge', :message => 'The AWS instance size for the Metrics host'})
@@ -621,9 +621,9 @@ namespace :pe_xl do
     raise err_msg unless match_data
 
     pe_dir = if !match_data[3]&.empty?
-               "http://enterprise.delivery.puppetlabs.net/#{match_data[1]}/ci-ready/"
+               "https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/#{match_data[1]}/ci-ready/"
              else
-               "http://enterprise.delivery.puppetlabs.net/archives/releases/#{match_data[1]}.#{match_data[2]}/"
+               "https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/#{match_data[1]}.#{match_data[2]}/"
              end
 
     mkdir_p BUILD_DIR

--- a/util/scale_run.sh
+++ b/util/scale_run.sh
@@ -192,9 +192,9 @@ if ! { [ "$PE_MAJOR" ] && [ "$PE_MINOR" ] && [ "$PE_PATCH" ]; }; then
 fi
 
 if [ "$PE_BUILD" ]; then
-  URL=http://enterprise.delivery.puppetlabs.net/$PE_MAJOR.$PE_MINOR/ci-ready/
+  URL=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/$PE_MAJOR.$PE_MINOR/ci-ready/
 else
-  URL=http://enterprise.delivery.puppetlabs.net/archives/releases/$PE_VERSION/
+  URL=https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/archives/releases/$PE_VERSION/
 fi
 
 # Ensure packages can be found for PE_VERSION


### PR DESCRIPTION
This commit updates BEAKER_PE_DIR references to use artifactory URIs
over the legacy enterprise locations.