### PR TITLE
 (SLV-610) Separate compiler csv data

### DIFF
--- a/spec/tests/helpers/perf_results_helper_spec.rb
+++ b/spec/tests/helpers/perf_results_helper_spec.rb
@@ -234,9 +234,13 @@ describe PerfResultsHelper do
   # TODO: complete
   describe "#average_csv" do
     context "when the specified file does not contain more than one row" do
-      it "raises an error" do
-        expect { subject.average_csv(TEST_VALID_CSV_HEADINGS_PATH) }
-          .to raise_error(RuntimeError)
+      it "fails validation" do
+        expect(subject).to receive(:valid_csv?).with(TEST_VALID_CSV_HEADINGS_PATH).and_return(false)
+        subject.average_csv(TEST_VALID_CSV_HEADINGS_PATH)
+      end
+      it "skips processing" do
+        expect(CSV).not_to receive(:read).with(TEST_VALID_CSV_HEADINGS_PATH)
+        subject.average_csv(TEST_VALID_CSV_HEADINGS_PATH)
       end
     end
 

--- a/tests/helpers/perf_results_helper.rb
+++ b/tests/helpers/perf_results_helper.rb
@@ -235,7 +235,7 @@ module PerfResultsHelper
   #   csv2html(csv_path)
   #
   def csv2html(csv_path)
-    validate_csv(csv_path)
+    return unless valid_csv?(csv_path)
 
     puts "  converting CSV file: #{csv_path}"
     csv_data = CSV.read(csv_path)
@@ -320,13 +320,11 @@ module PerfResultsHelper
   # TODO: error handling, spec test
   #
   def average_csv(data_csv_path, start_column = 0)
-    validate_csv(data_csv_path)
+    return unless valid_csv?(data_csv_path)
 
     puts "Reading CSV file: #{data_csv_path}"
     data_csv = CSV.read(data_csv_path)
     num_rows = data_csv.length - 1
-
-    raise "The specified CSV file contains no data: #{data_csv_path}" unless num_rows > 1
 
     headings_row = []
     averages_row = []
@@ -361,6 +359,14 @@ module PerfResultsHelper
       average_csv << headings_row
       average_csv << averages_row
     end
+  end
+
+  def valid_csv?(csv_path)
+    begin validate_csv(csv_path)
+    rescue StandardError
+      return false
+    end
+    true
   end
 
   # Validate the specified CSV file using csvlint
@@ -701,19 +707,30 @@ module PerfResultsHelper
     puppetserver_files = Dir.glob("#{metrics_dir}/puppetserver/**/*.json")
     raise "No JSON files found: #{puppetserver_dir}" if puppetserver_files.nil? || puppetserver_files.empty?
 
-    csv_path = "#{metrics_dir}/../puppetserver.csv"
-    CSV.open(csv_path, "wb") do |csv|
-      csv << PMC_ROW_HEADINGS
-
-      puppetserver_files.sort.each do |file|
-        puppetserver_metrics = extract_puppetserver_metrics_from_json(file)
-        csv << puppetserver_metrics unless puppetserver_metrics.nil?
-      end
+    # group files by servername
+    files_by_server = {}
+    puppetserver_files.each do |file|
+      servername = file.split("/")[-2]
+      files_by_server[servername] ||= []
+      files_by_server[servername] << file
     end
 
-    average_csv(csv_path, 2)
-    csv2html(csv_path)
-    csv2html(csv_path.gsub(".csv", ".average.csv"))
+    # store csv results in separate files by servername
+    files_by_server.each do |servername, file_list|
+      csv_path = "#{metrics_dir}/../puppetserver-#{servername}.csv"
+      CSV.open(csv_path, "wb") do |csv|
+        csv << PMC_ROW_HEADINGS
+
+        file_list.sort.each do |file|
+          puppetserver_metrics = extract_puppetserver_metrics_from_json(file)
+          csv << puppetserver_metrics unless puppetserver_metrics.nil?
+        end
+      end
+
+      average_csv(csv_path, 2)
+      csv2html(csv_path)
+      csv2html(csv_path.gsub(".csv", ".average.csv"))
+    end
   end
 
   # Processes the specified JSON file in the 'puppetserver' service directory


### PR DESCRIPTION
This commit updates the file creation logic in the
`extract_puppetserver_metrics` helper to create discrete files per
puppetserver host.

In the scenario of using load balanced compile masters for gatling node
catalog compilation the primary master puppetserver is not utilized for
catalog compilation.  This results in empty csv data.  For this reason,
the generation of the puppetserver metrics extraction files has been
updated to no longer throw an exception in the event of invalid csv
data.  A wrapper method called `valid_csv?` has been added to get a
boolean result as to the validity of a given csv file.  In the case of
an invalid file the extraction process skips over further processing of
the file and moves on to the next step/iteration of the extraction
process.
