### PR TITLE
(SLV-774) Restart compilers in scale_setup

### DIFF
--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -262,9 +262,9 @@ module PerfRunHelper
         puts
 
         # restart using master_manipulator
-        masters = select_hosts(roles: %w[master compile_master])
-        masters.each do |compiler|
-          restart_puppet_server(compiler)
+        puppet_servers = select_hosts(roles: %w[master compile_master])
+        puppet_servers.each do |host|
+          restart_puppet_server(host)
         end
 
       end

--- a/tests/helpers/perf_run_helper.rb
+++ b/tests/helpers/perf_run_helper.rb
@@ -262,7 +262,10 @@ module PerfRunHelper
         puts
 
         # restart using master_manipulator
-        restart_puppet_server(master)
+        masters = select_hosts(roles: %w[master compile_master])
+        masters.each do |compiler|
+          restart_puppet_server(compiler)
+        end
 
       end
 


### PR DESCRIPTION
This commit updates the call to `restart_puppet_server` in
`scale_setup` to iterate over all hosts with the roles of `master` and
`compile_master`.  Prior to this commit only the master was restarted
which is not sufficient in a deployment that uses compile masters in
addition to the core master server.